### PR TITLE
docs: update remote changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Add a `remote.Client.UploadSQLite` helper, SQLite object metadata in remote
+  status payloads, and contract metadata for publisher-side raw SQLite archive
+  uploads.
+
+## v0.9.0 - 2026-05-28
+
 - Add explicit `remote` protocol contract metadata and a public
   `Client.Contract` helper so Worker-fronted archive services can prove their
   supported routes, auth roles, query names, and ingest tables without coupling


### PR DESCRIPTION
## Summary
- add the missing v0.9.0 changelog heading for the remote contract release
- document the new remote SQLite upload API before the next crawlkit tag

## Verification
- git diff --check