### PR TITLE
feat(remote): define cloud archive contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Add explicit `remote` protocol contract metadata and a public
+  `Client.Contract` helper so Worker-fronted archive services can prove their
+  supported routes, auth roles, query names, and ingest tables without coupling
+  Cloudflare deployment state to the Go module.
+
 ## v0.8.0 - 2026-05-27
 
 - Add provider-neutral `remote` client/config/status contracts for

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ go install github.com/openclaw/crawlkit/cmd/crawlctl@latest
 
 Go packages are published by tagging this repository. There is no separate
 package registry step. See `docs/publishing.md` for the release commands.
-See `docs/boundary.md` for the crawlkit-versus-app ownership boundary.
+See `docs/boundary.md` for the crawlkit-versus-app ownership boundary and
+`docs/remote-contract.md` for the Worker/client split.
 
 ## Packages
 
@@ -32,7 +33,9 @@ See `docs/boundary.md` for the crawlkit-versus-app ownership boundary.
 - `vector`: float32 vector encoding, dimension validation, cosine scoring, top-k helpers, and reciprocal-rank fusion.
 - `releasecheck`: GitHub release checks, 24-hour cache handling, scripted-output
   suppression, and stderr update notice formatting for crawl app CLIs.
-- `remote`: provider-neutral HTTP client, config, query, ingest, auth, and status contracts for Worker-fronted remote archives such as Cloudflare D1.
+- `remote`: provider-neutral HTTP client, config, query, ingest, auth, status,
+  and protocol contract metadata for Worker-fronted remote archives such as
+  Cloudflare D1.
 - `output`: text/json/log output helpers.
 - `control`: crawl app metadata, command manifests, status payloads, and
   database inventory for launchers and automation.

--- a/docs/boundary.md
+++ b/docs/boundary.md
@@ -49,6 +49,9 @@ parsers, and product-specific ranking in the apps.
   fetches, local check caching, scripted-output suppression, and text notice
   formatting. Apps still own their command names, version variables, and install
   hints.
+- Provider-neutral remote archive client contracts: protocol version, route
+  metadata, auth role names, token providers, request/response structs, and
+  HTTP client behavior for Worker-fronted archive services.
 - Safe read-only desktop-cache snapshot helpers. The provider-specific parsing
   of those snapshots stays in the apps.
 
@@ -71,6 +74,9 @@ parsers, and product-specific ranking in the apps.
 - App CLI command contracts. Shared helpers can format JSON/text/log output,
   but the apps decide command names, flags, backward-compatible aliases, and
   deprecation behavior.
+- Hosted Worker deployments, Wrangler config, D1 migrations, service secrets,
+  GitHub org/team policy, and app-specific remote query/table allowlists. Those
+  belong in the service repo and downstream apps, not the Go module.
 
 ## current app seams
 

--- a/docs/cloudflare-remote-archives.md
+++ b/docs/cloudflare-remote-archives.md
@@ -153,10 +153,11 @@ Cloudflare D1 bindings
         +-- remote metadata DB
 ```
 
-The Worker should be a separate service, likely `openclaw/crawlcloud` or
-`openclaw/crawl-remote`, rather than hidden inside either app. It will need
-TypeScript, Wrangler, D1 migrations, Vitest tests, and deployment config. The
-Go apps consume it through `crawlkit`.
+The Worker should remain a separate service, `openclaw/crawl-remote`, rather
+than hidden inside either app or bundled into the Go module. `crawlkit/remote`
+owns the v1 client and protocol contract; `crawl-remote` owns TypeScript,
+Wrangler, D1 migrations, Vitest tests, secrets, and deployment cadence. The Go
+apps consume it through `crawlkit`.
 
 ## Why not direct D1 API from the CLI
 
@@ -418,6 +419,7 @@ Create a Cloudflare Worker service with:
 Suggested routes:
 
 ```text
+GET  /v1/contract
 POST /v1/auth/github/start
 GET  /v1/auth/github/callback
 POST /v1/auth/github/poll

--- a/docs/remote-contract.md
+++ b/docs/remote-contract.md
@@ -1,0 +1,37 @@
+# Remote Contract
+
+`crawlkit/remote` owns the provider-neutral client and v1 wire contract for
+hosted crawl archives. It does not own the Cloudflare Worker deployment.
+
+The current service implementation lives in `openclaw/crawl-remote`. That repo
+owns Wrangler config, D1 migrations, GitHub org/team authorization, Worker
+secrets, and deployment cadence.
+
+## Ownership
+
+| surface | owner |
+| --- | --- |
+| Go client, config, request/response structs | `crawlkit/remote` |
+| protocol version and public contract metadata | `crawlkit/remote` |
+| app CLI commands and privacy-aware publishing | downstream apps |
+| Cloudflare Worker routes and auth implementation | `openclaw/crawl-remote` |
+| D1 schema and migrations | `openclaw/crawl-remote` |
+| Wrangler deploy config and Worker secrets | `openclaw/crawl-remote` |
+
+The Worker exposes `GET /v1/contract` without authentication. Clients can use
+that route to verify protocol support before login or before publishing.
+
+## Compatibility
+
+The v1 contract is additive:
+
+- Existing JSON fields stay stable.
+- New routes, query names, app capabilities, and optional fields may be added.
+- Breaking route or field changes require a new protocol version.
+- App-specific privacy rules stay in the app or Worker implementation, not in
+  generic crawlkit SQL helpers.
+
+`remote.BaseContract()` is the SDK-side source of truth for protocol routes and
+auth role names. Service implementations add their own app-specific query names,
+ingest tables, capabilities, and privacy notes to `/v1/contract`, then run
+their own conformance tests.

--- a/remote/contract.go
+++ b/remote/contract.go
@@ -1,0 +1,125 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const (
+	ProtocolVersion = "v1"
+
+	ContractPath = "/v1/contract"
+	HealthPath   = "/health"
+
+	AuthPublic    = "public"
+	AuthReader    = "reader"
+	AuthPublisher = "publisher"
+)
+
+type Contract struct {
+	ProtocolVersion string      `json:"protocol_version"`
+	Service         string      `json:"service,omitempty"`
+	Routes          []RouteSpec `json:"routes"`
+	Apps            []AppSpec   `json:"apps"`
+	Auth            []AuthSpec  `json:"auth,omitempty"`
+	Notes           []string    `json:"notes,omitempty"`
+}
+
+type RouteSpec struct {
+	Method string `json:"method"`
+	Path   string `json:"path"`
+	Auth   string `json:"auth"`
+}
+
+type AuthSpec struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+type AppSpec struct {
+	App          string            `json:"app"`
+	Queries      []QuerySpec       `json:"queries,omitempty"`
+	IngestTables []IngestTableSpec `json:"ingest_tables,omitempty"`
+	Capabilities []string          `json:"capabilities,omitempty"`
+}
+
+type QuerySpec struct {
+	Name string   `json:"name"`
+	Args []string `json:"args,omitempty"`
+}
+
+type IngestTableSpec struct {
+	Name           string   `json:"name"`
+	Columns        []string `json:"columns"`
+	PrivacyFilters []string `json:"privacy_filters,omitempty"`
+}
+
+func BaseContract() Contract {
+	return Contract{
+		ProtocolVersion: ProtocolVersion,
+		Service:         "crawl-remote",
+		Routes: []RouteSpec{
+			{Method: http.MethodGet, Path: HealthPath, Auth: AuthPublic},
+			{Method: http.MethodGet, Path: ContractPath, Auth: AuthPublic},
+			{Method: http.MethodPost, Path: "/v1/auth/github/start", Auth: AuthPublic},
+			{Method: http.MethodGet, Path: "/v1/auth/github/callback", Auth: AuthPublic},
+			{Method: http.MethodPost, Path: "/v1/auth/github/poll", Auth: AuthPublic},
+			{Method: http.MethodPost, Path: "/v1/auth/github/token", Auth: AuthPublic},
+			{Method: http.MethodGet, Path: "/v1/whoami", Auth: AuthReader},
+			{Method: http.MethodGet, Path: "/v1/archives", Auth: AuthReader},
+			{Method: http.MethodGet, Path: "/v1/apps/:app/archives/:archive/status", Auth: AuthReader},
+			{Method: http.MethodPost, Path: "/v1/apps/:app/archives/:archive/query", Auth: AuthReader},
+			{Method: http.MethodPost, Path: "/v1/apps/:app/archives/:archive/batch-read", Auth: AuthReader},
+			{Method: http.MethodPost, Path: "/v1/apps/:app/archives/:archive/ingest", Auth: AuthPublisher},
+		},
+		Auth: []AuthSpec{
+			{Name: AuthPublic, Description: "no bearer token required"},
+			{Name: AuthReader, Description: "bearer token with reader or admin role"},
+			{Name: AuthPublisher, Description: "bearer token with publisher or admin role"},
+		},
+		Apps: []AppSpec{},
+		Notes: []string{
+			"Worker and D1 deployment live outside crawlkit; crawlkit owns the provider-neutral client and contract.",
+			"Routes and JSON fields are additive within a protocol version.",
+		},
+	}
+}
+
+func (c *Client) Contract(ctx context.Context) (Contract, error) {
+	var out Contract
+	err := c.do(ctx, http.MethodGet, ContractPath, nil, &out, false)
+	return out, err
+}
+
+func (c Contract) Validate() error {
+	if strings.TrimSpace(c.ProtocolVersion) != ProtocolVersion {
+		return fmt.Errorf("unsupported remote protocol version %q", c.ProtocolVersion)
+	}
+	if len(c.Routes) == 0 {
+		return errors.New("remote contract has no routes")
+	}
+	for _, route := range c.Routes {
+		if strings.TrimSpace(route.Method) == "" || strings.TrimSpace(route.Path) == "" {
+			return fmt.Errorf("remote contract route is incomplete: %#v", route)
+		}
+		switch strings.TrimSpace(route.Auth) {
+		case AuthPublic, AuthReader, AuthPublisher:
+		default:
+			return fmt.Errorf("remote contract route %s %s has unknown auth %q", route.Method, route.Path, route.Auth)
+		}
+	}
+	for _, app := range c.Apps {
+		if strings.TrimSpace(app.App) == "" {
+			return errors.New("remote contract app name is empty")
+		}
+		for _, table := range app.IngestTables {
+			if strings.TrimSpace(table.Name) == "" || len(table.Columns) == 0 {
+				return fmt.Errorf("remote contract app %q has incomplete ingest table %#v", app.App, table)
+			}
+		}
+	}
+	return nil
+}

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -126,6 +126,46 @@ func TestClientFromConfigUsesEnvToken(t *testing.T) {
 	}
 }
 
+func TestBaseContractValidates(t *testing.T) {
+	contract := BaseContract()
+	if err := contract.Validate(); err != nil {
+		t.Fatalf("contract validate: %v", err)
+	}
+	if contract.ProtocolVersion != ProtocolVersion {
+		t.Fatalf("protocol version = %q", contract.ProtocolVersion)
+	}
+	if !hasRoute(contract, http.MethodGet, ContractPath, AuthPublic) {
+		t.Fatalf("contract route missing")
+	}
+}
+
+func TestClientContractIsPublic(t *testing.T) {
+	var sawAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != ContractPath {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		sawAuth = r.Header.Get("authorization")
+		_ = json.NewEncoder(w).Encode(testServiceContract())
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Options{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	contract, err := client.Contract(context.Background())
+	if err != nil {
+		t.Fatalf("contract: %v", err)
+	}
+	if sawAuth != "" {
+		t.Fatalf("contract should not send authorization header, got %q", sawAuth)
+	}
+	if err := contract.Validate(); err != nil {
+		t.Fatalf("validate response: %v", err)
+	}
+}
+
 func TestChainTokenProviderSkipsNilAndUsesFirstToken(t *testing.T) {
 	t.Setenv("CRAWL_REMOTE_CHAIN_TOKEN", "chain-token")
 	provider := ChainTokenProvider{nil, EnvTokenProvider{Name: "CRAWL_REMOTE_CHAIN_TOKEN"}, StaticToken("fallback")}
@@ -195,6 +235,30 @@ func TestStaticTokenRejectsBlank(t *testing.T) {
 	if !errors.Is(err, ErrMissingToken) {
 		t.Fatalf("err = %v", err)
 	}
+}
+
+func hasRoute(contract Contract, method, path, auth string) bool {
+	for _, route := range contract.Routes {
+		if route.Method == method && route.Path == path && route.Auth == auth {
+			return true
+		}
+	}
+	return false
+}
+
+func testServiceContract() Contract {
+	contract := BaseContract()
+	contract.Apps = []AppSpec{{
+		App: "examplecrawl",
+		Queries: []QuerySpec{
+			{Name: "example.items.search", Args: []string{"query"}},
+		},
+		IngestTables: []IngestTableSpec{
+			{Name: "items", Columns: []string{"id", "title", "updated_at"}},
+		},
+		Capabilities: []string{"example.items.search"},
+	}}
+	return contract
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
## Summary
- add a provider-neutral remote protocol contract model and public contract client call
- document the crawlkit/crawl-remote ownership split
- keep app-specific Worker deployment, D1 schema, and query allowlists outside crawlkit

## Verification
- GOWORK=off go mod tidy
- git diff --exit-code -- go.mod go.sum
- GOWORK=off go vet ./...
- GOWORK=off go test -count=1 ./...