### PR TITLE
feat: add release check helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## Unreleased
+## v0.6.0 - 2026-05-17
+
+- Add `releasecheck` helpers for cached GitHub release checks and safe stderr
+  update notices in downstream crawl app CLIs.
 
 ## v0.5.3 - 2026-05-17
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ See `docs/boundary.md` for the crawlkit-versus-app ownership boundary.
 - `state`: generic crawler cursor and freshness records.
 - `embed`: reusable OpenAI-compatible, Ollama, and llama.cpp embedding providers plus local probe diagnostics.
 - `vector`: float32 vector encoding, dimension validation, cosine scoring, top-k helpers, and reciprocal-rank fusion.
+- `releasecheck`: GitHub release checks, 24-hour cache handling, scripted-output
+  suppression, and stderr update notice formatting for crawl app CLIs.
 - `output`: text/json/log output helpers.
 - `control`: crawl app metadata, command manifests, status payloads, and
   database inventory for launchers and automation.

--- a/docs/boundary.md
+++ b/docs/boundary.md
@@ -43,6 +43,10 @@ parsers, and product-specific ranking in the apps.
   rebuild/optimize helpers, deferred refresh orchestration, and progress logs.
 - Terminal archive browsing primitives: pane layout, sorting, focus, mouse
   actions, menus, detail rendering primitives, and local/remote status chrome.
+- Provider-neutral release checks for crawl app binaries: latest GitHub release
+  fetches, local check caching, scripted-output suppression, and text notice
+  formatting. Apps still own their command names, version variables, and install
+  hints.
 - Safe read-only desktop-cache snapshot helpers. The provider-specific parsing
   of those snapshots stays in the apps.
 

--- a/releasecheck/releasecheck.go
+++ b/releasecheck/releasecheck.go
@@ -1,0 +1,360 @@
+package releasecheck
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mattn/go-isatty"
+)
+
+const (
+	DefaultInterval = 24 * time.Hour
+)
+
+var GitHubAPI = "https://api.github.com"
+
+var ErrSkipped = errors.New("release check skipped")
+
+type Options struct {
+	AppName        string
+	Owner          string
+	Repo           string
+	CurrentVersion string
+	CacheDir       string
+	Interval       time.Duration
+	Force          bool
+	Client         *http.Client
+	Now            func() time.Time
+}
+
+type NotifyOptions struct {
+	Options
+	Stderr      io.Writer
+	InstallHint string
+	Args        []string
+	JSONOutput  bool
+	IsTerminal  bool
+	Getenv      func(string) string
+}
+
+type Result struct {
+	CheckedAt       time.Time `json:"checked_at"`
+	CurrentVersion  string    `json:"current_version"`
+	LatestVersion   string    `json:"latest_version,omitempty"`
+	LatestURL       string    `json:"latest_url,omitempty"`
+	UpdateAvailable bool      `json:"update_available"`
+	FromCache       bool      `json:"from_cache"`
+	Skipped         bool      `json:"skipped,omitempty"`
+	Reason          string    `json:"reason,omitempty"`
+}
+
+type cacheFile struct {
+	CheckedAt     time.Time `json:"checked_at"`
+	LatestVersion string    `json:"latest_version"`
+	LatestURL     string    `json:"latest_url"`
+}
+
+type latestRelease struct {
+	TagName string `json:"tag_name"`
+	HTMLURL string `json:"html_url"`
+}
+
+func Check(ctx context.Context, opts Options) (Result, error) {
+	opts = normalizeOptions(opts)
+	current := normalizeVersion(opts.CurrentVersion)
+	result := Result{
+		CheckedAt:      opts.Now(),
+		CurrentVersion: current,
+	}
+	if opts.AppName == "" || opts.Owner == "" || opts.Repo == "" {
+		result.Skipped = true
+		result.Reason = "missing release check metadata"
+		return result, ErrSkipped
+	}
+	lowerCurrent := strings.ToLower(current)
+	if current == "" || lowerCurrent == "dev" || lowerCurrent == "ci" || strings.Contains(lowerCurrent, "dev") || strings.Contains(lowerCurrent, "dirty") {
+		result.Skipped = true
+		result.Reason = "development version"
+		return result, ErrSkipped
+	}
+
+	if !opts.Force {
+		if cached, ok := readCache(opts); ok && opts.Now().Sub(cached.CheckedAt) < opts.Interval {
+			result.CheckedAt = cached.CheckedAt
+			result.LatestVersion = normalizeVersion(cached.LatestVersion)
+			result.LatestURL = cached.LatestURL
+			result.FromCache = true
+			result.UpdateAvailable = versionLess(current, result.LatestVersion)
+			return result, nil
+		}
+	}
+
+	latest, err := fetchLatest(ctx, opts)
+	if err != nil {
+		return result, err
+	}
+	result.CheckedAt = opts.Now()
+	result.LatestVersion = normalizeVersion(latest.TagName)
+	result.LatestURL = latest.HTMLURL
+	result.UpdateAvailable = versionLess(current, result.LatestVersion)
+	writeCache(opts, cacheFile{
+		CheckedAt:     result.CheckedAt,
+		LatestVersion: result.LatestVersion,
+		LatestURL:     result.LatestURL,
+	})
+	return result, nil
+}
+
+func Notify(ctx context.Context, opts NotifyOptions) (Result, error) {
+	if ok, reason := ShouldNotify(opts); !ok {
+		result := Result{
+			CheckedAt:      normalizeOptions(opts.Options).Now(),
+			CurrentVersion: normalizeVersion(opts.CurrentVersion),
+			Skipped:        true,
+			Reason:         reason,
+		}
+		return result, ErrSkipped
+	}
+	result, err := Check(ctx, opts.Options)
+	if err != nil {
+		return result, err
+	}
+	if result.UpdateAvailable && opts.Stderr != nil {
+		_, _ = io.WriteString(opts.Stderr, Notice(opts.AppName, opts.InstallHint, result))
+	}
+	return result, nil
+}
+
+func ShouldNotify(opts NotifyOptions) (bool, string) {
+	getenv := opts.Getenv
+	if getenv == nil {
+		getenv = os.Getenv
+	}
+	if opts.JSONOutput {
+		return false, "json output"
+	}
+	if !opts.IsTerminal {
+		return false, "stderr is not a terminal"
+	}
+	if envTruthy(getenv("CI")) {
+		return false, "ci environment"
+	}
+	if envTruthy(getenv("CRAWLKIT_NO_UPDATE_CHECK")) {
+		return false, "disabled by CRAWLKIT_NO_UPDATE_CHECK"
+	}
+	prefix := envPrefix(opts.AppName)
+	if prefix != "" && envTruthy(getenv(prefix+"_NO_UPDATE_CHECK")) {
+		return false, "disabled by " + prefix + "_NO_UPDATE_CHECK"
+	}
+	if len(opts.Args) > 0 && (opts.Args[0] == "metadata" || opts.Args[0] == "check-update") {
+		return false, opts.Args[0] + " command"
+	}
+	for _, arg := range opts.Args {
+		if arg == "--json" || strings.HasPrefix(arg, "--json=") {
+			return false, "json output"
+		}
+	}
+	return true, ""
+}
+
+func StderrIsTerminal() bool {
+	return isatty.IsTerminal(os.Stderr.Fd()) || isatty.IsCygwinTerminal(os.Stderr.Fd())
+}
+
+func Notice(appName, installHint string, result Result) string {
+	app := strings.TrimSpace(appName)
+	if app == "" {
+		app = "app"
+	}
+	current := displayVersion(result.CurrentVersion)
+	latest := displayVersion(result.LatestVersion)
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s: new version available: %s -> %s\n", app, current, latest)
+	if strings.TrimSpace(installHint) != "" {
+		fmt.Fprintf(&b, "upgrade: %s\n", strings.TrimSpace(installHint))
+	} else if strings.TrimSpace(result.LatestURL) != "" {
+		fmt.Fprintf(&b, "release: %s\n", strings.TrimSpace(result.LatestURL))
+	}
+	return b.String()
+}
+
+func StatusText(appName, installHint string, result Result) string {
+	if result.UpdateAvailable {
+		return Notice(appName, installHint, result)
+	}
+	app := strings.TrimSpace(appName)
+	if app == "" {
+		app = "app"
+	}
+	if result.Skipped {
+		return fmt.Sprintf("%s: update check skipped: %s\n", app, result.Reason)
+	}
+	return fmt.Sprintf("%s: up to date (%s)\n", app, displayVersion(result.CurrentVersion))
+}
+
+func normalizeOptions(opts Options) Options {
+	if opts.Interval <= 0 {
+		opts.Interval = DefaultInterval
+	}
+	if opts.Client == nil {
+		opts.Client = http.DefaultClient
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	return opts
+}
+
+func fetchLatest(ctx context.Context, opts Options) (latestRelease, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/releases/latest", GitHubAPI, opts.Owner, opts.Repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return latestRelease{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", opts.AppName+" releasecheck")
+	resp, err := opts.Client.Do(req)
+	if err != nil {
+		return latestRelease{}, fmt.Errorf("check latest %s/%s release: %w", opts.Owner, opts.Repo, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return latestRelease{}, fmt.Errorf("check latest %s/%s release: github returned %s", opts.Owner, opts.Repo, resp.Status)
+	}
+	var latest latestRelease
+	if err := json.NewDecoder(resp.Body).Decode(&latest); err != nil {
+		return latestRelease{}, fmt.Errorf("parse latest %s/%s release: %w", opts.Owner, opts.Repo, err)
+	}
+	if strings.TrimSpace(latest.TagName) == "" {
+		return latestRelease{}, fmt.Errorf("latest %s/%s release has no tag", opts.Owner, opts.Repo)
+	}
+	return latest, nil
+}
+
+func readCache(opts Options) (cacheFile, bool) {
+	path := cachePath(opts)
+	if path == "" {
+		return cacheFile{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cacheFile{}, false
+	}
+	var cached cacheFile
+	if err := json.Unmarshal(data, &cached); err != nil || cached.CheckedAt.IsZero() {
+		return cacheFile{}, false
+	}
+	return cached, true
+}
+
+func writeCache(opts Options, cached cacheFile) {
+	path := cachePath(opts)
+	if path == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	data, err := json.MarshalIndent(cached, "", "  ")
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, append(data, '\n'), 0o600)
+}
+
+func cachePath(opts Options) string {
+	dir := strings.TrimSpace(opts.CacheDir)
+	if dir == "" {
+		return ""
+	}
+	name := strings.TrimSpace(opts.AppName)
+	if name == "" {
+		name = strings.TrimSpace(opts.Repo)
+	}
+	if name == "" {
+		return ""
+	}
+	return filepath.Join(dir, "releasecheck", name+".json")
+}
+
+func versionLess(current, latest string) bool {
+	curParts, curOK := versionParts(current)
+	latParts, latOK := versionParts(latest)
+	if !curOK || !latOK {
+		return false
+	}
+	for i := 0; i < 3; i++ {
+		if curParts[i] < latParts[i] {
+			return true
+		}
+		if curParts[i] > latParts[i] {
+			return false
+		}
+	}
+	return false
+}
+
+var versionRE = regexp.MustCompile(`(?i)^v?([0-9]+)(?:\.([0-9]+))?(?:\.([0-9]+))?`)
+
+func versionParts(v string) ([3]int, bool) {
+	var out [3]int
+	match := versionRE.FindStringSubmatch(strings.TrimSpace(v))
+	if match == nil {
+		return out, false
+	}
+	for i := 1; i <= 3; i++ {
+		if match[i] == "" {
+			continue
+		}
+		n, err := strconv.Atoi(match[i])
+		if err != nil {
+			return out, false
+		}
+		out[i-1] = n
+	}
+	return out, true
+}
+
+func normalizeVersion(v string) string {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "version ")
+	return strings.TrimPrefix(v, "Version ")
+}
+
+func displayVersion(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return "unknown"
+	}
+	return v
+}
+
+func envTruthy(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func envPrefix(appName string) string {
+	appName = strings.ToUpper(strings.TrimSpace(appName))
+	appName = strings.Map(func(r rune) rune {
+		if r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' {
+			return r
+		}
+		return '_'
+	}, appName)
+	return strings.Trim(appName, "_")
+}

--- a/releasecheck/releasecheck_test.go
+++ b/releasecheck/releasecheck_test.go
@@ -1,0 +1,194 @@
+package releasecheck
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCheckReportsNewReleaseAndCaches(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path != "/repos/openclaw/gitcrawl/releases/latest" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"tag_name": "v0.4.0",
+			"html_url": "https://github.com/openclaw/gitcrawl/releases/tag/v0.4.0",
+		})
+	}))
+	defer server.Close()
+	oldAPI := GitHubAPI
+	GitHubAPI = server.URL
+	defer func() { GitHubAPI = oldAPI }()
+
+	now := time.Date(2026, 5, 17, 10, 0, 0, 0, time.UTC)
+	opts := Options{
+		AppName:        "gitcrawl",
+		Owner:          "openclaw",
+		Repo:           "gitcrawl",
+		CurrentVersion: "v0.3.2",
+		CacheDir:       t.TempDir(),
+		Now:            func() time.Time { return now },
+		Client:         server.Client(),
+	}
+	result, err := Check(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if !result.UpdateAvailable || result.LatestVersion != "v0.4.0" || result.FromCache {
+		t.Fatalf("result = %+v", result)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d", requests)
+	}
+
+	result, err = Check(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Check cached: %v", err)
+	}
+	if !result.FromCache || !result.UpdateAvailable {
+		t.Fatalf("cached result = %+v", result)
+	}
+	if requests != 1 {
+		t.Fatalf("requests after cache = %d", requests)
+	}
+}
+
+func TestCheckSkipsDevelopmentVersions(t *testing.T) {
+	for _, version := range []string{"dev", "ci", "0.0.0-dev", "v0.4.0-dirty"} {
+		t.Run(version, func(t *testing.T) {
+			result, err := Check(context.Background(), Options{
+				AppName:        "gitcrawl",
+				Owner:          "openclaw",
+				Repo:           "gitcrawl",
+				CurrentVersion: version,
+				CacheDir:       t.TempDir(),
+			})
+			if !errors.Is(err, ErrSkipped) {
+				t.Fatalf("err = %v", err)
+			}
+			if !result.Skipped || result.Reason != "development version" {
+				t.Fatalf("result = %+v", result)
+			}
+		})
+	}
+}
+
+func TestNotifyWritesOnlyWhenAllowedAndOutdated(t *testing.T) {
+	cacheDir := t.TempDir()
+	cache := cacheFile{
+		CheckedAt:     time.Now(),
+		LatestVersion: "v0.9.0",
+		LatestURL:     "https://github.com/openclaw/discrawl/releases/tag/v0.9.0",
+	}
+	data, err := json.Marshal(cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(cacheDir, "releasecheck", "discrawl.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr strings.Builder
+	result, err := Notify(context.Background(), NotifyOptions{
+		Options: Options{
+			AppName:        "discrawl",
+			Owner:          "openclaw",
+			Repo:           "discrawl",
+			CurrentVersion: "v0.8.0",
+			CacheDir:       cacheDir,
+		},
+		Stderr:      &stderr,
+		InstallHint: "brew upgrade openclaw/tap/discrawl",
+		IsTerminal:  true,
+		Getenv:      func(string) string { return "" },
+	})
+	if err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if !result.UpdateAvailable || !strings.Contains(stderr.String(), "discrawl: new version available: v0.8.0 -> v0.9.0") {
+		t.Fatalf("result=%+v stderr=%q", result, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "brew upgrade openclaw/tap/discrawl") {
+		t.Fatalf("missing install hint: %q", stderr.String())
+	}
+}
+
+func TestShouldNotifySkipsScriptedOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		opts NotifyOptions
+	}{
+		{name: "json", opts: NotifyOptions{JSONOutput: true, IsTerminal: true}},
+		{name: "not terminal", opts: NotifyOptions{IsTerminal: false}},
+		{name: "ci", opts: NotifyOptions{IsTerminal: true, Getenv: func(key string) string {
+			if key == "CI" {
+				return "true"
+			}
+			return ""
+		}}},
+		{name: "global disabled", opts: NotifyOptions{IsTerminal: true, Getenv: func(key string) string {
+			if key == "CRAWLKIT_NO_UPDATE_CHECK" {
+				return "1"
+			}
+			return ""
+		}}},
+		{name: "app disabled", opts: NotifyOptions{Options: Options{AppName: "gitcrawl"}, IsTerminal: true, Getenv: func(key string) string {
+			if key == "GITCRAWL_NO_UPDATE_CHECK" {
+				return "1"
+			}
+			return ""
+		}}},
+		{name: "metadata", opts: NotifyOptions{IsTerminal: true, Args: []string{"metadata"}}},
+		{name: "json flag value", opts: NotifyOptions{IsTerminal: true, Args: []string{"status", "--json=true"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if ok, _ := ShouldNotify(tt.opts); ok {
+				t.Fatal("ShouldNotify = true")
+			}
+		})
+	}
+}
+
+func TestVersionLess(t *testing.T) {
+	tests := []struct {
+		current string
+		latest  string
+		want    bool
+	}{
+		{"v0.3.2", "v0.4.0", true},
+		{"0.9.0", "v0.9.0", false},
+		{"v1.10.0", "v1.9.9", false},
+		{"dev", "v1.0.0", false},
+	}
+	for _, tt := range tests {
+		if got := versionLess(tt.current, tt.latest); got != tt.want {
+			t.Fatalf("versionLess(%q, %q) = %v, want %v", tt.current, tt.latest, got, tt.want)
+		}
+	}
+}
+
+func TestStatusText(t *testing.T) {
+	upToDate := StatusText("gitcrawl", "", Result{CurrentVersion: "v1.0.0"})
+	if !strings.Contains(upToDate, "gitcrawl: up to date (v1.0.0)") {
+		t.Fatalf("upToDate = %q", upToDate)
+	}
+	skipped := StatusText("gitcrawl", "", Result{Skipped: true, Reason: "development version"})
+	if !strings.Contains(skipped, "update check skipped: development version") {
+		t.Fatalf("skipped = %q", skipped)
+	}
+}


### PR DESCRIPTION
## Summary

- add a shared `releasecheck` package for GitHub latest-release polling, 24h cache reads, semver-ish comparison, and update notice formatting
- skip passive notices for JSON output, CI, non-terminal stderr, metadata/check-update commands, disabled env vars, and dev/dirty builds
- document the shared ownership boundary and downstream opt-in pattern

## Verification

- GOWORK=off go mod tidy
- git diff --exit-code -- go.mod go.sum
- GOWORK=off go vet ./...
- GOWORK=off go test -count=1 ./...
- git diff --check
