### PR TITLE
feat(remote): add Cloudflare remote archives

### DIFF
--- a/.agents/skills/autoreview/SKILL.md
+++ b/.agents/skills/autoreview/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: autoreview
+description: "Auto Review closeout. Codex review is the default when no engine is set and is the recommended reviewer."
+---
+
+# Auto Review
+
+Run the bundled structured review helper as a closeout check. This is code review, not Guardian `auto_review` approval routing.
+
+Codex review is the default when no engine is set. It usually delivers the best review results and should remain the normal final closeout engine.
+
+Use when:
+
+- user asks for Codex review / Claude review / autoreview / second-model review
+- after non-trivial code edits, before final/commit/ship
+- reviewing a local branch or PR branch after fixes
+
+## Contract
+
+- Treat review output as advisory. Never blindly apply it.
+- Verify every finding by reading the real code path and adjacent files.
+- Read dependency docs/source/types when the finding depends on external behavior.
+- Reject unrealistic edge cases, speculative risks, broad rewrites, and fixes that over-complicate the codebase.
+- Prefer small fixes at the right ownership boundary; no refactor unless it clearly improves the bug class.
+- Keep going until structured review returns no accepted/actionable findings.
+- If a review-triggered fix changes code, rerun focused tests and rerun the structured review helper.
+- For security-audit suppression changes, verify accepted findings remain auditable: suppressed findings stay in structured output, active output keeps an unsuppressible suppression notice, and aggregate findings cannot hide unrelated active risk.
+- Never switch or override the requested review engine/model. If the review hits model capacity, retry the same command a few times with the same engine/model.
+- Be patient with large bundles. Structured review can take up to 30 minutes while the model call is active, especially with Codex tools or web search.
+- Treat heartbeat lines like `review still running: ... elapsed=... pid=...` as healthy progress, not a hang. Let the helper continue while heartbeats are advancing. Pass `--stream-engine-output` when live engine text is useful; Codex and Claude filter tool/file chatter, other engines pass raw output through.
+- Do not kill a review just because it has been quiet for 2-5 minutes, or because it is still running under the 30-minute window. Inspect the process only after missing multiple expected heartbeats, after 30 minutes, or after an obviously failed subprocess; prefer letting the same helper command finish.
+- Tools are useful in review mode. The helper allows read-only inspection tools and web search by default so reviewers can check dependency contracts, upstream docs, and current behavior.
+- Security perspective is always included, but it should not cripple legitimate functionality. Report security findings only when the change creates a concrete, actionable risk or removes an important safety check.
+- For regression provenance, if no blamed PR is traceable, use the blamed commit as the provenance: commit SHA, date, and author username. Do not guess a merger or frame missing PR metadata as a separate finding.
+- Do not invoke built-in `codex review`, nested reviewers, or reviewer panels from inside the review. The helper builds one bundle, calls one selected engine, validates one structured result, and stops.
+- Stop as soon as the helper exits 0 with no accepted/actionable findings. Do not run an extra review just to get a nicer "clean" line, a second opinion, or clearer closeout wording.
+- Treat the helper's successful exit plus absence of actionable findings as the clean review result, even if the underlying Codex CLI output is terse.
+- Multi-reviewer panels are opt-in only. Use them when explicitly requested or when risk justifies the extra spend; the main agent still verifies every accepted finding before fixing.
+- If rejecting a finding as intentional/not worth fixing, add a brief inline code comment only when it explains a real invariant or ownership decision that future reviewers should know.
+- If `gh`/Gitcrawl reports `database disk image is malformed`, run `gitcrawl doctor --json` once to let the portable cache repair before retrying review; do not bypass the shim unless repair fails and freshness requires live GitHub.
+- If Gitcrawl reports a portable manifest mismatch, source/runtime DB health error, or stale portable-store checkout, run `gitcrawl doctor --json` and inspect `source_db_health`, `runtime_db_health`, and `portable_store_status` before falling back to live GitHub.
+- Do not push just to review. Push only when the user requested push/ship/PR update.
+
+## Pick Target
+
+Dirty local work:
+
+```bash
+<autoreview-helper> --mode local
+```
+
+Use this only when the patch is actually unstaged/staged/untracked in the
+current checkout. For committed, pushed, or PR work, point the helper at the commit
+or branch diff instead; do not force `--mode local` / `--uncommitted` just
+because the helper docs mention dirty work first. A clean local review
+only proves there is no local patch.
+
+Branch/PR work:
+
+```bash
+<autoreview-helper> --mode branch --base origin/main
+```
+
+Optional review context is first-class:
+
+```bash
+<autoreview-helper> --mode branch --base origin/main --prompt-file /tmp/review-notes.md --dataset /tmp/evidence.json
+```
+
+If an open PR exists, use its actual base:
+
+```bash
+base=$(gh pr view --json baseRefName --jq .baseRefName)
+<autoreview-helper> --mode branch --base "origin/$base"
+```
+
+Committed single change:
+
+```bash
+<autoreview-helper> --mode commit --commit HEAD
+```
+
+or with the helper:
+
+```bash
+/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode commit --commit HEAD
+```
+
+Use commit review for already-landed or already-pushed work on `main`. Reviewing
+clean `main` against `origin/main` is usually an empty diff after push. For a
+small stack, review each commit explicitly or review the branch before merging
+with `--base`.
+
+## Parallel Closeout
+
+Format first if formatting can change line locations. Then it is OK to run tests and review in parallel:
+
+```bash
+scripts/autoreview --parallel-tests "<focused test command>"
+```
+
+Tradeoff: tests may force code changes that stale the review. If tests or review lead to code edits, rerun the affected tests and rerun review until no accepted/actionable findings remain. Once that rerun exits cleanly, stop; do not spend another long review cycle on redundant confirmation.
+
+## Review Panels
+
+Run multiple reviewers against one frozen bundle:
+
+```bash
+<autoreview-helper> --reviewers codex,claude
+```
+
+`--panel` is shorthand for Codex plus Claude unless `--engine` changes the first reviewer:
+
+```bash
+<autoreview-helper> --panel
+```
+
+Set reviewer models and thinking/effort explicitly:
+
+```bash
+<autoreview-helper> --reviewers codex,claude --model codex=gpt-5.1 --thinking codex=high --model claude=sonnet --thinking claude=max
+```
+
+Inline syntax is also supported:
+
+```bash
+<autoreview-helper> --reviewers codex:gpt-5.1:high,claude:sonnet:max
+```
+
+Codex maps thinking to `model_reasoning_effort` and accepts `low`, `medium`,
+`high`, or `xhigh`. Claude maps thinking to `--effort` and also accepts `max`.
+Engines without a real thinking knob reject `--thinking`.
+
+## Context Efficiency
+
+Run the helper directly so target selection, engine choice, structured validation, and exit status all stay in one path. If output is noisy, summarize the completed helper output after it returns; do not ask another agent or reviewer to rerun the review.
+
+## Helper
+
+OpenClaw repo-local helper:
+
+```bash
+.agents/skills/autoreview/scripts/autoreview --help
+```
+
+`agent-scripts` checkout helper:
+
+```bash
+skills/autoreview/scripts/autoreview --help
+```
+
+Global helper from `agent-scripts`:
+
+```bash
+~/.codex/skills/agent-scripts/autoreview/scripts/autoreview --help
+```
+
+If installed from `agent-scripts`, path is:
+
+```bash
+/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --help
+```
+
+The helper:
+
+- chooses dirty local changes first
+- otherwise uses current PR base if `gh pr view` works
+- otherwise uses `origin/main` for non-main branches
+- supports `--engine codex`, `claude`, `droid`, and `copilot`; default is `AUTOREVIEW_ENGINE` or `codex`; Codex should remain the default when nothing is set
+- use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
+- should be left in `--mode auto` or forced to `--mode branch` for PR/branch work; do not force `--mode local` after committing
+- writes only to stdout unless `--output`, `--json-output`, or live streamed engine stderr is set
+- supports `--dry-run`, `--parallel-tests`, `--prompt`, `--prompt-file`, `--dataset`, `--no-tools`, `--no-web-search`, and commit refs
+- supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
+- supports opt-in review panels with `--panel` / `--reviewers`, plus per-engine `--model` and `--thinking`
+- allows read-only tools and web search by default where the selected CLI supports them; forbids nested review in the prompt; Codex is run through `codex exec` with read-only sandbox and structured output
+- prints `review still running: <engine> elapsed=<seconds>s pid=<pid>` to stderr at long-running intervals while waiting for the selected review engine, unless streamed output or compact Codex activity has been visible recently
+- prints `autoreview clean: no accepted/actionable findings reported` when the selected review command exits 0
+- exits nonzero when accepted/actionable findings are present
+
+## Final Report
+
+Include:
+
+- review command used
+- tests/proof run
+- findings accepted/rejected, briefly why
+- the clean review result from the final helper/review run, or why a remaining finding was consciously rejected
+
+Do not run another review solely to improve the final report wording. If the final helper run exited 0 and produced no accepted/actionable findings, report that exact run as clean.

--- a/.agents/skills/autoreview/scripts/autoreview
+++ b/.agents/skills/autoreview/scripts/autoreview
@@ -1,0 +1,1176 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import copy
+import json
+import os
+import queue
+import subprocess
+import sys
+import tempfile
+import textwrap
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+
+ENGINES = ("codex", "claude", "droid", "copilot")
+THINKING_LEVELS_BY_ENGINE = {
+    "codex": {"low", "medium", "high", "xhigh"},
+    "claude": {"low", "medium", "high", "xhigh", "max"},
+    "droid": set(),
+    "copilot": set(),
+}
+
+
+SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": [
+        "findings",
+        "overall_correctness",
+        "overall_explanation",
+        "overall_confidence",
+    ],
+    "properties": {
+        "findings": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": [
+                    "title",
+                    "body",
+                    "priority",
+                    "confidence",
+                    "category",
+                    "code_location",
+                ],
+                "properties": {
+                    "title": {"type": "string", "minLength": 1, "maxLength": 140},
+                    "body": {"type": "string", "minLength": 1, "maxLength": 2000},
+                    "priority": {"type": "string", "enum": ["P0", "P1", "P2", "P3"]},
+                    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                    "category": {
+                        "type": "string",
+                        "enum": ["bug", "security", "regression", "test_gap", "maintainability"],
+                    },
+                    "code_location": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["file_path", "line"],
+                        "properties": {
+                            "file_path": {"type": "string", "minLength": 1},
+                            "line": {"type": "integer", "minimum": 1},
+                        },
+                    },
+                },
+            },
+        },
+        "overall_correctness": {
+            "type": "string",
+            "enum": ["patch is correct", "patch is incorrect"],
+        },
+        "overall_explanation": {"type": "string", "minLength": 1, "maxLength": 3000},
+        "overall_confidence": {"type": "number", "minimum": 0, "maximum": 1},
+    },
+}
+
+
+def run(args: list[str], cwd: Path, *, input_text: str | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        input=input_text,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if check and result.returncode != 0:
+        cmd = " ".join(args)
+        raise SystemExit(f"command failed ({result.returncode}): {cmd}\n{result.stderr or result.stdout}")
+    return result
+
+
+def run_with_heartbeat(
+    args: list[str],
+    cwd: Path,
+    *,
+    input_text: str | None = None,
+    label: str,
+    heartbeat_seconds: int = 60,
+    stream_output: bool = False,
+    stream_display: Callable[[str, str], str | None] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    if stream_output:
+        return run_with_stream(
+            args,
+            cwd,
+            input_text=input_text,
+            label=label,
+            heartbeat_seconds=heartbeat_seconds,
+            stream_display=stream_display,
+        )
+    started = time.monotonic()
+    proc = subprocess.Popen(
+        args,
+        cwd=cwd,
+        stdin=subprocess.PIPE if input_text is not None else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    first_communicate = True
+    while True:
+        try:
+            stdout, stderr = proc.communicate(
+                input=input_text if first_communicate else None,
+                timeout=heartbeat_seconds,
+            )
+            return subprocess.CompletedProcess(args, int(proc.returncode or 0), stdout, stderr)
+        except subprocess.TimeoutExpired:
+            first_communicate = False
+            elapsed = int(time.monotonic() - started)
+            print(f"review still running: {label} elapsed={elapsed}s pid={proc.pid}", file=sys.stderr, flush=True)
+
+
+def run_with_stream(
+    args: list[str],
+    cwd: Path,
+    *,
+    input_text: str | None,
+    label: str,
+    heartbeat_seconds: int,
+    stream_display: Callable[[str, str], str | None] | None,
+) -> subprocess.CompletedProcess[str]:
+    started = time.monotonic()
+    proc = subprocess.Popen(
+        args,
+        cwd=cwd,
+        stdin=subprocess.PIPE if input_text is not None else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    events: queue.Queue[tuple[str, str | None]] = queue.Queue()
+    stdout_parts: list[str] = []
+    stderr_parts: list[str] = []
+
+    def read_stream(name: str, stream: Any) -> None:
+        try:
+            for line in iter(stream.readline, ""):
+                events.put((name, line))
+        finally:
+            events.put((name, None))
+
+    def write_stdin() -> None:
+        if proc.stdin is None or input_text is None:
+            return
+        try:
+            proc.stdin.write(input_text)
+            proc.stdin.close()
+        except BrokenPipeError:
+            return
+
+    threads = [
+        threading.Thread(target=read_stream, args=("stdout", proc.stdout), daemon=True),
+        threading.Thread(target=read_stream, args=("stderr", proc.stderr), daemon=True),
+    ]
+    for thread in threads:
+        thread.start()
+    stdin_thread = threading.Thread(target=write_stdin, daemon=True)
+    stdin_thread.start()
+
+    open_streams = 2
+    while open_streams:
+        try:
+            name, line = events.get(timeout=heartbeat_seconds)
+        except queue.Empty:
+            elapsed = int(time.monotonic() - started)
+            print(f"review still running: {label} elapsed={elapsed}s pid={proc.pid}", file=sys.stderr, flush=True)
+            continue
+        if line is None:
+            open_streams -= 1
+            continue
+        if name == "stdout":
+            stdout_parts.append(line)
+        else:
+            stderr_parts.append(line)
+        display = stream_display(name, line) if stream_display else line
+        if display:
+            target = sys.stdout if name == "stdout" else sys.stderr
+            target.write(display)
+            target.flush()
+
+    for thread in threads:
+        thread.join()
+    stdin_thread.join(timeout=1)
+    returncode = proc.wait()
+    return subprocess.CompletedProcess(args, returncode, "".join(stdout_parts), "".join(stderr_parts))
+
+
+def git(repo: Path, *args: str, check: bool = True) -> str:
+    return run(["git", *args], repo, check=check).stdout
+
+
+def repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        raise SystemExit("autoreview must run inside a git repository")
+    return Path(result.stdout.strip()).resolve()
+
+
+def current_branch(repo: Path) -> str:
+    return git(repo, "branch", "--show-current", check=False).strip() or "detached"
+
+
+def is_dirty(repo: Path) -> bool:
+    return bool(git(repo, "status", "--porcelain").strip())
+
+
+def choose_target(repo: Path, mode: str, base_ref: str | None) -> tuple[str, str | None]:
+    branch = current_branch(repo)
+    if mode == "local" or (mode == "auto" and is_dirty(repo)):
+        return "local", None
+    if mode == "commit":
+        return "commit", None
+    if mode == "branch" or (mode == "auto" and branch != "main"):
+        return "branch", base_ref or detect_pr_base(repo) or "origin/main"
+    raise SystemExit("no review target: clean main checkout and no forced mode")
+
+
+def detect_pr_base(repo: Path) -> str | None:
+    if not shutil_which("gh"):
+        return None
+    result = run(["gh", "pr", "view", "--json", "baseRefName", "--jq", ".baseRefName"], repo, check=False)
+    base = result.stdout.strip()
+    return f"origin/{base}" if result.returncode == 0 and base else None
+
+
+def shutil_which(name: str) -> str | None:
+    for part in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = Path(part) / name
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return None
+
+
+def bounded(text: str, limit: int = 180_000) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"\n\n[truncated at {limit} characters]\n"
+
+
+def bounded_field(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    suffix = "\n\n[truncated]"
+    return text[: max(0, limit - len(suffix))] + suffix
+
+
+def read_text(path: Path, limit: int = 40_000) -> str:
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        return f"[unreadable: {exc}]"
+    if b"\0" in data:
+        return "[binary file omitted]"
+    text = data.decode("utf-8", errors="replace")
+    return bounded(text, limit)
+
+
+def local_bundle(repo: Path) -> str:
+    parts = [
+        "# Git Status",
+        git(repo, "status", "--short"),
+        "# Staged Diff",
+        git(repo, "diff", "--cached", "--stat"),
+        bounded(git(repo, "diff", "--cached", "--patch", "--find-renames")),
+        "# Unstaged Diff",
+        git(repo, "diff", "--stat"),
+        bounded(git(repo, "diff", "--patch", "--find-renames")),
+    ]
+    untracked = [line for line in git(repo, "ls-files", "--others", "--exclude-standard").splitlines() if line]
+    if untracked:
+        parts.append("# Untracked Files")
+        for rel in untracked:
+            path = repo / rel
+            parts.append(f"## {rel}\n{read_text(path)}")
+    return "\n\n".join(parts)
+
+
+def branch_bundle(repo: Path, base_ref: str) -> str:
+    git(repo, "fetch", "origin", "--quiet", check=False)
+    return "\n\n".join(
+        [
+            "# Branch Diff",
+            f"base: {base_ref}",
+            git(repo, "diff", "--stat", f"{base_ref}...HEAD"),
+            bounded(git(repo, "diff", "--patch", "--find-renames", f"{base_ref}...HEAD")),
+        ]
+    )
+
+
+def commit_bundle(repo: Path, commit_ref: str) -> str:
+    return "\n\n".join(
+        [
+            "# Commit Diff",
+            f"commit: {commit_ref}",
+            git(repo, "show", "--stat", "--format=fuller", commit_ref),
+            bounded(git(repo, "show", "--patch", "--find-renames", "--format=fuller", commit_ref)),
+        ]
+    )
+
+
+def review_paths(repo: Path, target: str, target_ref: str | None, commit_ref: str) -> set[str]:
+    names: set[str] = set()
+    if target == "local":
+        sources = [
+            git(repo, "diff", "--name-only", "--cached"),
+            git(repo, "diff", "--name-only"),
+            git(repo, "ls-files", "--others", "--exclude-standard"),
+        ]
+    elif target == "branch":
+        assert target_ref
+        sources = [git(repo, "diff", "--name-only", f"{target_ref}...HEAD")]
+    else:
+        sources = [git(repo, "show", "--name-only", "--format=", commit_ref)]
+    for source in sources:
+        for line in source.splitlines():
+            path = line.strip()
+            if path:
+                names.add(path)
+    return names
+
+
+def load_extra_prompt(args: argparse.Namespace) -> str:
+    chunks: list[str] = []
+    for value in args.prompt or []:
+        chunks.append(value)
+    for path in args.prompt_file or []:
+        chunks.append(Path(path).read_text())
+    return "\n\n".join(chunks)
+
+
+def load_datasets(args: argparse.Namespace) -> str:
+    chunks: list[str] = []
+    for spec in args.dataset or []:
+        path = Path(spec)
+        if path.is_dir():
+            raise SystemExit(f"--dataset must be a file, got directory: {path}")
+        chunks.append(f"# Dataset: {path}\n{read_text(path)}")
+    return "\n\n".join(chunks)
+
+
+def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, extra_prompt: str, datasets: str) -> str:
+    target_line = f"{target} {target_ref}" if target_ref else target
+    return textwrap.dedent(
+        f"""
+        You are a senior code reviewer. Review the provided git change bundle only.
+
+        Hard rules:
+        - Return exactly one JSON object and nothing else. Do not wrap it in Markdown.
+        - The JSON object must match this schema exactly:
+        {json.dumps(SCHEMA, indent=2)}
+        - Do not modify files.
+        - Do not invoke nested reviewers or review tools.
+        - Forbidden nested review commands include: codex review, autoreview, claude review, oracle review.
+        - You may use read-only tools and web search to inspect files, dependency contracts, upstream docs, current behavior, and security implications.
+        - Shell commands, if available, must be read-only inspection commands. Do not run tests, formatters, package installs, generators, network mutation commands, git mutation commands, or commands that write files.
+        - Report only actionable defects introduced or exposed by this change.
+        - Prefer high-signal findings over style feedback.
+        - Include security findings: injection, secret leaks, authz/authn bypass, path traversal, unsafe deserialization, unsafe filesystem or shell use, privacy leaks, and credential handling.
+        - Do not reject legitimate functionality merely because it touches shell, filesystem, network, auth, or sensitive data. Report a security finding only when the patch creates a concrete exploitable risk, removes an important safety check, or lacks validation at a trust boundary.
+        - For each finding, use the smallest file/line location that demonstrates the issue.
+        - If there are no actionable findings, return an empty findings array and mark the patch correct.
+
+        Review target: {target_line}
+        Repository: {repo}
+
+        {extra_prompt}
+
+        {datasets}
+
+        # Change Bundle
+        {bundle}
+        """
+    ).strip()
+
+
+def write_json_temp(data: dict[str, Any]) -> Path:
+    handle = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+    with handle:
+        json.dump(data, handle)
+    return Path(handle.name)
+
+
+def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    if not args.tools:
+        raise SystemExit("--no-tools is not supported by the Codex engine; use --engine claude --no-tools for a no-tools run")
+    schema_path = write_json_temp(SCHEMA)
+    output_path = Path(tempfile.NamedTemporaryFile("w", suffix=".json", delete=False).name)
+    cmd = [args.codex_bin, "--ask-for-approval", "never"]
+    if args.web_search:
+        cmd.append("--search")
+    if args.model:
+        cmd.extend(["--model", args.model])
+    if args.thinking:
+        cmd.extend(["-c", f'model_reasoning_effort="{args.thinking}"'])
+    cmd.append("exec")
+    if args.stream_engine_output:
+        cmd.append("--json")
+    cmd.extend(
+        [
+            "--ephemeral",
+            "-C",
+            str(repo),
+            "-s",
+            "read-only",
+            "--output-schema",
+            str(schema_path),
+            "--output-last-message",
+            str(output_path),
+            "-",
+        ]
+    )
+    result = run_with_heartbeat(
+        cmd,
+        repo,
+        input_text=prompt,
+        label="codex",
+        stream_output=args.stream_engine_output,
+        stream_display=CodexStreamDisplay() if args.stream_engine_output else None,
+    )
+    try:
+        output = output_path.read_text()
+    finally:
+        schema_path.unlink(missing_ok=True)
+        output_path.unlink(missing_ok=True)
+    if result.returncode != 0:
+        raise SystemExit(f"codex engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return output or result.stdout
+
+
+def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    cmd = [
+        args.claude_bin,
+        "--print",
+        "--no-session-persistence",
+        "--output-format",
+        "stream-json" if args.stream_engine_output else "json",
+        "--json-schema",
+        json.dumps(SCHEMA),
+    ]
+    if args.tools:
+        cmd.extend(["--allowedTools", claude_allowed_tools(args)])
+    else:
+        cmd.extend(["--tools", ""])
+    if args.stream_engine_output:
+        cmd.append("--verbose")
+    if args.model:
+        cmd.extend(["--model", args.model])
+    if args.thinking:
+        cmd.extend(["--effort", args.thinking])
+    result = run_with_heartbeat(
+        cmd,
+        repo,
+        input_text=prompt,
+        label="claude",
+        stream_output=args.stream_engine_output,
+        stream_display=ClaudeStreamDisplay() if args.stream_engine_output else None,
+    )
+    if result.returncode != 0:
+        raise SystemExit(f"claude engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return result.stdout
+
+
+def run_droid(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    if args.thinking:
+        raise SystemExit("--thinking is not supported by the droid engine")
+    prompt_path = Path(tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False).name)
+    prompt_path.write_text(prompt)
+    cmd = [
+        args.droid_bin,
+        "exec",
+        "--cwd",
+        str(repo),
+        "--output-format",
+        "json",
+        "-f",
+        str(prompt_path),
+    ]
+    if args.model:
+        cmd.extend(["--model", args.model])
+    if not args.tools:
+        cmd.extend(["--disabled-tools", "*"])
+    result = run_with_heartbeat(cmd, repo, label="droid", stream_output=args.stream_engine_output)
+    prompt_path.unlink(missing_ok=True)
+    if result.returncode != 0:
+        raise SystemExit(f"droid engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return result.stdout
+
+
+def run_copilot(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    if args.thinking:
+        raise SystemExit("--thinking is not supported by the copilot engine")
+    if not args.tools:
+        raise SystemExit("--no-tools is not supported by the copilot engine; copilot requires a read-only file view tool to load the review bundle without exposing it in argv")
+    with tempfile.TemporaryDirectory(prefix="autoreview-copilot.") as tempdir:
+        prompt_path = Path(tempdir) / "prompt.txt"
+        prompt_path.write_text(prompt)
+        os.chmod(prompt_path, 0o600)
+        cmd = [
+            args.copilot_bin,
+            "-C",
+            tempdir,
+            "-p",
+            "Read ./prompt.txt and follow it exactly. Return only the requested JSON object.",
+            "--output-format",
+            "json",
+            "--stream",
+            "on" if args.stream_engine_output else "off",
+            "--no-ask-user",
+            "--disable-builtin-mcps",
+        ]
+        if args.model:
+            cmd.extend(["--model", args.model])
+        cmd.extend(
+            [
+                "--available-tools=read_agent,rg,view,web_fetch",
+                "--allow-tool=read_agent",
+                "--allow-tool=rg",
+                "--allow-tool=view",
+                "--allow-tool=web_fetch",
+            ]
+        )
+        if args.web_search:
+            cmd.append("--allow-all-urls")
+        result = run_with_heartbeat(cmd, Path(tempdir), label="copilot", stream_output=args.stream_engine_output)
+    if result.returncode != 0:
+        raise SystemExit(f"copilot engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return result.stdout
+
+
+class CodexStreamDisplay:
+    def __init__(self, *, activity_seconds: int = 20) -> None:
+        self.activity_seconds = activity_seconds
+        self.hidden_events = 0
+        self.last_visible = time.monotonic()
+
+    def __call__(self, name: str, line: str) -> str | None:
+        if name != "stdout":
+            return line
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            return self.visible(line)
+        event_type = event.get("type")
+        if event_type == "thread.started":
+            return self.visible(f"codex thread: {event.get('thread_id', '<unknown>')}\n")
+        if event_type == "turn.started":
+            return self.visible("codex turn started\n")
+        if event_type == "turn.completed":
+            usage = event.get("usage")
+            message = format_codex_usage(usage) + "\n" if isinstance(usage, dict) else "codex turn completed\n"
+            return self.visible(self.flush_hidden() + message)
+        item = event.get("item")
+        if isinstance(item, dict) and item.get("type") == "agent_message" and isinstance(item.get("text"), str):
+            return self.visible(self.flush_hidden() + item["text"].rstrip() + "\n")
+        return self.hidden_activity()
+
+    def hidden_activity(self) -> str | None:
+        self.hidden_events += 1
+        if time.monotonic() - self.last_visible < self.activity_seconds:
+            return None
+        return self.visible(self.flush_hidden())
+
+    def flush_hidden(self) -> str:
+        if not self.hidden_events:
+            return ""
+        count = self.hidden_events
+        self.hidden_events = 0
+        return f"codex activity: {count} hidden tool/status events\n"
+
+    def visible(self, text: str) -> str:
+        self.last_visible = time.monotonic()
+        return text
+
+
+class ClaudeStreamDisplay:
+    def __init__(self, *, activity_seconds: int = 20) -> None:
+        self.activity_seconds = activity_seconds
+        self.hidden_events = 0
+        self.last_visible = time.monotonic()
+        self.started = False
+
+    def __call__(self, name: str, line: str) -> str | None:
+        if name != "stdout":
+            return line
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            return self.visible(line)
+        event_type = event.get("type")
+        if event_type == "system" and not self.started:
+            self.started = True
+            return self.visible("claude turn started\n")
+        if event_type == "assistant":
+            return self.assistant_message(event)
+        if event_type == "result":
+            return self.visible(self.flush_hidden() + self.result_summary(event))
+        return self.hidden_activity()
+
+    def assistant_message(self, event: dict[str, Any]) -> str | None:
+        message = event.get("message")
+        if not isinstance(message, dict):
+            return self.hidden_activity()
+        chunks: list[str] = []
+        for item in message.get("content", []):
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") == "text" and isinstance(item.get("text"), str):
+                chunks.append(item["text"].rstrip())
+        if chunks:
+            return self.visible(self.flush_hidden() + "\n".join(chunks) + "\n")
+        return self.hidden_activity()
+
+    def result_summary(self, event: dict[str, Any]) -> str:
+        usage = event.get("usage")
+        fields: list[str] = []
+        if isinstance(usage, dict):
+            for key in (
+                "input_tokens",
+                "cache_read_input_tokens",
+                "cache_creation_input_tokens",
+                "output_tokens",
+            ):
+                value = usage.get(key)
+                if isinstance(value, int):
+                    fields.append(f"{key}={value}")
+        cost = event.get("total_cost_usd")
+        if isinstance(cost, (int, float)) and not isinstance(cost, bool):
+            fields.append(f"cost_usd={cost:.6f}")
+        return "claude usage: " + " ".join(fields) + "\n" if fields else "claude turn completed\n"
+
+    def hidden_activity(self) -> str | None:
+        self.hidden_events += 1
+        if time.monotonic() - self.last_visible < self.activity_seconds:
+            return None
+        return self.visible(self.flush_hidden())
+
+    def flush_hidden(self) -> str:
+        if not self.hidden_events:
+            return ""
+        count = self.hidden_events
+        self.hidden_events = 0
+        return f"claude activity: {count} hidden tool/status events\n"
+
+    def visible(self, text: str) -> str:
+        self.last_visible = time.monotonic()
+        return text
+
+
+def format_codex_usage(usage: dict[str, Any]) -> str:
+    fields = [
+        "input_tokens",
+        "cached_input_tokens",
+        "output_tokens",
+        "reasoning_output_tokens",
+    ]
+    parts = [f"{field}={usage[field]}" for field in fields if isinstance(usage.get(field), int)]
+    return "codex usage: " + " ".join(parts) if parts else "codex usage: unavailable"
+
+
+def claude_allowed_tools(args: argparse.Namespace) -> str:
+    tools = [tool.strip() for tool in args.claude_allowed_tools.split(",") if tool.strip()]
+    if not args.web_search:
+        tools = [tool for tool in tools if tool not in {"WebSearch", "WebFetch"}]
+    return ",".join(tools)
+
+
+def extract_json(text: str) -> dict[str, Any]:
+    stripped = text.strip()
+    if not stripped:
+        raise SystemExit("review engine returned empty output")
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError as exc:
+        fenced_report = parse_json_candidate(stripped)
+        if isinstance(fenced_report, dict) and "findings" in fenced_report:
+            return fenced_report
+        jsonl_report = extract_json_from_jsonl(stripped)
+        if jsonl_report:
+            return jsonl_report
+        raise SystemExit(f"review engine returned non-JSON output: {exc}\n{stripped[:2000]}")
+    if isinstance(parsed, dict) and "findings" in parsed:
+        return parsed
+    if isinstance(parsed, dict) and isinstance(parsed.get("structured_output"), dict):
+        return parsed["structured_output"]
+    if isinstance(parsed, dict) and isinstance(parsed.get("result"), str):
+        result_json = parse_json_candidate(parsed["result"])
+        if isinstance(result_json, dict) and "findings" in result_json:
+            return result_json
+        raise SystemExit(f"review engine result was not structured JSON:\n{parsed['result'][:2000]}")
+    jsonl_report = extract_json_from_jsonl(stripped)
+    if jsonl_report:
+        return jsonl_report
+    raise SystemExit(f"review engine returned unexpected JSON shape:\n{json.dumps(parsed)[:2000]}")
+
+
+def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
+    candidates: list[str | dict[str, Any]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        part = event.get("part")
+        if isinstance(part, dict) and isinstance(part.get("text"), str):
+            candidates.append(part["text"])
+        data = event.get("data")
+        if isinstance(data, dict) and isinstance(data.get("content"), str):
+            candidates.append(data["content"])
+        if isinstance(event.get("result"), str):
+            candidates.append(event["result"])
+        if isinstance(event.get("structured_output"), dict):
+            candidates.append(event["structured_output"])
+    for candidate in reversed(candidates):
+        if isinstance(candidate, dict):
+            if "findings" in candidate:
+                return candidate
+            continue
+        parsed = parse_json_candidate(candidate)
+        if isinstance(parsed, dict) and "findings" in parsed:
+            return parsed
+    return None
+
+
+def parse_json_candidate(text: str) -> Any | None:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        if lines and lines[0].startswith("```") and lines[-1].strip() == "```":
+            stripped = "\n".join(lines[1:-1]).strip()
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(parsed, str) and parsed != text:
+        nested = parse_json_candidate(parsed)
+        return nested if nested is not None else parsed
+    return parsed
+
+
+def validate_report(report: dict[str, Any], repo: Path, changed_paths: set[str], required: list[str]) -> None:
+    allowed_top = {"findings", "overall_correctness", "overall_explanation", "overall_confidence"}
+    extra_top = set(report) - allowed_top
+    if extra_top:
+        raise SystemExit(f"review JSON has unexpected top-level keys: {sorted(extra_top)}")
+    for key in SCHEMA["required"]:
+        if key not in report:
+            raise SystemExit(f"review JSON missing required key: {key}")
+    if not isinstance(report["findings"], list):
+        raise SystemExit("review JSON findings must be an array")
+    if report.get("overall_correctness") not in {"patch is correct", "patch is incorrect"}:
+        raise SystemExit(f"review JSON has invalid overall_correctness: {report.get('overall_correctness')}")
+    if not isinstance(report.get("overall_explanation"), str) or not report["overall_explanation"]:
+        raise SystemExit("review JSON overall_explanation must be a non-empty string")
+    if len(report["overall_explanation"]) > 3000:
+        raise SystemExit("review JSON overall_explanation is too long")
+    if not number_in_range(report.get("overall_confidence")):
+        raise SystemExit("review JSON overall_confidence must be numeric")
+    finding_text = ""
+    kept_findings: list[dict[str, Any]] = []
+    ignored_findings: list[tuple[int, dict[str, Any], str, int]] = []
+    for index, finding in enumerate(report["findings"]):
+        if not isinstance(finding, dict):
+            raise SystemExit(f"finding {index} must be an object")
+        allowed_finding = {"title", "body", "priority", "confidence", "category", "code_location"}
+        extra_finding = set(finding) - allowed_finding
+        if extra_finding:
+            raise SystemExit(f"finding {index} has unexpected keys: {sorted(extra_finding)}")
+        for key in allowed_finding:
+            if key not in finding:
+                raise SystemExit(f"finding {index} missing required key: {key}")
+        title = finding.get("title")
+        if not isinstance(title, str) or not title or len(title) > 140:
+            raise SystemExit(f"finding {index} has invalid title")
+        body = finding.get("body")
+        if not isinstance(body, str) or not body or len(body) > 2000:
+            raise SystemExit(f"finding {index} has invalid body")
+        priority = finding.get("priority")
+        if priority not in {"P0", "P1", "P2", "P3"}:
+            raise SystemExit(f"finding {index} has invalid priority: {priority}")
+        if not number_in_range(finding.get("confidence")):
+            raise SystemExit(f"finding {index} has invalid confidence")
+        category = finding.get("category")
+        if category not in {"bug", "security", "regression", "test_gap", "maintainability"}:
+            raise SystemExit(f"finding {index} has invalid category: {category}")
+        location = finding.get("code_location")
+        if not isinstance(location, dict):
+            raise SystemExit(f"finding {index} missing code_location")
+        rel = str(location.get("file_path", "")).strip()
+        line = location.get("line")
+        if not rel or not isinstance(line, int) or line < 1:
+            raise SystemExit(f"finding {index} has invalid location: {location}")
+        if Path(rel).is_absolute() or ".." in Path(rel).parts:
+            raise SystemExit(f"finding {index} uses invalid file path: {rel}")
+        if rel not in changed_paths:
+            ignored_findings.append((index, finding, rel, line))
+            continue
+        kept_findings.append(finding)
+        finding_text += "\n" + json.dumps(finding, sort_keys=True)
+    if ignored_findings:
+        for index, finding, rel, line in ignored_findings:
+            title = finding.get("title", "<untitled>")
+            print(
+                f"autoreview ignored out-of-scope finding {index}: {title} ({rel}:{line})",
+                file=sys.stderr,
+            )
+            print(bounded_field(str(finding.get("body", "")), 500), file=sys.stderr)
+        report["findings"] = kept_findings
+        if not kept_findings and report["overall_correctness"] == "patch is incorrect":
+            note = f"Ignored {len(ignored_findings)} out-of-scope finding(s) outside the reviewed change."
+            explanation = report["overall_explanation"].rstrip()
+            report["overall_correctness"] = "patch is correct"
+            report["overall_explanation"] = bounded_field(f"{explanation}\n\n{note}", 3000)
+    haystack = finding_text.lower()
+    for needle in required:
+        if needle.lower() not in haystack:
+            raise SystemExit(f"required finding text not found: {needle}")
+
+
+def number_in_range(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and 0 <= value <= 1
+
+
+def print_report(report: dict[str, Any], *, label: str = "autoreview") -> None:
+    findings = report["findings"]
+    if findings:
+        print(f"{label} findings: {len(findings)}")
+    elif report["overall_correctness"] == "patch is incorrect":
+        print(f"{label} verdict: patch is incorrect without discrete findings")
+    else:
+        print(f"{label} clean: no accepted/actionable findings reported")
+    for finding in findings:
+        loc = finding["code_location"]
+        print(f"[{finding['priority']}] {finding['title']}")
+        print(f"{loc['file_path']}:{loc['line']}")
+        print(f"{finding['body']}")
+        print()
+    print(f"overall: {report['overall_correctness']} ({report['overall_confidence']})")
+    print(report["overall_explanation"])
+
+
+def start_parallel_tests(command: str, repo: Path) -> tuple[subprocess.Popen, float]:
+    print(f"tests: {command}")
+    return subprocess.Popen(command, cwd=repo, shell=True), time.time()
+
+
+def finish_parallel_tests(proc: subprocess.Popen, started: float) -> int:
+    proc.wait()
+    print(f"tests exit: {proc.returncode} after {int(time.time() - started)}s")
+    return int(proc.returncode or 0)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Bundle-driven AI code review.")
+    parser.add_argument("--mode", choices=["auto", "local", "branch", "commit"], default="auto")
+    parser.add_argument("--base")
+    parser.add_argument("--commit", default="HEAD")
+    parser.add_argument("--engine", choices=ENGINES, default=os.environ.get("AUTOREVIEW_ENGINE", "codex"))
+    parser.add_argument("--reviewers", help="Comma-separated review panel, e.g. codex,claude or codex:gpt-5:high.")
+    parser.add_argument("--panel", action="store_true", help="Run a Codex/Claude review panel unless --engine changes the first reviewer.")
+    parser.add_argument("--model", action="append", help="Model for all reviewers or engine=model. Repeatable.")
+    parser.add_argument("--thinking", action="append", help="Thinking/effort for all reviewers or engine=level. Repeatable. Codex: low, medium, high, xhigh. Claude: low, medium, high, xhigh, max.")
+    parser.add_argument("--allow-partial-panel", action="store_true", help="Continue panel output when one reviewer fails.")
+    parser.add_argument("--codex-bin", default=os.environ.get("CODEX_BIN", "codex"))
+    parser.add_argument("--claude-bin", default=os.environ.get("CLAUDE_BIN", "claude"))
+    parser.add_argument("--droid-bin", default=os.environ.get("DROID_BIN", "droid"))
+    parser.add_argument("--copilot-bin", default=os.environ.get("COPILOT_BIN", "copilot"))
+    parser.add_argument("--no-tools", dest="tools", action="store_false", default=True, help="Disable tools for engines that support it. Codex and copilot reject no-tools review.")
+    parser.add_argument("--no-web-search", dest="web_search", action="store_false", default=True)
+    parser.add_argument(
+        "--claude-allowed-tools",
+        default=os.environ.get(
+            "AUTOREVIEW_CLAUDE_TOOLS",
+            "Read,Grep,Glob,WebSearch,WebFetch",
+        ),
+    )
+    parser.add_argument("--prompt", action="append", help="Additional review instruction text.")
+    parser.add_argument("--prompt-file", action="append", help="Additional review instruction file.")
+    parser.add_argument("--dataset", action="append", help="Extra evidence file to include in the review bundle.")
+    parser.add_argument("--output", help="Write human output to a file as well as stdout.")
+    parser.add_argument("--json-output", help="Write validated structured review JSON.")
+    parser.add_argument(
+        "--stream-engine-output",
+        action="store_true",
+        default=os.environ.get("AUTOREVIEW_STREAM_ENGINE_OUTPUT") == "1",
+        help="Stream review engine output while preserving buffered output for validation. Codex output is filtered to hide tool/file chatter.",
+    )
+    parser.add_argument("--parallel-tests", help="Run a test command concurrently with review; failure fails the helper.")
+    parser.add_argument("--require-finding", action="append", default=[], help="Require finding text to contain this substring.")
+    parser.add_argument("--expect-findings", action="store_true", help="Treat findings as success; for harness acceptance tests.")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    if args.engine not in ENGINES:
+        raise SystemExit(f"invalid --engine/AUTOREVIEW_ENGINE: {args.engine}")
+    return args
+
+
+def run_engine(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    if args.engine == "codex":
+        return run_codex(args, repo, prompt)
+    if args.engine == "claude":
+        return run_claude(args, repo, prompt)
+    if args.engine == "droid":
+        return run_droid(args, repo, prompt)
+    if args.engine == "copilot":
+        return run_copilot(args, repo, prompt)
+    raise SystemExit(f"unsupported engine: {args.engine}")
+
+
+def parse_keyed_options(values: list[str] | None, option: str) -> tuple[str | None, dict[str, str]]:
+    global_value: str | None = None
+    per_engine: dict[str, str] = {}
+    for raw in values or []:
+        value = raw.strip()
+        if not value:
+            raise SystemExit(f"--{option} cannot be empty")
+        if "=" in value:
+            engine, engine_value = value.split("=", 1)
+            engine = engine.strip()
+            engine_value = engine_value.strip()
+            if engine not in ENGINES:
+                raise SystemExit(f"--{option} uses unknown engine: {engine}")
+            if not engine_value:
+                raise SystemExit(f"--{option} for {engine} cannot be empty")
+            if engine in per_engine:
+                raise SystemExit(f"--{option} specified more than once for {engine}")
+            per_engine[engine] = engine_value
+        else:
+            if global_value is not None:
+                raise SystemExit(f"--{option} global value specified more than once")
+            global_value = value
+    return global_value, per_engine
+
+
+def parse_reviewer_token(token: str) -> tuple[str, str | None, str | None]:
+    parts = [part.strip() for part in token.split(":")]
+    if len(parts) > 3 or not parts[0]:
+        raise SystemExit(f"invalid reviewer spec: {token}")
+    engine = parts[0]
+    if engine not in ENGINES:
+        raise SystemExit(f"unknown reviewer engine: {engine}")
+    model = parts[1] if len(parts) >= 2 and parts[1] else None
+    thinking = parts[2] if len(parts) == 3 and parts[2] else None
+    return engine, model, thinking
+
+
+def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
+    global_model, model_by_engine = parse_keyed_options(args.model, "model")
+    global_thinking, thinking_by_engine = parse_keyed_options(args.thinking, "thinking")
+    reviewers: list[tuple[str, str | None, str | None]] = []
+    if args.reviewers:
+        tokens = [token.strip() for token in args.reviewers.split(",") if token.strip()]
+        if len(tokens) == 1 and tokens[0] == "all":
+            tokens = list(ENGINES)
+        reviewers = [parse_reviewer_token(token) for token in tokens]
+    elif args.panel:
+        engines = [args.engine]
+        for engine in ("codex", "claude"):
+            if engine not in engines:
+                engines.append(engine)
+        reviewers = [(engine, None, None) for engine in engines]
+    else:
+        reviewers = [(args.engine, None, None)]
+
+    seen: set[str] = set()
+    result: list[argparse.Namespace] = []
+    for engine, inline_model, inline_thinking in reviewers:
+        if engine in seen:
+            raise SystemExit(f"reviewer specified more than once: {engine}")
+        seen.add(engine)
+        model = inline_model or model_by_engine.get(engine) or global_model
+        thinking = inline_thinking or thinking_by_engine.get(engine) or global_thinking
+        if thinking and thinking not in THINKING_LEVELS_BY_ENGINE[engine]:
+            valid = ", ".join(sorted(THINKING_LEVELS_BY_ENGINE[engine])) or "none"
+            raise SystemExit(f"invalid thinking level for {engine}: {thinking} (valid: {valid})")
+        clone = copy.copy(args)
+        clone.engine = engine
+        clone.model = model
+        clone.thinking = thinking
+        result.append(clone)
+    return result
+
+
+def reviewer_label(args: argparse.Namespace) -> str:
+    parts = [args.engine]
+    if args.model:
+        parts.append(f"model={args.model}")
+    if args.thinking:
+        parts.append(f"thinking={args.thinking}")
+    return " ".join(parts)
+
+
+def run_reviewer(args: argparse.Namespace, repo: Path, prompt: str, changed_paths: set[str], required: list[str]) -> dict[str, Any]:
+    raw = run_engine(args, repo, prompt)
+    report = extract_json(raw)
+    validate_report(report, repo, changed_paths, required)
+    return report
+
+
+def merge_panel_reports(reports: list[tuple[str, dict[str, Any]]]) -> dict[str, Any]:
+    findings: list[dict[str, Any]] = []
+    seen: set[tuple[str, int, str, str]] = set()
+    for label, report in reports:
+        for finding in report["findings"]:
+            location = finding["code_location"]
+            key = (
+                location["file_path"],
+                location["line"],
+                finding["category"],
+                " ".join(finding["title"].lower().split()),
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            merged = copy.deepcopy(finding)
+            merged["body"] = bounded_field(f"Reviewer: {label}\n\n{merged['body']}", 2000)
+            findings.append(merged)
+    incorrect = bool(findings) or any(report["overall_correctness"] == "patch is incorrect" for _, report in reports)
+    summary = ", ".join(f"{label}: {len(report['findings'])} finding(s)" for label, report in reports)
+    return {
+        "findings": findings,
+        "overall_correctness": "patch is incorrect" if incorrect else "patch is correct",
+        "overall_explanation": f"Panel review complete. {summary}.",
+        "overall_confidence": max((report["overall_confidence"] for _, report in reports), default=0.5),
+    }
+
+
+def run_panel(args: argparse.Namespace, reviewers: list[argparse.Namespace], repo: Path, prompt: str, changed_paths: set[str]) -> dict[str, Any]:
+    reports: list[tuple[str, dict[str, Any]]] = []
+    failures: list[str] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(reviewers)) as executor:
+        future_by_label = {
+            executor.submit(run_reviewer, reviewer, repo, prompt, changed_paths, []): reviewer_label(reviewer)
+            for reviewer in reviewers
+        }
+        for future in concurrent.futures.as_completed(future_by_label):
+            label = future_by_label[future]
+            try:
+                reports.append((label, future.result()))
+            except SystemExit as exc:
+                failures.append(f"{label}: {exc}")
+            except Exception as exc:
+                failures.append(f"{label}: {exc}")
+    if failures and not args.allow_partial_panel:
+        raise SystemExit("autoreview panel failed\n" + "\n".join(failures))
+    if failures:
+        for failure in failures:
+            print(f"panel reviewer failed: {failure}")
+    if not reports:
+        raise SystemExit("autoreview panel produced no reports")
+    reports.sort(key=lambda item: item[0])
+    report = merge_panel_reports(reports)
+    validate_report(report, repo, changed_paths, args.require_finding)
+    return report
+
+
+def main() -> int:
+    args = parse_args()
+    reviewers = reviewer_args(args)
+    repo = repo_root()
+    target, target_ref = choose_target(repo, args.mode, args.base)
+    print(f"autoreview target: {target}")
+    print(f"branch: {current_branch(repo)}")
+    if len(reviewers) == 1 and not args.reviewers and not args.panel:
+        print(f"engine: {reviewers[0].engine}")
+        if reviewers[0].model:
+            print(f"model: {reviewers[0].model}")
+        if reviewers[0].thinking:
+            print(f"thinking: {reviewers[0].thinking}")
+    else:
+        print(f"reviewers: {', '.join(reviewer_label(reviewer) for reviewer in reviewers)}")
+    print(f"tools: {'on' if args.tools else 'off'}")
+    print(f"web_search: {'on' if args.web_search else 'off'}")
+    display_ref = args.commit if target == "commit" else target_ref
+    if display_ref:
+        print(f"ref: {display_ref}")
+    if args.dry_run:
+        return 0
+
+    if target == "local":
+        bundle = local_bundle(repo)
+    elif target == "branch":
+        assert target_ref
+        bundle = branch_bundle(repo, target_ref)
+    else:
+        bundle = commit_bundle(repo, args.commit)
+        target_ref = args.commit
+    prompt = build_prompt(repo, target, target_ref, bundle, load_extra_prompt(args), load_datasets(args))
+    changed_paths = review_paths(repo, target, target_ref, args.commit)
+    print(f"bundle: {len(prompt)} chars")
+
+    tests_proc: tuple[subprocess.Popen, float] | None = None
+    if args.parallel_tests:
+        tests_proc = start_parallel_tests(args.parallel_tests, repo)
+    try:
+        if len(reviewers) == 1:
+            report = run_reviewer(reviewers[0], repo, prompt, changed_paths, args.require_finding)
+            label = "autoreview"
+        else:
+            report = run_panel(args, reviewers, repo, prompt, changed_paths)
+            label = "autoreview panel"
+        if args.json_output:
+            Path(args.json_output).write_text(json.dumps(report, indent=2) + "\n")
+
+        if args.output:
+            original_stdout = sys.stdout
+            with Path(args.output).open("w") as handle:
+                sys.stdout = Tee(original_stdout, handle)
+                print_report(report, label=label)
+                sys.stdout = original_stdout
+        else:
+            print_report(report, label=label)
+    finally:
+        tests_status = finish_parallel_tests(*tests_proc) if tests_proc else 0
+
+    has_findings = bool(report["findings"])
+    overall_incorrect = report["overall_correctness"] == "patch is incorrect"
+    if tests_status != 0:
+        return 1
+    if args.expect_findings:
+        return 0 if has_findings else 1
+    return 1 if has_findings or overall_incorrect else 0
+
+
+class Tee:
+    def __init__(self, *streams: Any) -> None:
+        self.streams = streams
+
+    def write(self, data: str) -> None:
+        for stream in self.streams:
+            stream.write(data)
+
+    def flush(self) -> None:
+        for stream in self.streams:
+            stream.flush()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/autoreview/scripts/test-review-harness
+++ b/.agents/skills/autoreview/scripts/test-review-harness
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: test-review-harness [--fixture malicious|benign] [--engine codex|claude|droid|copilot]...
+
+Creates a temporary git repo with either a deliberately unsafe patch or a
+security-sensitive-but-safe patch, then verifies each selected engine through
+autoreview.
+Default engines: codex, claude.
+EOF
+}
+
+engines=()
+fixture=malicious
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fixture)
+      fixture=${2:-}
+      shift 2
+      ;;
+    --engine)
+      engines+=("${2:-}")
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$fixture" in
+  malicious|benign) ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if [[ ${#engines[@]} -eq 0 ]]; then
+  engines=(codex claude)
+fi
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo=$(mktemp -d "${TMPDIR:-/tmp}/autoreview-fixture.XXXXXX")
+trap 'rm -rf "$repo"' EXIT
+
+cd "$repo"
+git init --quiet
+git config user.name "Review Fixture"
+git config user.email "review-fixture@example.com"
+
+if [[ "$fixture" == malicious ]]; then
+  cat > app.js <<'EOF'
+export function uploadPath(name) {
+  return `uploads/${name.replaceAll("/", "")}`;
+}
+
+export function publicUser(user) {
+  return { id: user.id, name: user.name };
+}
+EOF
+else
+  cat > app.js <<'EOF'
+import path from "node:path";
+
+const uploadsRoot = path.resolve("uploads");
+
+function safeChildPath(root, name) {
+  if (name.includes("/") || name.includes("\\") || name.includes("\0")) {
+    throw new Error("invalid child name");
+  }
+  const resolved = path.resolve(root, name);
+  if (!resolved.startsWith(root + path.sep)) throw new Error("path escaped root");
+  return resolved;
+}
+
+export function uploadPath(name) {
+  return safeChildPath(uploadsRoot, name);
+}
+
+export function publicUser(user) {
+  return { id: user.id, name: user.name };
+}
+EOF
+fi
+
+git add app.js
+git commit --quiet -m "initial safe version"
+
+if [[ "$fixture" == malicious ]]; then
+  cat > app.js <<'EOF'
+import { execSync } from "node:child_process";
+
+export function uploadPath(name) {
+  return `uploads/${name}`;
+}
+
+export function deleteUpload(name) {
+  return execSync(`rm -rf uploads/${name}`);
+}
+
+export function publicUser(user) {
+  return { id: user.id, name: user.name, password: user.password };
+}
+EOF
+else
+  cat > app.js <<'EOF'
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const uploadsRoot = path.resolve("uploads");
+const reposRoot = path.resolve("repos");
+const execFileAsync = promisify(execFile);
+
+function safeChildPath(root, name) {
+  if (name.includes("/") || name.includes("\\") || name.includes("\0")) {
+    throw new Error("invalid child name");
+  }
+  const resolved = path.resolve(root, name);
+  if (!resolved.startsWith(root + path.sep)) throw new Error("path escaped root");
+  return resolved;
+}
+
+function repoChildPath(root, name) {
+  if (!/^[A-Za-z0-9._-]+$/.test(name)) throw new Error("invalid repo name");
+  return safeChildPath(root, name);
+}
+
+export function uploadPath(name) {
+  return safeChildPath(uploadsRoot, name);
+}
+
+export async function repoStatus(repoName) {
+  const { stdout } = await execFileAsync("git", ["status", "--short"], {
+    cwd: repoChildPath(reposRoot, repoName),
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  return stdout;
+}
+
+export function publicUser(user) {
+  return { id: user.id, name: user.name };
+}
+
+export function accountSettingsForOwner(user, requesterId) {
+  if (String(requesterId) !== String(user.id)) throw new Error("forbidden");
+  return { id: user.id, hasPassword: Boolean(user.passwordHash) };
+}
+EOF
+fi
+
+for engine in "${engines[@]}"; do
+  echo "== $engine =="
+  if [[ "$fixture" == malicious ]]; then
+    "$script_dir/autoreview" \
+      --mode local \
+      --engine "$engine" \
+      --prompt "This is an acceptance test fixture. The changed app.js patch contains real security bugs. Review normally and report only actionable defects from the patch." \
+      --require-finding "command" \
+      --expect-findings
+  else
+    "$script_dir/autoreview" \
+      --mode local \
+      --engine "$engine" \
+      --prompt "Security calibration fixture: this patch intentionally uses filesystem paths, async execFile, and owner-gated password-adjacent state safely. Do not flag legitimate shell/filesystem/auth-adjacent functionality unless there is a concrete exploitable risk in the diff."
+  fi
+done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## v0.7.1 - Unreleased
 
+- Add provider-neutral `remote` client/config/status contracts for
+  Worker-fronted cloud archives, including authenticated query, batch-read,
+  ingest, archive listing, and GitHub login helper calls.
+- Add remote archive fields to `control.Status` and database inventories so
+  downstream apps can report D1/Worker storage without pretending it is a local
+  SQLite path.
+
 ## v0.7.0 - 2026-05-22
 
 - Add `crawlctl`, a cross-platform controller for discovering crawl apps, running configured refresh jobs, recording JSONL run history, tailing logs, and installing OS-native schedules through launchd, systemd, Windows Task Scheduler, or cron output.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ See `docs/boundary.md` for the crawlkit-versus-app ownership boundary.
 - `vector`: float32 vector encoding, dimension validation, cosine scoring, top-k helpers, and reciprocal-rank fusion.
 - `releasecheck`: GitHub release checks, 24-hour cache handling, scripted-output
   suppression, and stderr update notice formatting for crawl app CLIs.
+- `remote`: provider-neutral HTTP client, config, query, ingest, auth, and status contracts for Worker-fronted remote archives such as Cloudflare D1.
 - `output`: text/json/log output helpers.
 - `control`: crawl app metadata, command manifests, status payloads, and
   database inventory for launchers and automation.

--- a/control/control.go
+++ b/control/control.go
@@ -72,6 +72,7 @@ type Status struct {
 	Counts        []Count    `json:"counts,omitempty"`
 	Freshness     *Freshness `json:"freshness,omitempty"`
 	Share         *Share     `json:"share,omitempty"`
+	Remote        *Remote    `json:"remote,omitempty"`
 	Databases     []Database `json:"databases,omitempty"`
 	Warnings      []string   `json:"warnings,omitempty"`
 	Errors        []string   `json:"errors,omitempty"`
@@ -97,12 +98,24 @@ type Share struct {
 	NeedsUpdate bool   `json:"needs_update,omitempty"`
 }
 
+type Remote struct {
+	Enabled      bool   `json:"enabled"`
+	Mode         string `json:"mode,omitempty"`
+	Endpoint     string `json:"endpoint,omitempty"`
+	Archive      string `json:"archive,omitempty"`
+	LastIngestAt string `json:"last_ingest_at,omitempty"`
+	LastSyncAt   string `json:"last_sync_at,omitempty"`
+	NeedsUpdate  bool   `json:"needs_update,omitempty"`
+}
+
 type Database struct {
 	ID         string  `json:"id"`
 	Label      string  `json:"label"`
 	Kind       string  `json:"kind"`
 	Role       string  `json:"role"`
 	Path       string  `json:"path"`
+	Endpoint   string  `json:"endpoint,omitempty"`
+	Archive    string  `json:"archive,omitempty"`
 	IsPrimary  bool    `json:"is_primary"`
 	Bytes      int64   `json:"bytes"`
 	ModifiedAt string  `json:"modified_at,omitempty"`
@@ -149,6 +162,26 @@ func SQLiteDatabase(id, label, role, path string, primary bool, counts []Count) 
 	if info, err := os.Stat(db.Path); err == nil {
 		db.Bytes = info.Size()
 		db.ModifiedAt = info.ModTime().UTC().Format(time.RFC3339)
+	}
+	return db
+}
+
+func RemoteDatabase(id, label, role, kind, endpoint, archive string, primary bool, counts []Count) Database {
+	db := Database{
+		ID:        strings.TrimSpace(id),
+		Label:     strings.TrimSpace(label),
+		Kind:      strings.TrimSpace(kind),
+		Role:      strings.TrimSpace(role),
+		Endpoint:  strings.TrimRight(strings.TrimSpace(endpoint), "/"),
+		Archive:   strings.TrimSpace(archive),
+		IsPrimary: primary,
+		Counts:    append([]Count(nil), counts...),
+	}
+	if db.Kind == "" {
+		db.Kind = "remote"
+	}
+	if db.Role == "" {
+		db.Role = "archive"
 	}
 	return db
 }

--- a/docs/cloudflare-remote-archives.md
+++ b/docs/cloudflare-remote-archives.md
@@ -1121,7 +1121,7 @@ Implemented branches:
     Git-backed path.
   - Cloud-mode status maps Worker archive status into crawlkit control status
     without opening the local store.
-- local `openclaw/crawl-remote` Worker repo
+- `openclaw/crawl-remote` Worker repo
   - Added Wrangler/D1 service scaffold, migration, typed route handlers, and
     Vitest coverage.
   - Added GitHub OAuth start/callback/poll flow, allowed org/team checks,
@@ -1165,8 +1165,8 @@ Compression note:
 
 Remaining release work:
 
-- Create/push the `openclaw/crawl-remote` GitHub repo or move the local Worker
-  scaffold into the chosen service repo.
+- Decide when to make `openclaw/crawl-remote` public; it was created private
+  for the first infra scaffold push.
 - Configure real Cloudflare D1 database ids and GitHub OAuth app secrets.
 - Run OAuth/org/team login against a deployed staging Worker.
 - Tag `crawlkit`, then bump `gitcrawl` and `discrawl` from the pseudo-version

--- a/docs/cloudflare-remote-archives.md
+++ b/docs/cloudflare-remote-archives.md
@@ -1,6 +1,6 @@
 # Cloudflare remote archives
 
-Status: draft plan, not implemented.
+Status: implementation spec with local Worker/D1 prototype.
 
 This spec covers an additive remote archive option for `crawlkit`,
 `openclaw/gitcrawl`, and `openclaw/discrawl`.
@@ -1090,10 +1090,10 @@ syncs stable and gives OpenClaw a clean path from "state repos with files" to
 
 ## Implementation checkpoint - 2026-05-27
 
-The first implementation pass landed the client-side/read-only pieces in the
-three existing repos. This does not include the standalone Worker service yet;
-that remains the next repo/stage so crawlkit does not absorb provider-specific
-Cloudflare auth, D1 schema migration, or Worker routing ownership.
+The current implementation pass now covers the shared client, both app
+publisher/read paths, and a standalone Cloudflare Worker/D1 service prototype.
+The design still keeps Cloudflare auth, D1 schema migration, Worker routing,
+and app-specific table policy out of `crawlkit`.
 
 Implemented branches:
 
@@ -1105,28 +1105,50 @@ Implemented branches:
   - Added `[remote]` config, env overrides, remote token resolution, `init --remote`,
     `remote status`, `remote archives`, `whoami`, cloud-mode `status`, owner/repo
     search, and gh-shaped `search issues|prs` routing.
+  - Added `gitcrawl cloud publish` to push local repository/thread rows to the
+    Worker ingest endpoint.
   - Cloud mode rejects local runtime opens for local-only commands rather than
     creating or mutating SQLite.
   - `doctor` reports remote endpoint/archive/token/status health without opening
     local SQLite.
 - `openclaw/discrawl` branch `feature/cloudflare-remote-archives`
   - Added `[remote]` config, `subscribe-cloud`, `remote status`,
-    `remote archives`, `remote whoami`, top-level `whoami`, and cloud-mode
-    `status`.
+    `remote archives`, `remote whoami`, top-level `whoami`, cloud-mode
+    `status`, cloud-mode `search`, and filtered cloud-mode `messages`.
+  - Added `discrawl cloud publish` to push non-DM guild/channel/member/message
+    rows to the Worker ingest endpoint.
   - Existing Git `publish` / `subscribe` / `update` share commands remain the
     Git-backed path.
   - Cloud-mode status maps Worker archive status into crawlkit control status
     without opening the local store.
+- local `openclaw/crawl-remote` Worker repo
+  - Added Wrangler/D1 service scaffold, migration, typed route handlers, and
+    Vitest coverage.
+  - Added GitHub OAuth start/callback/poll flow, allowed org/team checks,
+    signed bearer sessions, and admin-token bootstrap auth.
+  - Added role-gated archive status/list/query/batch-read/ingest routes.
+  - Added named D1 queries for `gitcrawl.threads.search`,
+    `discrawl.messages.search`, and `discrawl.messages.list`.
+  - Added ingest table allowlists for gitcrawl and discrawl, including
+    `@me`/DM row rejection for discrawl.
 
 Validation completed:
 
 - `crawlkit`: `GOWORK=off go mod tidy`, clean `go.mod`/`go.sum`,
   `GOWORK=off go vet ./...`, and `GOWORK=off go test -count=1 ./...`.
 - `gitcrawl`: `GOWORK=off go test -count=1 ./...`, plus autoreview after
-  remote gh-search and doctor fixes.
-- `discrawl`: `GOWORK=off go test -count=1 ./...`, plus autoreview.
-- Wrangler local D1 smoke: `wrangler 4.87.0`, temp `wrangler.toml`, local D1
-  create/insert/select for `remote_archives`, including archive ids with `/`.
+  remote gh-search and doctor fixes. Additional focused coverage verifies
+  `gitcrawl cloud publish` ingest shape.
+- `discrawl`: `GOWORK=off go test -count=1 ./...`, plus autoreview. Additional
+  focused coverage verifies cloud status/search/messages without local SQLite
+  and `discrawl cloud publish` non-DM ingest shape.
+- Worker: `npm run typecheck`, `npm test`, and local Wrangler D1 migrations.
+- Local Worker/D1 end-to-end:
+  - `gitcrawl cloud publish` pushed a temp SQLite archive to
+    `http://127.0.0.1:8787`, then cloud search read the row back from D1.
+  - `discrawl cloud publish` pushed a temp non-DM SQLite archive to
+    `http://127.0.0.1:8787`, then a reader config with no SQLite database ran
+    cloud `search` and `messages` against D1. The reader DB stayed absent.
 
 Dependency state:
 
@@ -1140,3 +1162,12 @@ Compression note:
 - No gzip/binary snapshot compression was added to the read path. Keep
   compression in publisher ingest or R2 snapshot layers so D1 named queries over
   indexed rows and vector metadata stay normal SQL.
+
+Remaining release work:
+
+- Create/push the `openclaw/crawl-remote` GitHub repo or move the local Worker
+  scaffold into the chosen service repo.
+- Configure real Cloudflare D1 database ids and GitHub OAuth app secrets.
+- Run OAuth/org/team login against a deployed staging Worker.
+- Tag `crawlkit`, then bump `gitcrawl` and `discrawl` from the pseudo-version
+  to the release tag.

--- a/docs/cloudflare-remote-archives.md
+++ b/docs/cloudflare-remote-archives.md
@@ -203,6 +203,20 @@ cli login
   -> signed bearer token stored locally
 ```
 
+For non-browser bootstrap and CI/operator lanes, the CLI can also exchange an
+existing GitHub token:
+
+```text
+cli login --github-token-env GITHUB_TOKEN
+  -> POST /v1/auth/github/token
+  -> Worker verifies GitHub user/org/team membership
+  -> signed bearer token stored locally
+```
+
+The Worker must not store the supplied GitHub token. It only uses the token to
+query GitHub, verifies the same org/team policy as OAuth, and returns an
+OpenClaw remote session token.
+
 Required GitHub OAuth scopes:
 
 - `read:user`
@@ -218,7 +232,7 @@ CRAWL_REMOTE_GITHUB_CLIENT_ID
 CRAWL_REMOTE_GITHUB_CLIENT_SECRET
 CRAWL_REMOTE_DEFAULT_ORG=openclaw
 CRAWL_REMOTE_GITHUB_ALLOWED_ORGS=openclaw
-CRAWL_REMOTE_GITHUB_ALLOWED_TEAMS=openclaw/maintainers
+CRAWL_REMOTE_GITHUB_ALLOWED_TEAMS=openclaw/maintainer
 CRAWL_REMOTE_ADMIN_TOKEN
 CRAWL_REMOTE_ACCESS_TEAM_DOMAIN
 CRAWL_REMOTE_ACCESS_AUD
@@ -1100,13 +1114,14 @@ Implemented branches:
 - `openclaw/crawlkit` branch `spec/cloudflare-remote`
   - Added provider-neutral `remote` package.
   - Added GitHub login poll-secret helpers for Worker OAuth flows.
+  - Added GitHub-token login exchange helpers for non-browser org/team auth.
   - Added `control.Remote` and remote database inventory fields.
   - Added this spec and synced the living copy to `~/.spec`.
 - `openclaw/gitcrawl` branch `feature/cloudflare-remote-archives`
   - Added `[remote]` config, env overrides, remote token resolution, `init --remote`,
-    GitHub-backed `remote login`, `remote status`, `remote archives`, `whoami`,
-    cloud-mode `status`, owner/repo search, and gh-shaped `search issues|prs`
-    routing.
+    GitHub-backed `remote login` with OAuth or `--github-token-env`,
+    `remote status`, `remote archives`, `whoami`, cloud-mode `status`,
+    owner/repo search, and gh-shaped `search issues|prs` routing.
   - `remote login` stores the Worker-issued bearer token in the OS keyring.
   - Added `gitcrawl cloud publish` to push local repository/thread rows to the
     Worker ingest endpoint.
@@ -1116,9 +1131,9 @@ Implemented branches:
     local SQLite.
 - `openclaw/discrawl` branch `feature/cloudflare-remote-archives`
   - Added `[remote]` config, `subscribe-cloud`, `remote status`,
-    GitHub-backed `remote login`, `remote archives`, `remote whoami`,
-    top-level `whoami`, cloud-mode `status`, cloud-mode `search`, and filtered
-    cloud-mode `messages`.
+    GitHub-backed `remote login` with OAuth or `--github-token-env`,
+    `remote archives`, `remote whoami`, top-level `whoami`, cloud-mode
+    `status`, cloud-mode `search`, and filtered cloud-mode `messages`.
   - `remote login` stores the Worker-issued bearer token in the OS keyring.
   - Added `discrawl cloud publish` to push non-DM guild/channel/member/message
     rows to the Worker ingest endpoint.
@@ -1129,8 +1144,9 @@ Implemented branches:
 - `openclaw/crawl-remote` Worker repo
   - Added Wrangler/D1 service scaffold, migration, typed route handlers, and
     Vitest coverage.
-  - Added GitHub OAuth start/callback/poll flow, allowed org/team checks,
-    signed bearer sessions, and admin-token bootstrap auth.
+  - Added GitHub OAuth start/callback/poll flow, GitHub-token bootstrap,
+    allowed org/team checks, signed bearer sessions, and admin-token bootstrap
+    auth.
   - Added role-gated archive status/list/query/batch-read/ingest routes.
   - Added named D1 queries for `gitcrawl.threads.search`,
     `discrawl.messages.search`, and `discrawl.messages.list`.
@@ -1154,6 +1170,16 @@ Validation completed:
 - Deployed Worker smoke: `/health`, `/v1/whoami`, and `/v1/archives` succeed
   against `https://crawl-remote.services-91b.workers.dev` with admin-token
   auth.
+- Deployed GitHub org/team auth:
+  - `POST /v1/auth/github/token` verifies the current GitHub identity as
+    `openclaw` org plus `openclaw/maintainer` team, returns a Worker session
+    token, and that token succeeds against `/v1/whoami`.
+  - `gitcrawl remote login --github-token-env GH_TOKEN` stores the returned
+    remote session token in the OS keyring, `gitcrawl whoami` reads it back
+    from the deployed Worker, and the temp config run creates no SQLite DB.
+  - `discrawl remote login --github-token-env GH_TOKEN` stores the returned
+    remote session token in the OS keyring, `discrawl whoami` reads it back
+    from the deployed Worker, and the temp config run creates no SQLite DB.
 - Deployed Worker/D1 end-to-end:
   - `gitcrawl cloud publish` pushed a temp SQLite archive to the deployed
     Worker, then cloud search read the row back from remote D1.
@@ -1170,7 +1196,7 @@ Validation completed:
 Dependency state:
 
 - `gitcrawl` and `discrawl` temporarily depend on crawlkit pseudo-version
-  `v0.7.1-0.20260527173115-df4eca58a4c9`.
+  `v0.7.1-0.20260527174716-74916a98ee45`.
 - Release should tag crawlkit first, then bump both apps from the pseudo-version
   to the released tag before final app releases.
 
@@ -1184,9 +1210,10 @@ Remaining release work:
 
 - Decide when to make `openclaw/crawl-remote` public; it was created private
   for the first infra scaffold push.
-- Configure the real GitHub OAuth app client id/secret for callback
+- Optional browser-login polish: configure the real GitHub OAuth app
+  client id/secret for callback
   `https://crawl-remote.services-91b.workers.dev/v1/auth/github/callback`.
-- Run live OAuth/org/team login against the deployed Worker once those secrets
-  are present.
+  The deployed remote path already has live GitHub org/team auth through
+  `--github-token-env`.
 - Tag `crawlkit`, then bump `gitcrawl` and `discrawl` from the pseudo-version
   to the release tag.

--- a/docs/cloudflare-remote-archives.md
+++ b/docs/cloudflare-remote-archives.md
@@ -1099,12 +1099,15 @@ Implemented branches:
 
 - `openclaw/crawlkit` branch `spec/cloudflare-remote`
   - Added provider-neutral `remote` package.
+  - Added GitHub login poll-secret helpers for Worker OAuth flows.
   - Added `control.Remote` and remote database inventory fields.
   - Added this spec and synced the living copy to `~/.spec`.
 - `openclaw/gitcrawl` branch `feature/cloudflare-remote-archives`
   - Added `[remote]` config, env overrides, remote token resolution, `init --remote`,
-    `remote status`, `remote archives`, `whoami`, cloud-mode `status`, owner/repo
-    search, and gh-shaped `search issues|prs` routing.
+    GitHub-backed `remote login`, `remote status`, `remote archives`, `whoami`,
+    cloud-mode `status`, owner/repo search, and gh-shaped `search issues|prs`
+    routing.
+  - `remote login` stores the Worker-issued bearer token in the OS keyring.
   - Added `gitcrawl cloud publish` to push local repository/thread rows to the
     Worker ingest endpoint.
   - Cloud mode rejects local runtime opens for local-only commands rather than
@@ -1113,8 +1116,10 @@ Implemented branches:
     local SQLite.
 - `openclaw/discrawl` branch `feature/cloudflare-remote-archives`
   - Added `[remote]` config, `subscribe-cloud`, `remote status`,
-    `remote archives`, `remote whoami`, top-level `whoami`, cloud-mode
-    `status`, cloud-mode `search`, and filtered cloud-mode `messages`.
+    GitHub-backed `remote login`, `remote archives`, `remote whoami`,
+    top-level `whoami`, cloud-mode `status`, cloud-mode `search`, and filtered
+    cloud-mode `messages`.
+  - `remote login` stores the Worker-issued bearer token in the OS keyring.
   - Added `discrawl cloud publish` to push non-DM guild/channel/member/message
     rows to the Worker ingest endpoint.
   - Existing Git `publish` / `subscribe` / `update` share commands remain the
@@ -1131,6 +1136,9 @@ Implemented branches:
     `discrawl.messages.search`, and `discrawl.messages.list`.
   - Added ingest table allowlists for gitcrawl and discrawl, including
     `@me`/DM row rejection for discrawl.
+  - Created remote D1 database `crawl-remote`
+    (`42baacd3-c917-400f-a12f-e0fada21e11f`) and deployed the Worker to
+    `https://crawl-remote.services-91b.workers.dev`.
 
 Validation completed:
 
@@ -1143,6 +1151,15 @@ Validation completed:
   focused coverage verifies cloud status/search/messages without local SQLite
   and `discrawl cloud publish` non-DM ingest shape.
 - Worker: `npm run typecheck`, `npm test`, and local Wrangler D1 migrations.
+- Deployed Worker smoke: `/health`, `/v1/whoami`, and `/v1/archives` succeed
+  against `https://crawl-remote.services-91b.workers.dev` with admin-token
+  auth.
+- Deployed Worker/D1 end-to-end:
+  - `gitcrawl cloud publish` pushed a temp SQLite archive to the deployed
+    Worker, then cloud search read the row back from remote D1.
+  - `discrawl cloud publish` pushed a temp non-DM SQLite archive to the
+    deployed Worker, then a reader config with no SQLite database ran cloud
+    `search` and `messages` against remote D1. The reader DB stayed absent.
 - Local Worker/D1 end-to-end:
   - `gitcrawl cloud publish` pushed a temp SQLite archive to
     `http://127.0.0.1:8787`, then cloud search read the row back from D1.
@@ -1153,7 +1170,7 @@ Validation completed:
 Dependency state:
 
 - `gitcrawl` and `discrawl` temporarily depend on crawlkit pseudo-version
-  `v0.7.1-0.20260527123833-22b471a17caa`.
+  `v0.7.1-0.20260527173115-df4eca58a4c9`.
 - Release should tag crawlkit first, then bump both apps from the pseudo-version
   to the released tag before final app releases.
 
@@ -1167,7 +1184,9 @@ Remaining release work:
 
 - Decide when to make `openclaw/crawl-remote` public; it was created private
   for the first infra scaffold push.
-- Configure real Cloudflare D1 database ids and GitHub OAuth app secrets.
-- Run OAuth/org/team login against a deployed staging Worker.
+- Configure the real GitHub OAuth app client id/secret for callback
+  `https://crawl-remote.services-91b.workers.dev/v1/auth/github/callback`.
+- Run live OAuth/org/team login against the deployed Worker once those secrets
+  are present.
 - Tag `crawlkit`, then bump `gitcrawl` and `discrawl` from the pseudo-version
   to the release tag.

--- a/docs/cloudflare-remote-archives.md
+++ b/docs/cloudflare-remote-archives.md
@@ -1087,3 +1087,56 @@ The strategic move is to make `crawlkit` own the transport and archive
 contracts now, while leaving app semantics in the apps. That keeps today's Git
 syncs stable and gives OpenClaw a clean path from "state repos with files" to
 "live hosted archives with optional distributed cache."
+
+## Implementation checkpoint - 2026-05-27
+
+The first implementation pass landed the client-side/read-only pieces in the
+three existing repos. This does not include the standalone Worker service yet;
+that remains the next repo/stage so crawlkit does not absorb provider-specific
+Cloudflare auth, D1 schema migration, or Worker routing ownership.
+
+Implemented branches:
+
+- `openclaw/crawlkit` branch `spec/cloudflare-remote`
+  - Added provider-neutral `remote` package.
+  - Added `control.Remote` and remote database inventory fields.
+  - Added this spec and synced the living copy to `~/.spec`.
+- `openclaw/gitcrawl` branch `feature/cloudflare-remote-archives`
+  - Added `[remote]` config, env overrides, remote token resolution, `init --remote`,
+    `remote status`, `remote archives`, `whoami`, cloud-mode `status`, owner/repo
+    search, and gh-shaped `search issues|prs` routing.
+  - Cloud mode rejects local runtime opens for local-only commands rather than
+    creating or mutating SQLite.
+  - `doctor` reports remote endpoint/archive/token/status health without opening
+    local SQLite.
+- `openclaw/discrawl` branch `feature/cloudflare-remote-archives`
+  - Added `[remote]` config, `subscribe-cloud`, `remote status`,
+    `remote archives`, `remote whoami`, top-level `whoami`, and cloud-mode
+    `status`.
+  - Existing Git `publish` / `subscribe` / `update` share commands remain the
+    Git-backed path.
+  - Cloud-mode status maps Worker archive status into crawlkit control status
+    without opening the local store.
+
+Validation completed:
+
+- `crawlkit`: `GOWORK=off go mod tidy`, clean `go.mod`/`go.sum`,
+  `GOWORK=off go vet ./...`, and `GOWORK=off go test -count=1 ./...`.
+- `gitcrawl`: `GOWORK=off go test -count=1 ./...`, plus autoreview after
+  remote gh-search and doctor fixes.
+- `discrawl`: `GOWORK=off go test -count=1 ./...`, plus autoreview.
+- Wrangler local D1 smoke: `wrangler 4.87.0`, temp `wrangler.toml`, local D1
+  create/insert/select for `remote_archives`, including archive ids with `/`.
+
+Dependency state:
+
+- `gitcrawl` and `discrawl` temporarily depend on crawlkit pseudo-version
+  `v0.7.1-0.20260527123833-22b471a17caa`.
+- Release should tag crawlkit first, then bump both apps from the pseudo-version
+  to the released tag before final app releases.
+
+Compression note:
+
+- No gzip/binary snapshot compression was added to the read path. Keep
+  compression in publisher ingest or R2 snapshot layers so D1 named queries over
+  indexed rows and vector metadata stay normal SQL.

--- a/docs/cloudflare-remote-archives.md
+++ b/docs/cloudflare-remote-archives.md
@@ -1,0 +1,1089 @@
+# Cloudflare remote archives
+
+Status: draft plan, not implemented.
+
+This spec covers an additive remote archive option for `crawlkit`,
+`openclaw/gitcrawl`, and `openclaw/discrawl`.
+
+The target is a Cloudflare-hosted SQLite archive backed by D1, accessed through
+an OpenClaw Worker with GitHub organization authentication. Existing local
+SQLite databases and Git-backed portable stores must keep working exactly as
+they do today.
+
+## Recommendation
+
+Build the remote option as a Worker-fronted D1 service, not as direct client
+access to the Cloudflare D1 REST API.
+
+The CLI should never require a user's Cloudflare account token. The Worker owns
+the D1 binding, GitHub org/team authorization, query allowlists, ingest policy,
+and audit trail. `crawlkit` should provide the reusable remote archive HTTP
+client, token storage helpers, status/query result types, and test harness.
+`gitcrawl` and `discrawl` should keep their provider schemas, provider syncers,
+privacy filters, and command contracts.
+
+This is a hosted SQLite archive, not a downloadable SQLite-file mirror. D1 is
+the native Cloudflare SQLite database layer; readers interact with it through
+Worker APIs and receive rows/pages, not `.db`, WAL, SHM, or Git snapshot files.
+
+## Goals
+
+- Add a fully remote read mode where normal reader commands do not create or
+  depend on a local SQLite database.
+- Keep the existing local-first and Git-backed modes unchanged.
+- Use Cloudflare D1 as the hosted SQLite substrate so app schemas remain close
+  to the current SQLite schemas.
+- Use GitHub org/team auth for humans and agents, following the Crabbox
+  browser-login plus bearer-session pattern.
+- Let publishers update remote archives without forcing readers to have
+  GitHub, Discord, Cloudflare, or bot credentials.
+- Preserve `discrawl` privacy boundaries: local wiretap DMs and `@me` data stay
+  out of shared remote archives by default.
+- Leave room for later Worker-native sync, R2-backed content-addressed shards,
+  and distributed cache federation.
+
+## Non-goals
+
+- Do not replace local SQLite.
+- Do not replace Git-backed portable stores.
+- Do not put GitHub or Discord provider clients in `crawlkit`.
+- Do not expose raw SQL to ordinary remote readers.
+- Do not make `crawlkit` know what a GitHub PR, Discord DM, guild, channel, or
+  maintainer report means.
+- Do not implement the future distributed cache layer in the first version.
+
+## Current state
+
+`crawlkit` owns reusable archive mechanics:
+
+- config paths
+- SQLite open/query helpers
+- snapshot packing/import
+- Git mirror mechanics
+- sync state helpers
+- control/status metadata
+- TUI primitives
+
+`gitcrawl` is local SQLite first. It has a Git-backed portable store where a
+published SQLite database is cloned, copied into a runtime mirror for local
+writes, and used by read commands. It also has a `gh` shim that serves many
+read-only GitHub queries from local SQLite and falls back or hydrates as needed.
+
+`discrawl` is also local SQLite first. It can publish a private Git snapshot
+through `crawlkit/snapshot` and `crawlkit/mirror`, then read commands can
+auto-import a stale share before querying. `discrawl` deliberately excludes
+wiretap `@me` data from Git snapshots and preserves local `@me` data during
+imports.
+
+`crabbox` already has the auth shape we want:
+
+- CLI starts a GitHub OAuth flow against a Cloudflare Worker.
+- Worker requires GitHub `read:user`, `user:email`, and `read:org`.
+- Worker checks allowed orgs and optional teams.
+- Worker issues a signed bearer token.
+- CLI stores the broker token in user config.
+- Worker optionally verifies Cloudflare Access JWTs and derives an identity.
+
+`openclaw/maintainers` shows the operational shape this can later support:
+
+- org-wide live GitHub reads
+- daily reports
+- claim logs for multi-agent work splitting
+- durable generated artifacts
+
+The remote archive should make those workflows query live hosted archives
+instead of cloning state repos or keeping each agent's local DB warm.
+
+## Modes
+
+Every app should have an explicit archive mode.
+
+| mode | storage | intended use |
+| --- | --- | --- |
+| `local` | local SQLite | existing default; full sync/search/TUI/write behavior |
+| `git` | Git checkout plus local runtime mirror | existing portable-store/share behavior |
+| `cloud` | Worker + D1 only | no local DB; remote reads and remote TUI |
+| `hybrid` | local SQLite plus cloud import/write-through | later; local speed with shared live cache |
+| `publisher` | local or ephemeral DB plus cloud ingest | scheduled or maintainer-controlled publishing |
+
+The first implementation should ship `cloud` read mode and `publisher` ingest.
+`hybrid` is useful later, but adding it first would muddy the compatibility
+story.
+
+## Archive naming
+
+Use stable archive slugs that do not leak local paths or maintainer machine
+details.
+
+Suggested production slugs:
+
+```text
+gitcrawl/openclaw__openclaw
+gitcrawl/openclaw__gitcrawl
+discrawl/openclaw-maintainers
+discrawl/openclaw-community
+```
+
+Suggested D1 database names:
+
+```text
+crawl-gitcrawl-openclaw-openclaw-prod
+crawl-discrawl-openclaw-maintainers-prod
+crawl-remote-meta-prod
+```
+
+The public archive slug is part of the API. The D1 binding name is internal to
+the Worker and can change during migrations.
+
+## Architecture
+
+```text
+gitcrawl/discrawl CLI
+        |
+        | crawlkit/remote HTTP client
+        v
+OpenClaw crawl Worker
+        |
+        | GitHub OAuth session, org/team policy, query allowlist
+        v
+Cloudflare D1 bindings
+        |
+        +-- gitcrawl archive DBs
+        +-- discrawl archive DBs
+        +-- remote metadata DB
+```
+
+The Worker should be a separate service, likely `openclaw/crawlcloud` or
+`openclaw/crawl-remote`, rather than hidden inside either app. It will need
+TypeScript, Wrangler, D1 migrations, Vitest tests, and deployment config. The
+Go apps consume it through `crawlkit`.
+
+## Why not direct D1 API from the CLI
+
+Direct D1 API access is the wrong user abstraction.
+
+- It requires Cloudflare credentials on every reader machine.
+- It pushes authorization policy into each CLI.
+- It makes raw SQL tempting.
+- It cannot reuse the GitHub org/team auth pattern cleanly.
+- It exposes too much blast radius for ordinary read-only archive users.
+
+Direct D1 API usage is still useful for admin bootstrap, emergency export,
+and migration jobs. Normal CLI traffic should go through the Worker.
+
+## Cloudflare design constraints
+
+D1 is close enough to SQLite that existing schemas can be carried forward, but
+the service should design around remote execution instead of pretending D1 is a
+local `database/sql` handle.
+
+Important constraints:
+
+- Query through a Worker D1 binding for normal app traffic.
+- Use the Cloudflare D1 REST API only for admin/bootstrap tasks.
+- Use prepared statements and bound parameters.
+- Keep requests paginated.
+- Avoid giant SQL statements and oversized bound rows.
+- Treat batch ingest as chunked transactional units, not one enormous import.
+- Verify FTS5, JSON, triggers, and PRAGMA behavior against Wrangler/D1 before
+  claiming support for an app command.
+
+The user-facing CLI should talk to the Worker. The Worker should talk to D1.
+
+## Auth model
+
+Use the Crabbox pattern, generalized:
+
+```text
+cli login
+  -> POST /v1/auth/github/start
+  -> browser GitHub OAuth
+  -> GET /v1/auth/github/callback
+  -> POST /v1/auth/github/poll
+  -> signed bearer token stored locally
+```
+
+Required GitHub OAuth scopes:
+
+- `read:user`
+- `user:email`
+- `read:org`
+
+Worker env:
+
+```text
+CRAWL_REMOTE_PUBLIC_URL
+CRAWL_REMOTE_SESSION_SECRET
+CRAWL_REMOTE_GITHUB_CLIENT_ID
+CRAWL_REMOTE_GITHUB_CLIENT_SECRET
+CRAWL_REMOTE_DEFAULT_ORG=openclaw
+CRAWL_REMOTE_GITHUB_ALLOWED_ORGS=openclaw
+CRAWL_REMOTE_GITHUB_ALLOWED_TEAMS=openclaw/maintainers
+CRAWL_REMOTE_ADMIN_TOKEN
+CRAWL_REMOTE_ACCESS_TEAM_DOMAIN
+CRAWL_REMOTE_ACCESS_AUD
+```
+
+Roles:
+
+| role | source | capabilities |
+| --- | --- | --- |
+| `reader` | allowed GitHub org/team member | list archives, status, search, read TUI pages, named read queries |
+| `publisher` | allowed publisher team or admin token | ingest batches, update metadata, run integrity checks |
+| `admin` | admin token or admin team | migrations, archive registry, dangerous maintenance endpoints |
+
+The bearer token should encode owner email, GitHub login, org, roles, issued
+time, and expiry. Keep expiry finite, default 30 days. Do not store GitHub
+access tokens after login unless a future Worker-native GitHub syncer truly
+needs them. If that future syncer lands, store refreshable provider auth in a
+separate encrypted Worker secret flow, not in reader tokens.
+
+Cloudflare Access can sit in front of the Worker as defense in depth. The
+Worker should verify `cf-access-jwt-assertion` when configured, then strip
+Access headers before forwarding any request context.
+
+## Config shape
+
+Add provider-neutral remote config structs in `crawlkit`, then embed them in
+each app config.
+
+```toml
+[remote]
+mode = "local" # local | git | cloud | hybrid | publisher
+endpoint = "https://crawl.openclaw.ai"
+archive = "openclaw/gitcrawl/openclaw__openclaw"
+token_env = "CRAWL_REMOTE_TOKEN"
+stale_after = "2m"
+
+[remote.auth]
+token_source = "keyring" # keyring | env | config | none
+keyring_service = "crawl-remote"
+keyring_account = "openclaw"
+```
+
+For `gitcrawl`, keep existing portable-store config and add remote next to it.
+
+```toml
+[github]
+token_env = "GITHUB_TOKEN"
+
+[portable_store]
+url = "https://github.com/openclaw/gitcrawl-store.git"
+database = "data/openclaw__openclaw.sync.db"
+checkout_dir = "~/.config/gitcrawl/portable"
+
+[remote]
+mode = "cloud"
+endpoint = "https://crawl.openclaw.ai"
+archive = "gitcrawl/openclaw__openclaw"
+```
+
+For `discrawl`, keep `[share]` as the Git-backed path and add `[remote]`.
+`discord.token_source = "none"` remains valid for read-only cloud readers.
+
+```toml
+[discord]
+token_source = "none"
+
+[share]
+remote = "https://github.com/openclaw/discord-store.git"
+repo_path = "~/.discrawl/share"
+auto_update = true
+
+[remote]
+mode = "cloud"
+endpoint = "https://crawl.openclaw.ai"
+archive = "discrawl/openclaw-maintainers"
+```
+
+In `cloud` mode, no app should require `db_path` to exist. Existing config
+defaults can remain, but opening a local DB should be skipped for remote-only
+commands.
+
+## crawlkit package plan
+
+Add a new `remote` package. Keep it transport-level and provider-neutral.
+
+Proposed types:
+
+```go
+package remote
+
+type Config struct {
+    Mode       string
+    Endpoint   string
+    Archive    string
+    TokenEnv   string
+    StaleAfter string
+    Auth       AuthConfig
+}
+
+type AuthConfig struct {
+    TokenSource     string
+    KeyringService  string
+    KeyringAccount  string
+}
+
+type Client struct { /* HTTP client, endpoint, token provider */ }
+
+type QueryRequest struct {
+    App     string         `json:"app"`
+    Archive string        `json:"archive"`
+    Name    string        `json:"name"`
+    Args    map[string]any `json:"args,omitempty"`
+    Limit   int           `json:"limit,omitempty"`
+    Cursor  string        `json:"cursor,omitempty"`
+}
+
+type QueryResult struct {
+    Columns    []string         `json:"columns"`
+    Rows       [][]any          `json:"rows"`
+    Values     []map[string]any `json:"values,omitempty"`
+    Cursor     string           `json:"cursor,omitempty"`
+    Stats      QueryStats       `json:"stats,omitempty"`
+    SchemaHash string           `json:"schema_hash,omitempty"`
+}
+
+type Status struct {
+    App          string
+    Archive      string
+    Mode         string
+    GeneratedAt  string
+    LastSyncAt   string
+    LastIngestAt string
+    Counts       []control.Count
+    Capabilities []string
+    Warnings     []string
+}
+```
+
+Package responsibilities:
+
+- normalize endpoint URLs
+- attach bearer auth
+- run login start/poll helper methods
+- expose `Whoami`, `Status`, `Query`, `BatchRead`, and `Ingest` primitives
+- map remote errors to typed Go errors
+- provide test servers for app unit tests
+- add control/status JSON helpers for remote archives
+
+Do not add app-specific query names, schemas, rows, or auth policies here.
+
+Update `control` to represent non-file databases:
+
+```go
+type Database struct {
+    ID         string
+    Label      string
+    Kind       string // sqlite | d1 | remote
+    Role       string
+    Path       string // local path when kind=sqlite
+    Endpoint   string // remote endpoint when kind=d1|remote
+    Archive    string
+    IsPrimary  bool
+    Bytes      int64
+    Counts     []Count
+}
+```
+
+Existing JSON fields should stay additive. No current consumer should break.
+
+## Worker service plan
+
+Create a Cloudflare Worker service with:
+
+- D1 bindings for app archives
+- a metadata binding for archive registry and auth audit
+- GitHub OAuth routes copied from Crabbox and renamed
+- optional Cloudflare Access verification copied from Crabbox
+- query allowlists per app
+- ingest allowlists per app
+- Vitest coverage for auth, policy, query routing, and ingest validation
+- Wrangler local D1 tests
+
+Suggested routes:
+
+```text
+POST /v1/auth/github/start
+GET  /v1/auth/github/callback
+POST /v1/auth/github/poll
+GET  /v1/whoami
+
+GET  /v1/archives
+GET  /v1/apps/:app/archives/:archive/status
+POST /v1/apps/:app/archives/:archive/query
+POST /v1/apps/:app/archives/:archive/batch-read
+POST /v1/apps/:app/archives/:archive/ingest
+POST /v1/apps/:app/archives/:archive/integrity
+```
+
+Do not add a general `/sql` route for readers. For admin-only diagnostics, make
+raw SQL opt-in and disabled in production unless a break-glass env var is set.
+
+Deployment environments:
+
+| env | purpose | auth |
+| --- | --- | --- |
+| `local` | Wrangler/Vitest fixtures | fake GitHub/OAuth and local D1 |
+| `staging` | real GitHub org auth, disposable D1 data | restricted maintainer team |
+| `prod` | live archives | org/team policy plus optional Access |
+
+Archive registry table:
+
+```sql
+create table if not exists remote_archives (
+  id text primary key,
+  app text not null,
+  slug text not null,
+  d1_binding text not null,
+  schema_name text not null,
+  schema_version integer not null,
+  schema_hash text not null,
+  visibility text not null default 'org',
+  read_role text not null default 'reader',
+  publish_role text not null default 'publisher',
+  created_at text not null,
+  updated_at text not null,
+  unique(app, slug)
+);
+
+create table if not exists remote_ingest_runs (
+  id text primary key,
+  archive_id text not null references remote_archives(id),
+  actor_login text not null,
+  actor_owner text not null,
+  source text not null,
+  status text not null,
+  started_at text not null,
+  finished_at text,
+  stats_json text not null default '{}',
+  error_text text
+);
+```
+
+Each app archive D1 database should also have local metadata:
+
+```sql
+create table if not exists crawl_remote_metadata (
+  key text primary key,
+  value text not null,
+  updated_at text not null
+);
+```
+
+Required metadata keys:
+
+- `app`
+- `archive`
+- `schema_name`
+- `schema_version`
+- `schema_hash`
+- `last_ingest_at`
+- `last_source_sync_at`
+- `privacy_policy`
+- `capabilities`
+
+## Query policy
+
+Remote reads should use named queries, not raw SQL strings from users.
+
+Example request:
+
+```json
+{
+  "name": "gitcrawl.search_threads",
+  "args": {
+    "repo": "openclaw/openclaw",
+    "query": "provider auth",
+    "state": "open"
+  },
+  "limit": 50
+}
+```
+
+The Worker maps this to a prepared statement:
+
+```sql
+select number, kind, state, title, html_url, updated_at_gh
+from threads
+join repositories on repositories.id = threads.repo_id
+where repositories.full_name = ?
+  and state = ?
+  and documents_fts match ?
+order by updated_at_gh desc
+limit ?
+```
+
+Benefits:
+
+- stable API contract
+- less SQL injection surface
+- app-specific privacy filters remain enforceable
+- D1 query cost stays visible per query name
+- TUI pagination can be tuned by endpoint
+
+## gitcrawl remote scope
+
+First commands to support in `cloud` mode:
+
+- `login`
+- `whoami`
+- `status --json`
+- `metadata --json`
+- `threads`
+- `search issues|prs`
+- `gh issue list`
+- `gh issue view`
+- `gh pr list`
+- `gh pr view`
+- `gh pr checks`
+- `gh pr status`
+- `tui`
+
+Commands that should stay local or explicit in v1:
+
+- `sync`: local/provider sync unless running as a publisher
+- `refresh`, `embed`, `cluster`: local or publisher-only
+- `close-thread`, `close-cluster`, overrides: local-only until conflict policy
+  exists
+- `portable prune`: Git-backed only
+
+Remote query names:
+
+```text
+gitcrawl.status
+gitcrawl.repositories
+gitcrawl.threads.list
+gitcrawl.threads.search
+gitcrawl.thread.detail
+gitcrawl.thread.comments
+gitcrawl.pr.detail
+gitcrawl.pr.files
+gitcrawl.pr.commits
+gitcrawl.pr.checks
+gitcrawl.pr.review_threads
+gitcrawl.workflow_runs
+gitcrawl.clusters.list
+gitcrawl.cluster.detail
+gitcrawl.neighbors
+gitcrawl.tui.initial
+gitcrawl.tui.page
+```
+
+`gh` shim behavior in cloud mode:
+
+- exact read supported if the remote archive has the row
+- broad list/search supported through named queries
+- auto-hydration must not silently write to remote for a normal reader
+- if data is stale or missing, either fall back to real `gh` live read or return
+  a structured cache miss depending on the existing shim policy
+- publisher mode may expose `gitcrawl cloud hydrate --numbers ...` later
+
+## discrawl remote scope
+
+First commands to support in `cloud` mode:
+
+- `login`
+- `whoami`
+- `status --json`
+- `metadata --json`
+- `search`
+- `messages`
+- `channels`
+- `members`
+- `mentions`
+- `report`
+- `digest`
+- `tui`
+
+Commands that should stay local or explicit in v1:
+
+- `sync`: local bot or desktop cache sync unless publisher mode
+- `tail`: local bot/Gateway only
+- `wiretap`: local-only
+- `dms`: local-only by default
+- `publish`, `subscribe`, `update`: Git-backed share commands, unchanged
+- `sql`: local-only for normal users; admin-only remote diagnostics later
+
+Remote query names:
+
+```text
+discrawl.status
+discrawl.guilds.list
+discrawl.channels.list
+discrawl.messages.search
+discrawl.messages.page
+discrawl.messages.by_channel
+discrawl.members.search
+discrawl.mentions.search
+discrawl.report.summary
+discrawl.digest.window
+discrawl.tui.initial
+discrawl.tui.page
+```
+
+Privacy invariant:
+
+Every remote ingest and remote query must exclude `guild_id = '@me'` unless an
+explicit future private-per-user archive is designed. The first shared remote
+archive is org/guild shared data, not personal Discord Desktop data.
+
+## Ingest model
+
+V1 should use explicit publisher ingest, not Worker-native provider crawling.
+
+`gitcrawl` publisher:
+
+```bash
+gitcrawl sync openclaw/openclaw --state open --include-comments --with pr-details
+gitcrawl cloud publish --archive gitcrawl/openclaw__openclaw --remote https://crawl.openclaw.ai
+```
+
+`discrawl` publisher:
+
+```bash
+discrawl sync --full --skip-members=false
+discrawl cloud publish --archive discrawl/openclaw-maintainers --remote https://crawl.openclaw.ai
+```
+
+Publisher implementation options:
+
+1. Row-batch ingest from the live local DB.
+2. Snapshot JSONL/Gzip export streamed to the Worker.
+3. SQL export imported by admin tooling.
+
+Recommendation: start with row-batch ingest for app tables plus a manifest.
+It is easier to validate, easier to retry, and lets the Worker enforce table
+allowlists and privacy filters. Keep the snapshot export path reusable for
+bulk bootstrap, but do not make ordinary publish depend on Git.
+
+Ingest request:
+
+```json
+{
+  "manifest": {
+    "app": "discrawl",
+    "archive": "discrawl/openclaw-maintainers",
+    "schema_version": 2,
+    "schema_hash": "sha256:...",
+    "mode": "replace",
+    "source_sync_at": "2026-05-27T12:00:00Z"
+  },
+  "table": "messages",
+  "columns": ["id", "guild_id", "channel_id", "author_id", "content", "created_at"],
+  "rows": [["...", "..."]]
+}
+```
+
+Replace ingest strategy:
+
+1. Publisher starts ingest run.
+2. Worker writes into shadow tables or uses archive generation suffixes.
+3. Worker validates counts and `pragma quick_check` where supported.
+4. Worker swaps metadata pointer or finalizes the replace.
+5. Worker records `last_ingest_at` and actor.
+
+For large archives, use append/update by natural primary keys after the replace
+path is proven.
+
+## Migration from state repos
+
+Existing state repos should remain valid indefinitely. The cloud service starts
+as another publish target.
+
+Stage 1:
+
+- Keep `openclaw/gitcrawl-store` and Discord store repos as canonical for
+  existing readers.
+- Add a scheduled publisher that reads the same source DB/snapshot and also
+  publishes to D1.
+- Compare table counts, freshness, and representative query output.
+
+Stage 2:
+
+- Make cloud mode the recommended reader path for OpenClaw maintainers.
+- Keep Git stores as backup/export artifacts.
+- Update docs to present Git stores as offline/portable fallback.
+
+Stage 3:
+
+- Decide whether the Git state repos become generated exports from D1, or
+  whether they stop updating after a deprecation window.
+- Do not remove Git support from apps; just stop making Git the only hosted
+  sharing mechanism.
+
+This keeps existing users safe while letting OpenClaw move its own shared
+archives to live hosted reads.
+
+## Schema strategy
+
+Keep app schemas app-owned.
+
+`gitcrawl` should publish a D1-compatible variant of its existing schema. The
+remote archive can keep the same core tables, portable metadata, PR detail
+tables, and FTS tables. Generated local-only or expensive tables can be omitted
+unless a remote command needs them.
+
+`discrawl` should publish the existing guild/channel/member/message schema,
+`sync_state`, FTS tables, and optional embedding tables only after semantic
+remote search is proven. `@me` rows remain excluded.
+
+Add per-app schema files:
+
+```text
+gitcrawl/internal/remote/schema_d1.sql
+discrawl/internal/remote/schema_d1.sql
+```
+
+Add schema hash generation:
+
+```text
+schema_hash = sha256(normalized schema_d1.sql + query registry version)
+```
+
+The Worker refuses ingest when the client schema hash is unknown or newer than
+the deployed query registry.
+
+## Local code refactor shape
+
+Do not try to make `database/sql` magically remote. That will turn gross fast.
+
+Instead, split app store usage into reader interfaces and writer stores.
+
+For `gitcrawl`:
+
+```go
+type ThreadReader interface {
+    SearchThreads(ctx context.Context, opts ThreadSearchOptions) ([]Thread, error)
+    ThreadDetail(ctx context.Context, repo string, number int) (ThreadDetail, error)
+    PullRequestStatus(ctx context.Context, repo string, number int) (PRStatus, error)
+    Status(ctx context.Context) (Status, error)
+}
+
+type LocalStore struct { /* existing */ }
+type RemoteStore struct { client *remote.Client }
+```
+
+For `discrawl`:
+
+```go
+type ArchiveReader interface {
+    Search(ctx context.Context, opts SearchOptions) ([]SearchResult, error)
+    Messages(ctx context.Context, opts MessageOptions) ([]MessageRow, error)
+    Members(ctx context.Context, opts MemberSearchOptions) ([]MemberRow, error)
+    Status(ctx context.Context) (Status, error)
+}
+```
+
+Read commands depend on the reader interface. Sync/publish commands still
+depend on local writable stores.
+
+## Command additions
+
+Generic:
+
+```bash
+<app> login --remote https://crawl.openclaw.ai
+<app> whoami
+<app> remote status --json
+<app> remote archives --json
+```
+
+`gitcrawl`:
+
+```bash
+gitcrawl init --remote https://crawl.openclaw.ai --archive gitcrawl/openclaw__openclaw
+gitcrawl cloud publish --archive gitcrawl/openclaw__openclaw
+gitcrawl cloud integrity --archive gitcrawl/openclaw__openclaw
+```
+
+`discrawl`:
+
+```bash
+discrawl subscribe-cloud https://crawl.openclaw.ai/discrawl/openclaw-maintainers
+discrawl cloud publish --archive discrawl/openclaw-maintainers
+discrawl cloud integrity --archive discrawl/openclaw-maintainers
+```
+
+Use `subscribe-cloud` instead of overloading `subscribe`; existing `subscribe`
+means Git snapshot today.
+
+## Status and metadata
+
+Remote status should make the storage mode obvious:
+
+```json
+{
+  "schema_version": "crawlkit.control.v1",
+  "app_id": "discrawl",
+  "state": "ok",
+  "summary": "124122 messages across 88 channels",
+  "database_path": "",
+  "databases": [
+    {
+      "id": "primary",
+      "label": "Discord archive",
+      "kind": "d1",
+      "role": "archive",
+      "endpoint": "https://crawl.openclaw.ai",
+      "archive": "discrawl/openclaw-maintainers",
+      "is_primary": true
+    }
+  ],
+  "share": {
+    "enabled": false
+  },
+  "remote": {
+    "enabled": true,
+    "mode": "cloud",
+    "endpoint": "https://crawl.openclaw.ai",
+    "archive": "discrawl/openclaw-maintainers",
+    "last_ingest_at": "2026-05-27T12:00:00Z"
+  }
+}
+```
+
+Additive JSON only. Existing status consumers should ignore new fields.
+
+## Backup and recovery
+
+Use three layers:
+
+1. D1 native export for disaster recovery.
+2. App-level row-batch manifest exports for reproducible app restores.
+3. Existing Git-backed portable stores as a compatibility backup until the
+   cloud path has proven itself.
+
+Operational commands:
+
+```bash
+wrangler d1 export crawl-gitcrawl-openclaw-openclaw-prod --remote --output backup.sql
+gitcrawl cloud export --archive gitcrawl/openclaw__openclaw --output backup.jsonl.gz
+discrawl cloud export --archive discrawl/openclaw-maintainers --output backup.jsonl.gz
+```
+
+The app-level export should preserve the same privacy policy as ingest. A
+`discrawl` cloud export must not include `@me` rows.
+
+## Rollout plan
+
+### Phase 0: spec and compatibility inventory
+
+- Land this spec.
+- Add issue checklists for `crawlkit`, `gitcrawl`, `discrawl`, and the Worker.
+- Capture current command matrices for local and Git modes.
+
+Exit criteria:
+
+- No behavior change.
+- Agreement that Worker + D1 is the first target.
+
+### Phase 1: crawlkit remote primitives
+
+- Add `remote` package.
+- Add token-source abstraction with env and config sources first.
+- Add keyring source only if apps already have a dependency or it can stay
+  optional.
+- Add `control` remote database/status fields.
+- Add httptest fixtures for query, status, auth, errors, pagination, and ingest.
+
+Exit criteria:
+
+- `GOWORK=off go test -count=1 ./...`
+- No downstream app needs to change unless it opts into `remote`.
+
+### Phase 2: Worker skeleton
+
+- Create Worker repo.
+- Port Crabbox GitHub OAuth/session code under neutral names.
+- Add GitHub org/team policy.
+- Add D1 metadata binding.
+- Add `/whoami`, `/archives`, `/status`, and one fake query.
+- Add Wrangler local D1 tests.
+
+Exit criteria:
+
+- `wrangler dev` local login/query works.
+- Vitest covers org deny, team deny, expired token, and reader/publisher roles.
+
+### Phase 3: gitcrawl read-only cloud mode
+
+- Add `[remote]` config.
+- Add remote client wiring.
+- Extract read interfaces for search/thread/detail/status.
+- Implement named Worker queries for core read commands.
+- Wire cloud mode into `gh` shim for read-only supported shapes.
+- Ensure no local DB is created in cloud mode for supported commands.
+
+Exit criteria:
+
+- Existing local and portable-store tests still pass.
+- New cloud-mode tests prove no local SQLite file is created.
+- Remote search/detail output matches seeded local fixtures.
+
+### Phase 4: discrawl read-only cloud mode
+
+- Add `[remote]` config.
+- Add `subscribe-cloud`.
+- Extract read interfaces for search/messages/members/report/status/TUI.
+- Implement remote named queries.
+- Enforce `@me` exclusion in ingest and query fixtures.
+- Keep existing Git `publish/subscribe/update` untouched.
+
+Exit criteria:
+
+- Existing Git share tests still pass.
+- New cloud-mode tests prove no local SQLite file is created.
+- Remote reads never return `@me` rows.
+
+### Phase 5: publisher ingest
+
+- Add `gitcrawl cloud publish`.
+- Add `discrawl cloud publish`.
+- Add Worker ingest endpoints with publisher role checks.
+- Start with replace-mode ingest into D1.
+- Add integrity endpoint comparing table counts, schema hash, and metadata.
+
+Exit criteria:
+
+- A temp local DB can publish to local Wrangler D1.
+- Reader commands can query the published D1 with no local DB.
+- Existing Git-based publishing remains unchanged.
+
+### Phase 6: OpenClaw hosted pilot
+
+- Deploy staging Worker.
+- Create staging D1 archives:
+  - `gitcrawl/openclaw__openclaw`
+  - `discrawl/openclaw-maintainers`
+- Seed from current local or CI publishers.
+- Add one maintainer daily report read path against remote.
+- Compare remote report output against local/Git store output.
+
+Exit criteria:
+
+- Staging readers can login with GitHub org auth.
+- No local DB is created for supported read commands.
+- Report/search/TUI latency and D1 read counts are acceptable.
+
+## Validation matrix
+
+`crawlkit`:
+
+```bash
+GOWORK=off go mod tidy
+git diff --exit-code -- go.mod go.sum
+GOWORK=off go vet ./...
+GOWORK=off go test -count=1 ./...
+```
+
+`gitcrawl`:
+
+```bash
+GOWORK=off go test ./...
+gitcrawl --config "$TMP/config.toml" init --remote "$REMOTE" --archive gitcrawl/openclaw__openclaw --json
+gitcrawl --config "$TMP/config.toml" status --json
+gitcrawl --config "$TMP/config.toml" search issues "auth" -R openclaw/openclaw --json number,title,url
+test ! -e "$TMP/gitcrawl.db"
+```
+
+`discrawl`:
+
+```bash
+GOWORK=off go test ./...
+discrawl --config "$TMP/config.toml" subscribe-cloud "$REMOTE/discrawl/openclaw-maintainers" --json
+discrawl --config "$TMP/config.toml" status --json
+discrawl --config "$TMP/config.toml" search "github" --json
+discrawl --config "$TMP/config.toml" messages --channel maintainers --last 20 --json
+test ! -e "$TMP/discrawl.db"
+```
+
+Worker:
+
+```bash
+npm test
+npx wrangler d1 migrations apply crawl-remote-meta --local
+npx wrangler d1 migrations apply gitcrawl-openclaw --local
+npx wrangler d1 migrations apply discrawl-maintainers --local
+npx wrangler dev
+```
+
+Security checks:
+
+- reader cannot ingest
+- reader cannot raw SQL
+- publisher cannot admin migrate
+- expired token fails
+- wrong org fails
+- wrong team fails when teams are configured
+- Access JWT is verified when configured
+- `discrawl` remote ingest rejects `@me`
+- token values are redacted in logs and JSON status
+
+Compatibility checks:
+
+- existing `gitcrawl` local commands pass
+- existing `gitcrawl` portable-store tests pass
+- existing `discrawl` Git share tests pass
+- existing `discrawl` wiretap local tests pass
+- existing `crawlkit` snapshot/mirror/store tests pass
+
+## Risks
+
+### Remote SQL is not local SQLite
+
+D1 supports SQLite semantics, but not every local pragma, import shape, or
+runtime assumption is equivalent. Do not reuse local SQL blindly. Keep a D1
+schema file and query registry tested under Wrangler.
+
+### Arbitrary SQL is a foot-gun
+
+`discrawl sql` is useful locally, but exposing it remotely would turn the
+archive into an exfiltration API. Keep remote reads named and paginated.
+
+### `gh` shim auto-hydration can mutate by surprise
+
+In local mode, auto-hydration writing to a local runtime DB is fine. In cloud
+mode, a reader should not silently write to shared D1. Make mutation explicit
+and role-gated.
+
+### D1 database size
+
+Use separate D1 databases by app/archive and shard before the archive is close
+to D1 limits. Good boundaries are repo for `gitcrawl` and guild/community for
+`discrawl`.
+
+### Discord DMs
+
+The fastest way to break trust is to accidentally upload wiretap DMs. Treat
+`@me` exclusion as a hard test fixture in every ingest path.
+
+### Worker-native provider sync is tempting
+
+Do not start there. `gitcrawl` and `discrawl` already have local syncers. Use
+publisher ingest first, then decide if a Worker-native GitHub syncer is worth
+it. Discord Gateway/live tail is a worse fit for a first Worker service.
+
+## Future direction
+
+The later distributed cache idea should be modeled as provenance-aware shared
+cache, not anonymous row gossip.
+
+Possible future shape:
+
+- D1 stores canonical indexes and metadata.
+- R2 stores content-addressed snapshot shards.
+- Clients can submit signed cache shards.
+- Worker verifies schema hash, source provenance, freshness, and privacy
+  filters.
+- Trusted shards are merged into per-archive D1 indexes.
+- Untrusted shards remain quarantined or private.
+
+This gives the IPFS-like property that machines can contribute cache work, but
+keeps OpenClaw policy centralized enough to avoid poisoning, privacy leaks, and
+schema drift.
+
+The strategic move is to make `crawlkit` own the transport and archive
+contracts now, while leaving app semantics in the apps. That keeps today's Git
+syncs stable and gives OpenClaw a clean path from "state repos with files" to
+"live hosted archives with optional distributed cache."

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -1,0 +1,459 @@
+package remote
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/openclaw/crawlkit/control"
+)
+
+const (
+	ModeLocal     = "local"
+	ModeGit       = "git"
+	ModeCloud     = "cloud"
+	ModeHybrid    = "hybrid"
+	ModePublisher = "publisher"
+
+	DefaultTokenEnv = "CRAWL_REMOTE_TOKEN"
+)
+
+type Config struct {
+	Mode       string     `toml:"mode" json:"mode"`
+	Endpoint   string     `toml:"endpoint" json:"endpoint"`
+	Archive    string     `toml:"archive" json:"archive"`
+	TokenEnv   string     `toml:"token_env" json:"token_env"`
+	StaleAfter string     `toml:"stale_after" json:"stale_after"`
+	Auth       AuthConfig `toml:"auth" json:"auth"`
+}
+
+type AuthConfig struct {
+	TokenSource    string `toml:"token_source" json:"token_source"`
+	KeyringService string `toml:"keyring_service" json:"keyring_service"`
+	KeyringAccount string `toml:"keyring_account" json:"keyring_account"`
+}
+
+func (c *Config) Normalize() {
+	c.Mode = strings.ToLower(strings.TrimSpace(c.Mode))
+	if c.Mode == "" {
+		c.Mode = ModeLocal
+	}
+	c.Endpoint = strings.TrimRight(strings.TrimSpace(c.Endpoint), "/")
+	c.Archive = strings.TrimSpace(c.Archive)
+	c.TokenEnv = strings.TrimSpace(c.TokenEnv)
+	if c.TokenEnv == "" {
+		c.TokenEnv = DefaultTokenEnv
+	}
+	c.StaleAfter = strings.TrimSpace(c.StaleAfter)
+	c.Auth.TokenSource = strings.ToLower(strings.TrimSpace(c.Auth.TokenSource))
+	c.Auth.KeyringService = strings.TrimSpace(c.Auth.KeyringService)
+	c.Auth.KeyringAccount = strings.TrimSpace(c.Auth.KeyringAccount)
+}
+
+func (c Config) Enabled() bool {
+	mode := strings.ToLower(strings.TrimSpace(c.Mode))
+	return mode == ModeCloud || mode == ModeHybrid || mode == ModePublisher
+}
+
+type TokenProvider interface {
+	Token(context.Context) (string, error)
+}
+
+type StaticToken string
+
+func (t StaticToken) Token(context.Context) (string, error) {
+	token := strings.TrimSpace(string(t))
+	if token == "" {
+		return "", ErrMissingToken
+	}
+	return token, nil
+}
+
+type EnvTokenProvider struct {
+	Name string
+}
+
+func (p EnvTokenProvider) Token(context.Context) (string, error) {
+	name := strings.TrimSpace(p.Name)
+	if name == "" {
+		name = DefaultTokenEnv
+	}
+	token := strings.TrimSpace(os.Getenv(name))
+	if token == "" {
+		return "", fmt.Errorf("%w: %s", ErrMissingToken, name)
+	}
+	return token, nil
+}
+
+type ChainTokenProvider []TokenProvider
+
+func (p ChainTokenProvider) Token(ctx context.Context) (string, error) {
+	var lastErr error
+	for _, provider := range p {
+		if provider == nil {
+			continue
+		}
+		token, err := provider.Token(ctx)
+		if err == nil && strings.TrimSpace(token) != "" {
+			return token, nil
+		}
+		lastErr = err
+	}
+	if lastErr != nil {
+		return "", lastErr
+	}
+	return "", ErrMissingToken
+}
+
+var ErrMissingToken = errors.New("remote token is missing")
+
+type Options struct {
+	Endpoint      string
+	HTTPClient    *http.Client
+	TokenProvider TokenProvider
+	UserAgent     string
+}
+
+type Client struct {
+	endpoint      *url.URL
+	httpClient    *http.Client
+	tokenProvider TokenProvider
+	userAgent     string
+}
+
+func NewClient(opts Options) (*Client, error) {
+	endpoint := strings.TrimRight(strings.TrimSpace(opts.Endpoint), "/")
+	if endpoint == "" {
+		return nil, errors.New("remote endpoint is required")
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("invalid remote endpoint %q", endpoint)
+	}
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	userAgent := strings.TrimSpace(opts.UserAgent)
+	if userAgent == "" {
+		userAgent = "crawlkit-remote"
+	}
+	return &Client{
+		endpoint:      parsed,
+		httpClient:    client,
+		tokenProvider: opts.TokenProvider,
+		userAgent:     userAgent,
+	}, nil
+}
+
+func NewClientFromConfig(cfg Config, opts Options) (*Client, error) {
+	cfg.Normalize()
+	if opts.Endpoint == "" {
+		opts.Endpoint = cfg.Endpoint
+	}
+	if opts.TokenProvider == nil {
+		opts.TokenProvider = EnvTokenProvider{Name: cfg.TokenEnv}
+	}
+	return NewClient(opts)
+}
+
+type Identity struct {
+	Owner string   `json:"owner"`
+	Org   string   `json:"org"`
+	Login string   `json:"login,omitempty"`
+	Auth  string   `json:"auth,omitempty"`
+	Roles []string `json:"roles,omitempty"`
+}
+
+type Archive struct {
+	ID            string   `json:"id"`
+	App           string   `json:"app"`
+	Slug          string   `json:"slug"`
+	SchemaName    string   `json:"schema_name,omitempty"`
+	SchemaVersion int      `json:"schema_version,omitempty"`
+	SchemaHash    string   `json:"schema_hash,omitempty"`
+	Capabilities  []string `json:"capabilities,omitempty"`
+	LastIngestAt  string   `json:"last_ingest_at,omitempty"`
+	LastSyncAt    string   `json:"last_sync_at,omitempty"`
+}
+
+type Status struct {
+	App          string          `json:"app"`
+	Archive      string          `json:"archive"`
+	Mode         string          `json:"mode,omitempty"`
+	GeneratedAt  string          `json:"generated_at,omitempty"`
+	LastSyncAt   string          `json:"last_sync_at,omitempty"`
+	LastIngestAt string          `json:"last_ingest_at,omitempty"`
+	Counts       []control.Count `json:"counts,omitempty"`
+	Capabilities []string        `json:"capabilities,omitempty"`
+	Warnings     []string        `json:"warnings,omitempty"`
+}
+
+type QueryRequest struct {
+	App     string         `json:"app,omitempty"`
+	Archive string         `json:"archive,omitempty"`
+	Name    string         `json:"name"`
+	Args    map[string]any `json:"args,omitempty"`
+	Limit   int            `json:"limit,omitempty"`
+	Cursor  string         `json:"cursor,omitempty"`
+}
+
+type QueryStats struct {
+	RowsRead    int64  `json:"rows_read,omitempty"`
+	RowsWritten int64  `json:"rows_written,omitempty"`
+	DurationMS  int64  `json:"duration_ms,omitempty"`
+	ServedBy    string `json:"served_by,omitempty"`
+}
+
+type QueryResult struct {
+	Columns    []string         `json:"columns"`
+	Rows       [][]any          `json:"rows"`
+	Values     []map[string]any `json:"values,omitempty"`
+	Cursor     string           `json:"cursor,omitempty"`
+	Stats      QueryStats       `json:"stats,omitempty"`
+	SchemaHash string           `json:"schema_hash,omitempty"`
+}
+
+type IngestManifest struct {
+	App           string `json:"app"`
+	Archive       string `json:"archive"`
+	SchemaName    string `json:"schema_name,omitempty"`
+	SchemaVersion int    `json:"schema_version"`
+	SchemaHash    string `json:"schema_hash"`
+	Mode          string `json:"mode,omitempty"`
+	Source        string `json:"source,omitempty"`
+	SourceSyncAt  string `json:"source_sync_at,omitempty"`
+}
+
+type IngestRequest struct {
+	Manifest IngestManifest `json:"manifest"`
+	Table    string         `json:"table"`
+	Columns  []string       `json:"columns"`
+	Rows     [][]any        `json:"rows"`
+	Cursor   string         `json:"cursor,omitempty"`
+	Final    bool           `json:"final,omitempty"`
+}
+
+type IngestResult struct {
+	RunID        string `json:"run_id,omitempty"`
+	Table        string `json:"table,omitempty"`
+	RowsAccepted int64  `json:"rows_accepted,omitempty"`
+	Cursor       string `json:"cursor,omitempty"`
+	Complete     bool   `json:"complete,omitempty"`
+}
+
+type LoginStartRequest struct {
+	PollSecretHash string `json:"pollSecretHash"`
+}
+
+type LoginStartResult struct {
+	LoginID   string `json:"loginID"`
+	URL       string `json:"url"`
+	ExpiresAt string `json:"expiresAt,omitempty"`
+}
+
+type LoginPollRequest struct {
+	LoginID    string `json:"loginID"`
+	PollSecret string `json:"pollSecret"`
+}
+
+type LoginPollResult struct {
+	Status string `json:"status"`
+	Token  string `json:"token,omitempty"`
+	Owner  string `json:"owner,omitempty"`
+	Org    string `json:"org,omitempty"`
+	Login  string `json:"login,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+func (c *Client) Whoami(ctx context.Context) (Identity, error) {
+	var out Identity
+	err := c.do(ctx, http.MethodGet, "/v1/whoami", nil, &out, true)
+	return out, err
+}
+
+func (c *Client) Archives(ctx context.Context) ([]Archive, error) {
+	var out struct {
+		Archives []Archive `json:"archives"`
+	}
+	err := c.do(ctx, http.MethodGet, "/v1/archives", nil, &out, true)
+	return out.Archives, err
+}
+
+func (c *Client) Status(ctx context.Context, app, archive string) (Status, error) {
+	var out Status
+	err := c.do(ctx, http.MethodGet, archivePath(app, archive, "status"), nil, &out, true)
+	return out, err
+}
+
+func (c *Client) Query(ctx context.Context, app, archive string, req QueryRequest) (QueryResult, error) {
+	req.App = strings.TrimSpace(app)
+	req.Archive = strings.TrimSpace(archive)
+	var out QueryResult
+	err := c.do(ctx, http.MethodPost, archivePath(app, archive, "query"), req, &out, true)
+	return out, err
+}
+
+func (c *Client) BatchRead(ctx context.Context, app, archive string, requests []QueryRequest) ([]QueryResult, error) {
+	body := struct {
+		Requests []QueryRequest `json:"requests"`
+	}{Requests: requests}
+	for i := range body.Requests {
+		body.Requests[i].App = strings.TrimSpace(app)
+		body.Requests[i].Archive = strings.TrimSpace(archive)
+	}
+	var out struct {
+		Results []QueryResult `json:"results"`
+	}
+	err := c.do(ctx, http.MethodPost, archivePath(app, archive, "batch-read"), body, &out, true)
+	return out.Results, err
+}
+
+func (c *Client) Ingest(ctx context.Context, app, archive string, req IngestRequest) (IngestResult, error) {
+	req.Manifest.App = strings.TrimSpace(app)
+	req.Manifest.Archive = strings.TrimSpace(archive)
+	var out IngestResult
+	err := c.do(ctx, http.MethodPost, archivePath(app, archive, "ingest"), req, &out, true)
+	return out, err
+}
+
+func (c *Client) StartGitHubLogin(ctx context.Context, pollSecretHash string) (LoginStartResult, error) {
+	var out LoginStartResult
+	err := c.do(ctx, http.MethodPost, "/v1/auth/github/start", LoginStartRequest{PollSecretHash: pollSecretHash}, &out, false)
+	return out, err
+}
+
+func (c *Client) PollGitHubLogin(ctx context.Context, loginID, pollSecret string) (LoginPollResult, error) {
+	var out LoginPollResult
+	err := c.do(ctx, http.MethodPost, "/v1/auth/github/poll", LoginPollRequest{LoginID: loginID, PollSecret: pollSecret}, &out, false)
+	return out, err
+}
+
+type Error struct {
+	Status  int    `json:"status"`
+	Code    string `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+func (e *Error) Error() string {
+	msg := strings.TrimSpace(e.Message)
+	if msg == "" {
+		msg = http.StatusText(e.Status)
+	}
+	code := strings.TrimSpace(e.Code)
+	if code == "" {
+		return fmt.Sprintf("remote request failed: status=%d message=%s", e.Status, msg)
+	}
+	return fmt.Sprintf("remote request failed: status=%d code=%s message=%s", e.Status, code, msg)
+}
+
+func (c *Client) do(ctx context.Context, method, route string, input, output any, auth bool) error {
+	var body io.Reader
+	if input != nil {
+		var buf bytes.Buffer
+		if err := json.NewEncoder(&buf).Encode(input); err != nil {
+			return fmt.Errorf("encode remote request: %w", err)
+		}
+		body = &buf
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.url(route), body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("accept", "application/json")
+	req.Header.Set("user-agent", c.userAgent)
+	if input != nil {
+		req.Header.Set("content-type", "application/json")
+	}
+	if auth {
+		if c.tokenProvider == nil {
+			return ErrMissingToken
+		}
+		token, err := c.tokenProvider.Token(ctx)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("authorization", "Bearer "+token)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return decodeRemoteError(resp)
+	}
+	if output == nil || resp.StatusCode == http.StatusNoContent {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(output); err != nil {
+		return fmt.Errorf("decode remote response: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) url(route string) string {
+	route = "/" + strings.TrimLeft(route, "/")
+	u := *c.endpoint
+	escapedPath := strings.TrimRight(u.EscapedPath(), "/") + route
+	unescapedPath, err := url.PathUnescape(escapedPath)
+	if err == nil {
+		u.Path = unescapedPath
+		if unescapedPath != escapedPath {
+			u.RawPath = escapedPath
+		}
+	} else {
+		u.Path = escapedPath
+	}
+	return u.String()
+}
+
+func archivePath(app, archive, action string) string {
+	return path.Join(
+		"/v1/apps",
+		url.PathEscape(strings.TrimSpace(app)),
+		"archives",
+		url.PathEscape(strings.TrimSpace(archive)),
+		strings.TrimSpace(action),
+	)
+}
+
+func decodeRemoteError(resp *http.Response) error {
+	payload, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	errOut := Error{Status: resp.StatusCode}
+	var decoded struct {
+		Error   string `json:"error"`
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(payload, &decoded); err == nil {
+		errOut.Code = firstNonEmpty(decoded.Code, decoded.Error)
+		errOut.Message = decoded.Message
+		if errOut.Message == "" && decoded.Error != "" && decoded.Code == "" {
+			errOut.Message = decoded.Error
+		}
+	}
+	if errOut.Message == "" {
+		errOut.Message = strings.TrimSpace(string(payload))
+	}
+	return &errOut
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -3,6 +3,9 @@ package remote
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -273,6 +276,19 @@ type LoginPollResult struct {
 	Org    string `json:"org,omitempty"`
 	Login  string `json:"login,omitempty"`
 	Error  string `json:"error,omitempty"`
+}
+
+func NewLoginPollSecret() (string, error) {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", fmt.Errorf("create login poll secret: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(bytes), nil
+}
+
+func LoginPollSecretHash(secret string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(secret)))
+	return fmt.Sprintf("%x", sum[:])
 }
 
 func (c *Client) Whoami(ctx context.Context) (Identity, error) {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -269,6 +269,10 @@ type LoginPollRequest struct {
 	PollSecret string `json:"pollSecret"`
 }
 
+type GitHubTokenLoginRequest struct {
+	Token string `json:"token"`
+}
+
 type LoginPollResult struct {
 	Status string `json:"status"`
 	Token  string `json:"token,omitempty"`
@@ -351,6 +355,12 @@ func (c *Client) StartGitHubLogin(ctx context.Context, pollSecretHash string) (L
 func (c *Client) PollGitHubLogin(ctx context.Context, loginID, pollSecret string) (LoginPollResult, error) {
 	var out LoginPollResult
 	err := c.do(ctx, http.MethodPost, "/v1/auth/github/poll", LoginPollRequest{LoginID: loginID, PollSecret: pollSecret}, &out, false)
+	return out, err
+}
+
+func (c *Client) LoginWithGitHubToken(ctx context.Context, token string) (LoginPollResult, error) {
+	var out LoginPollResult
+	err := c.do(ctx, http.MethodPost, "/v1/auth/github/token", GitHubTokenLoginRequest{Token: strings.TrimSpace(token)}, &out, false)
 	return out, err
 }
 

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -1,0 +1,150 @@
+package remote
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestConfigNormalizeAndEnabled(t *testing.T) {
+	cfg := Config{Mode: " Cloud ", Endpoint: "https://remote.test/", Archive: " gitcrawl/openclaw ", Auth: AuthConfig{TokenSource: " Env "}}
+	cfg.Normalize()
+	if cfg.Mode != ModeCloud || cfg.Endpoint != "https://remote.test" || cfg.Archive != "gitcrawl/openclaw" {
+		t.Fatalf("normalized config = %#v", cfg)
+	}
+	if cfg.TokenEnv != DefaultTokenEnv {
+		t.Fatalf("token env = %q", cfg.TokenEnv)
+	}
+	if !cfg.Enabled() {
+		t.Fatal("cloud mode should be enabled")
+	}
+	cfg.Mode = ModeGit
+	if cfg.Enabled() {
+		t.Fatal("git mode should not be cloud-enabled")
+	}
+}
+
+func TestEnvTokenProvider(t *testing.T) {
+	t.Setenv("CRAWL_REMOTE_TEST_TOKEN", " tok ")
+	token, err := EnvTokenProvider{Name: "CRAWL_REMOTE_TEST_TOKEN"}.Token(context.Background())
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	if token != "tok" {
+		t.Fatalf("token = %q", token)
+	}
+	_, err = EnvTokenProvider{Name: "CRAWL_REMOTE_MISSING_TOKEN"}.Token(context.Background())
+	if !errors.Is(err, ErrMissingToken) {
+		t.Fatalf("missing token err = %v", err)
+	}
+}
+
+func TestClientQuerySendsBearerAndEscapedArchive(t *testing.T) {
+	var sawAuth string
+	var sawPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("authorization")
+		sawPath = r.URL.EscapedPath()
+		var req QueryRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.App != "gitcrawl" || req.Archive != "gitcrawl/openclaw__openclaw" || req.Name != "gitcrawl.threads.search" {
+			t.Fatalf("request = %#v", req)
+		}
+		_ = json.NewEncoder(w).Encode(QueryResult{
+			Columns: []string{"number", "title"},
+			Rows:    [][]any{{float64(1), "remote"}},
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Options{Endpoint: server.URL, TokenProvider: StaticToken("secret"), UserAgent: "test-agent"})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	result, err := client.Query(context.Background(), "gitcrawl", "gitcrawl/openclaw__openclaw", QueryRequest{Name: "gitcrawl.threads.search"})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if sawAuth != "Bearer secret" {
+		t.Fatalf("auth = %q", sawAuth)
+	}
+	if !strings.Contains(sawPath, "gitcrawl%2Fopenclaw__openclaw") {
+		t.Fatalf("path did not escape archive slash: %q", sawPath)
+	}
+	if len(result.Rows) != 1 || result.Columns[0] != "number" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestClientErrorDecoding(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"forbidden","message":"wrong team"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Options{Endpoint: server.URL, TokenProvider: StaticToken("secret")})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	_, err = client.Whoami(context.Background())
+	var remoteErr *Error
+	if !errors.As(err, &remoteErr) {
+		t.Fatalf("err = %T %v", err, err)
+	}
+	if remoteErr.Status != http.StatusForbidden || remoteErr.Code != "forbidden" || remoteErr.Message != "wrong team" {
+		t.Fatalf("remote err = %#v", remoteErr)
+	}
+}
+
+func TestClientFromConfigUsesEnvToken(t *testing.T) {
+	t.Setenv("CRAWL_REMOTE_FROM_CONFIG", "env-token")
+	var auth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth = r.Header.Get("authorization")
+		_ = json.NewEncoder(w).Encode(Identity{Owner: "owner@example.com", Org: "openclaw"})
+	}))
+	defer server.Close()
+
+	cfg := Config{Mode: ModeCloud, Endpoint: server.URL, TokenEnv: "CRAWL_REMOTE_FROM_CONFIG"}
+	client, err := NewClientFromConfig(cfg, Options{})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if _, err := client.Whoami(context.Background()); err != nil {
+		t.Fatalf("whoami: %v", err)
+	}
+	if auth != "Bearer env-token" {
+		t.Fatalf("auth = %q", auth)
+	}
+}
+
+func TestChainTokenProviderSkipsNilAndUsesFirstToken(t *testing.T) {
+	t.Setenv("CRAWL_REMOTE_CHAIN_TOKEN", "chain-token")
+	provider := ChainTokenProvider{nil, EnvTokenProvider{Name: "CRAWL_REMOTE_CHAIN_TOKEN"}, StaticToken("fallback")}
+	token, err := provider.Token(context.Background())
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	if token != "chain-token" {
+		t.Fatalf("token = %q", token)
+	}
+}
+
+func TestStaticTokenRejectsBlank(t *testing.T) {
+	_, err := StaticToken(" ").Token(context.Background())
+	if !errors.Is(err, ErrMissingToken) {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -154,6 +154,42 @@ func TestLoginPollSecretHash(t *testing.T) {
 	}
 }
 
+func TestLoginWithGitHubToken(t *testing.T) {
+	var sawToken string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/auth/github/token" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		var req GitHubTokenLoginRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		sawToken = req.Token
+		_ = json.NewEncoder(w).Encode(LoginPollResult{
+			Status: "complete",
+			Token:  "session-token",
+			Org:    "openclaw",
+			Login:  "alice",
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Options{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	result, err := client.LoginWithGitHubToken(context.Background(), " github-token ")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if sawToken != "github-token" {
+		t.Fatalf("github token = %q", sawToken)
+	}
+	if result.Status != "complete" || result.Token != "session-token" || result.Login != "alice" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
 func TestStaticTokenRejectsBlank(t *testing.T) {
 	_, err := StaticToken(" ").Token(context.Background())
 	if !errors.Is(err, ErrMissingToken) {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -138,6 +138,22 @@ func TestChainTokenProviderSkipsNilAndUsesFirstToken(t *testing.T) {
 	}
 }
 
+func TestLoginPollSecretHash(t *testing.T) {
+	secret, err := NewLoginPollSecret()
+	if err != nil {
+		t.Fatalf("new secret: %v", err)
+	}
+	if secret == "" {
+		t.Fatal("secret is empty")
+	}
+	if got := LoginPollSecretHash(" poll-secret "); got != LoginPollSecretHash("poll-secret") {
+		t.Fatalf("hash should trim surrounding spaces")
+	}
+	if got := LoginPollSecretHash("poll-secret"); got != "0e3e16e9ef6f0c4887962402b8af7242b241128b711567a0baff5902dd3540b8" {
+		t.Fatalf("hash = %q", got)
+	}
+}
+
 func TestStaticTokenRejectsBlank(t *testing.T) {
 	_, err := StaticToken(" ").Token(context.Background())
 	if !errors.Is(err, ErrMissingToken) {


### PR DESCRIPTION
## Summary
- add crawlkit remote client/config/control support for Worker-fronted archive reads, ingest, and auth
- document the Cloudflare D1 remote archive architecture and rollout proof
- add GitHub OAuth poll helpers plus GitHub-token bootstrap exchange support for non-browser lanes

## Validation
- `GOWORK=off go mod tidy`
- `git diff --exit-code -- go.mod go.sum`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test -count=1 ./...`
- deployed Worker/D1 proof recorded in `docs/cloudflare-remote-archives.md`

## Release
- intended crawlkit release tag after merge: `v0.8.0`
- downstream branches are ready to bump from pseudo-version to the tag once this lands
