### PR TITLE
feat(remote): add compressed sqlite bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Add a `remote.Client.UploadSQLite` helper, SQLite object metadata in remote
   status payloads, and contract metadata for publisher-side raw SQLite archive
   uploads.
+- Add gzip-compressed SQLite bundle manifests, chunk builders, and upload
+  helpers for R2-backed remote archive bootstrap/fallback data.
 
 ## v0.9.0 - 2026-05-28
 

--- a/remote/contract.go
+++ b/remote/contract.go
@@ -84,6 +84,7 @@ func BaseContract() Contract {
 		Apps: []AppSpec{},
 		Notes: []string{
 			"Worker and D1 deployment live outside crawlkit; crawlkit owns the provider-neutral client and contract.",
+			"SQLite upload routes may accept raw SQLite objects or gzip chunk bundle parts/manifests.",
 			"Routes and JSON fields are additive within a protocol version.",
 		},
 	}

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -199,6 +199,7 @@ type Status struct {
 	Counts       []control.Count `json:"counts,omitempty"`
 	Capabilities []string        `json:"capabilities,omitempty"`
 	SQLiteObject *SQLiteObject   `json:"sqlite_object,omitempty"`
+	SQLiteBundle *SQLiteBundle   `json:"sqlite_bundle,omitempty"`
 	Warnings     []string        `json:"warnings,omitempty"`
 }
 
@@ -279,6 +280,22 @@ type SQLiteObject struct {
 	UploadedAt  string `json:"uploaded_at,omitempty"`
 	ContentType string `json:"content_type,omitempty"`
 	SHA256      string `json:"sha256,omitempty"`
+}
+
+type SQLiteBundleUploadResult struct {
+	App      string        `json:"app,omitempty"`
+	Archive  string        `json:"archive,omitempty"`
+	Complete bool          `json:"complete,omitempty"`
+	Bundle   *SQLiteBundle `json:"bundle,omitempty"`
+}
+
+type SQLiteBundle struct {
+	Key         string                `json:"key,omitempty"`
+	Size        int64                 `json:"size,omitempty"`
+	ETag        string                `json:"etag,omitempty"`
+	UploadedAt  string                `json:"uploaded_at,omitempty"`
+	ContentType string                `json:"content_type,omitempty"`
+	Manifest    *SQLiteBundleManifest `json:"manifest,omitempty"`
 }
 
 type LoginStartRequest struct {
@@ -386,6 +403,61 @@ func (c *Client) UploadSQLite(ctx context.Context, app, archive string, upload S
 	setHeader(headers, "x-crawl-content-sha256", upload.ContentSHA256)
 	var out SQLiteUploadResult
 	err := c.doRaw(ctx, http.MethodPut, archivePath(app, archive, "sqlite"), upload.Body, upload.Size, headers, &out, true)
+	return out, err
+}
+
+func (c *Client) UploadSQLiteBundlePart(ctx context.Context, app, archive string, part SQLiteBundlePartUpload) (SQLiteUploadResult, error) {
+	if part.Body == nil {
+		return SQLiteUploadResult{}, errors.New("sqlite bundle part body is required")
+	}
+	headers := http.Header{}
+	headers.Set("content-type", "application/gzip")
+	headers.Set("x-crawl-sqlite-upload", "bundle-part")
+	headers.Set("x-crawl-bundle-part-index", fmt.Sprintf("%d", part.Index))
+	setHeader(headers, "x-crawl-content-sha256", part.SHA256)
+	setHeader(headers, "x-crawl-compression", part.Compression)
+	var out SQLiteUploadResult
+	err := c.doRaw(ctx, http.MethodPut, archivePath(app, archive, "sqlite"), part.Body, part.Size, headers, &out, true)
+	return out, err
+}
+
+func (c *Client) UploadSQLiteBundleFiles(ctx context.Context, app, archive string, manifest SQLiteBundleManifest, parts []SQLiteBundlePartFile) (SQLiteBundleUploadResult, error) {
+	for _, part := range parts {
+		file, err := os.Open(part.Path)
+		if err != nil {
+			return SQLiteBundleUploadResult{}, fmt.Errorf("open sqlite bundle part %d: %w", part.Index, err)
+		}
+		_, uploadErr := c.UploadSQLiteBundlePart(ctx, app, archive, SQLiteBundlePartUpload{
+			Index:       part.Index,
+			Body:        file,
+			Size:        part.Size,
+			SHA256:      part.SHA256,
+			Compression: SQLiteGzipCompression,
+		})
+		_ = file.Close()
+		if uploadErr != nil {
+			return SQLiteBundleUploadResult{}, uploadErr
+		}
+	}
+	return c.UploadSQLiteBundleManifest(ctx, app, archive, manifest)
+}
+
+func (c *Client) UploadSQLiteBundleManifest(ctx context.Context, app, archive string, manifest SQLiteBundleManifest) (SQLiteBundleUploadResult, error) {
+	if strings.TrimSpace(manifest.App) == "" {
+		manifest.App = strings.TrimSpace(app)
+	}
+	if strings.TrimSpace(manifest.Archive) == "" {
+		manifest.Archive = strings.TrimSpace(archive)
+	}
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(manifest); err != nil {
+		return SQLiteBundleUploadResult{}, fmt.Errorf("encode sqlite bundle manifest: %w", err)
+	}
+	headers := http.Header{}
+	headers.Set("content-type", "application/json")
+	headers.Set("x-crawl-sqlite-upload", "bundle-manifest")
+	var out SQLiteBundleUploadResult
+	err := c.doRaw(ctx, http.MethodPut, archivePath(app, archive, "sqlite"), &buf, int64(buf.Len()), headers, &out, true)
 	return out, err
 }
 

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -8,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -144,6 +146,133 @@ func TestClientUploadSQLiteSendsRawBodyAndMetadata(t *testing.T) {
 		t.Fatalf("metadata sha/schema = %q/%q", sawSHA, sawSchema)
 	}
 	if result.Object == nil || result.Object.Size != int64(len("SQLite bytes")) {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestBuildGzipSQLiteBundleSplitsAndDescribesParts(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "archive.db")
+	payload := strings.Repeat("SQLite format 3\n", 100)
+	if err := os.WriteFile(source, []byte(payload), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	bundle, err := BuildGzipSQLiteBundle(context.Background(), SQLiteBundleBuildOptions{
+		App:        "gitcrawl",
+		Archive:    "gitcrawl/openclaw__openclaw",
+		SourcePath: source,
+		WorkDir:    dir,
+		ChunkSize:  64,
+		Counts:     map[string]int64{"threads": 3},
+	})
+	if err != nil {
+		t.Fatalf("build bundle: %v", err)
+	}
+	defer bundle.Cleanup()
+	if bundle.Manifest.Format != SQLiteGzipChunkedBundleFormat {
+		t.Fatalf("format = %q", bundle.Manifest.Format)
+	}
+	if bundle.Manifest.Compression.Algorithm != SQLiteGzipCompression {
+		t.Fatalf("compression = %#v", bundle.Manifest.Compression)
+	}
+	if bundle.Manifest.Object.Size != int64(len(payload)) || bundle.Manifest.Object.SHA256 == "" {
+		t.Fatalf("object = %#v", bundle.Manifest.Object)
+	}
+	if bundle.Manifest.CompressedObject.Size <= 0 || bundle.Manifest.CompressedObject.SHA256 == "" {
+		t.Fatalf("compressed object = %#v", bundle.Manifest.CompressedObject)
+	}
+	if len(bundle.Parts) < 1 || len(bundle.Manifest.Parts) != len(bundle.Parts) {
+		t.Fatalf("parts = %#v manifest=%#v", bundle.Parts, bundle.Manifest.Parts)
+	}
+	var compressed strings.Builder
+	for _, part := range bundle.Parts {
+		bytes, err := os.ReadFile(part.Path)
+		if err != nil {
+			t.Fatalf("read part: %v", err)
+		}
+		compressed.Write(bytes)
+		if !strings.Contains(part.Key, "current.db.gz.part-") {
+			t.Fatalf("part key = %q", part.Key)
+		}
+	}
+	reader, err := gzip.NewReader(strings.NewReader(compressed.String()))
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	decompressed, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("decompress: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	if string(decompressed) != payload {
+		t.Fatalf("decompressed payload mismatch")
+	}
+}
+
+func TestClientUploadSQLiteBundleFilesUploadsPartsThenManifest(t *testing.T) {
+	dir := t.TempDir()
+	partPath := filepath.Join(dir, "part")
+	if err := os.WriteFile(partPath, []byte("compressed"), 0o600); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+	var uploads []string
+	var sawManifest bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uploads = append(uploads, r.Header.Get("x-crawl-sqlite-upload"))
+		switch r.Header.Get("x-crawl-sqlite-upload") {
+		case "bundle-part":
+			if r.Header.Get("x-crawl-bundle-part-index") != "0" || r.Header.Get("content-type") != "application/gzip" {
+				t.Fatalf("part headers index=%q content-type=%q", r.Header.Get("x-crawl-bundle-part-index"), r.Header.Get("content-type"))
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read part body: %v", err)
+			}
+			if string(body) != "compressed" {
+				t.Fatalf("part body = %q", body)
+			}
+			_ = json.NewEncoder(w).Encode(SQLiteUploadResult{Complete: true})
+		case "bundle-manifest":
+			sawManifest = true
+			var manifest SQLiteBundleManifest
+			if err := json.NewDecoder(r.Body).Decode(&manifest); err != nil {
+				t.Fatalf("decode manifest: %v", err)
+			}
+			if manifest.Format != SQLiteGzipChunkedBundleFormat {
+				t.Fatalf("manifest = %#v", manifest)
+			}
+			_ = json.NewEncoder(w).Encode(SQLiteBundleUploadResult{
+				App:      "gitcrawl",
+				Archive:  "gitcrawl/openclaw__openclaw",
+				Complete: true,
+				Bundle:   &SQLiteBundle{Key: SQLiteBundleManifestKey("gitcrawl", "gitcrawl/openclaw__openclaw"), Manifest: &manifest},
+			})
+		default:
+			t.Fatalf("unexpected upload kind %q", r.Header.Get("x-crawl-sqlite-upload"))
+		}
+	}))
+	defer server.Close()
+	client, err := NewClient(Options{Endpoint: server.URL, TokenProvider: StaticToken("secret"), UserAgent: "test-agent"})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	result, err := client.UploadSQLiteBundleFiles(context.Background(), "gitcrawl", "gitcrawl/openclaw__openclaw", SQLiteBundleManifest{
+		Format:  SQLiteGzipChunkedBundleFormat,
+		App:     "gitcrawl",
+		Archive: "gitcrawl/openclaw__openclaw",
+	}, []SQLiteBundlePartFile{{
+		SQLiteBundlePart: SQLiteBundlePart{Index: 0, Size: int64(len("compressed")), SHA256: "part-sha"},
+		Path:             partPath,
+	}})
+	if err != nil {
+		t.Fatalf("upload bundle files: %v", err)
+	}
+	if !sawManifest || len(uploads) != 2 || uploads[0] != "bundle-part" || uploads[1] != "bundle-manifest" {
+		t.Fatalf("uploads = %#v sawManifest=%v", uploads, sawManifest)
+	}
+	if result.Bundle == nil || result.Bundle.Manifest == nil {
 		t.Fatalf("result = %#v", result)
 	}
 }

--- a/remote/sqlite_bundle.go
+++ b/remote/sqlite_bundle.go
@@ -1,0 +1,297 @@
+package remote
+
+import (
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	SQLiteGzipChunkedBundleFormat = "sqlite-gzip-chunked-v1"
+	SQLiteGzipCompression         = "gzip"
+	DefaultSQLiteBundleChunkSize  = int64(256 * 1024 * 1024)
+)
+
+type SQLiteBundleObject struct {
+	Key    string `json:"key,omitempty"`
+	Size   int64  `json:"size,omitempty"`
+	SHA256 string `json:"sha256,omitempty"`
+}
+
+type SQLiteBundleCompression struct {
+	Algorithm string `json:"algorithm,omitempty"`
+}
+
+type SQLiteBundlePart struct {
+	Index  int    `json:"index"`
+	Key    string `json:"key,omitempty"`
+	Size   int64  `json:"size,omitempty"`
+	SHA256 string `json:"sha256,omitempty"`
+}
+
+type SQLiteBundleManifest struct {
+	Format           string                  `json:"format"`
+	App              string                  `json:"app"`
+	Archive          string                  `json:"archive"`
+	GeneratedAt      string                  `json:"generated_at,omitempty"`
+	ContentType      string                  `json:"content_type,omitempty"`
+	Compression      SQLiteBundleCompression `json:"compression,omitempty"`
+	Privacy          map[string]any          `json:"privacy,omitempty"`
+	Object           SQLiteBundleObject      `json:"object"`
+	CompressedObject SQLiteBundleObject      `json:"compressed_object"`
+	Reconstruct      string                  `json:"reconstruct,omitempty"`
+	Counts           map[string]int64        `json:"counts,omitempty"`
+	Parts            []SQLiteBundlePart      `json:"parts"`
+}
+
+type SQLiteBundlePartFile struct {
+	SQLiteBundlePart
+	Path string
+}
+
+type SQLiteBundleBuild struct {
+	Manifest       SQLiteBundleManifest
+	CompressedPath string
+	Parts          []SQLiteBundlePartFile
+	Cleanup        func()
+}
+
+type SQLiteBundleBuildOptions struct {
+	App              string
+	Archive          string
+	SourcePath       string
+	WorkDir          string
+	ChunkSize        int64
+	CompressionLevel int
+	GeneratedAt      time.Time
+	ContentType      string
+	Privacy          map[string]any
+	Counts           map[string]int64
+}
+
+type SQLiteBundlePartUpload struct {
+	Index       int
+	Body        io.Reader
+	Size        int64
+	SHA256      string
+	Compression string
+}
+
+func BuildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions) (SQLiteBundleBuild, error) {
+	if opts.SourcePath == "" {
+		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle source path is required")
+	}
+	sourceInfo, err := os.Stat(opts.SourcePath)
+	if err != nil {
+		return SQLiteBundleBuild{}, fmt.Errorf("stat sqlite bundle source: %w", err)
+	}
+	chunkSize := opts.ChunkSize
+	if chunkSize <= 0 {
+		chunkSize = DefaultSQLiteBundleChunkSize
+	}
+	level := opts.CompressionLevel
+	if level == 0 {
+		level = gzip.DefaultCompression
+	}
+	generatedAt := opts.GeneratedAt
+	if generatedAt.IsZero() {
+		generatedAt = time.Now().UTC()
+	}
+	contentType := opts.ContentType
+	if contentType == "" {
+		contentType = "application/vnd.sqlite3"
+	}
+	tmpDir, err := os.MkdirTemp(opts.WorkDir, "crawl-sqlite-bundle-*")
+	if err != nil {
+		return SQLiteBundleBuild{}, fmt.Errorf("create sqlite bundle dir: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(tmpDir) }
+	compressedPath := filepath.Join(tmpDir, "current.db.gz")
+	if err := gzipFile(ctx, opts.SourcePath, compressedPath, level); err != nil {
+		cleanup()
+		return SQLiteBundleBuild{}, err
+	}
+	sourceSHA, err := fileSHA256(ctx, opts.SourcePath)
+	if err != nil {
+		cleanup()
+		return SQLiteBundleBuild{}, err
+	}
+	compressedInfo, err := os.Stat(compressedPath)
+	if err != nil {
+		cleanup()
+		return SQLiteBundleBuild{}, fmt.Errorf("stat compressed sqlite bundle: %w", err)
+	}
+	compressedSHA, err := fileSHA256(ctx, compressedPath)
+	if err != nil {
+		cleanup()
+		return SQLiteBundleBuild{}, err
+	}
+	parts, err := splitBundleParts(ctx, compressedPath, tmpDir, opts.App, opts.Archive, chunkSize)
+	if err != nil {
+		cleanup()
+		return SQLiteBundleBuild{}, err
+	}
+	manifestParts := make([]SQLiteBundlePart, len(parts))
+	for i, part := range parts {
+		manifestParts[i] = part.SQLiteBundlePart
+	}
+	manifest := SQLiteBundleManifest{
+		Format:      SQLiteGzipChunkedBundleFormat,
+		App:         opts.App,
+		Archive:     opts.Archive,
+		GeneratedAt: generatedAt.Format(time.RFC3339Nano),
+		ContentType: contentType,
+		Compression: SQLiteBundleCompression{
+			Algorithm: SQLiteGzipCompression,
+		},
+		Privacy: opts.Privacy,
+		Object: SQLiteBundleObject{
+			Key:    SQLiteObjectKey(opts.App, opts.Archive),
+			Size:   sourceInfo.Size(),
+			SHA256: sourceSHA,
+		},
+		CompressedObject: SQLiteBundleObject{
+			Key:    SQLiteCompressedObjectKey(opts.App, opts.Archive),
+			Size:   compressedInfo.Size(),
+			SHA256: compressedSHA,
+		},
+		Reconstruct: "concatenate parts in index order to current.db.gz, then gzip-decompress to current.db",
+		Counts:      opts.Counts,
+		Parts:       manifestParts,
+	}
+	return SQLiteBundleBuild{
+		Manifest:       manifest,
+		CompressedPath: compressedPath,
+		Parts:          parts,
+		Cleanup:        cleanup,
+	}, nil
+}
+
+func SQLiteObjectKey(app, archive string) string {
+	return fmt.Sprintf("v1/%s/%s/sqlite/current.db", url.PathEscape(app), url.PathEscape(archive))
+}
+
+func SQLiteCompressedObjectKey(app, archive string) string {
+	return fmt.Sprintf("v1/%s/%s/sqlite/current.db.gz", url.PathEscape(app), url.PathEscape(archive))
+}
+
+func SQLiteBundleManifestKey(app, archive string) string {
+	return fmt.Sprintf("v1/%s/%s/sqlite/current.manifest.json", url.PathEscape(app), url.PathEscape(archive))
+}
+
+func SQLiteBundlePartKey(app, archive string, index int) string {
+	return fmt.Sprintf("v1/%s/%s/sqlite/chunks/current.db.gz.part-%04d", url.PathEscape(app), url.PathEscape(archive), index)
+}
+
+func gzipFile(ctx context.Context, sourcePath, targetPath string, level int) error {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return fmt.Errorf("open sqlite bundle source: %w", err)
+	}
+	defer func() { _ = source.Close() }()
+	target, err := os.OpenFile(targetPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("create compressed sqlite bundle: %w", err)
+	}
+	defer func() { _ = target.Close() }()
+	gzw, err := gzip.NewWriterLevel(target, level)
+	if err != nil {
+		return fmt.Errorf("create gzip writer: %w", err)
+	}
+	if err := copyWithContext(ctx, gzw, source); err != nil {
+		_ = gzw.Close()
+		return fmt.Errorf("compress sqlite bundle: %w", err)
+	}
+	if err := gzw.Close(); err != nil {
+		return fmt.Errorf("finish compressed sqlite bundle: %w", err)
+	}
+	return nil
+}
+
+func splitBundleParts(ctx context.Context, sourcePath, dir, app, archive string, chunkSize int64) ([]SQLiteBundlePartFile, error) {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return nil, fmt.Errorf("open compressed sqlite bundle: %w", err)
+	}
+	defer func() { _ = source.Close() }()
+	var parts []SQLiteBundlePartFile
+	for index := 0; ; index++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		partPath := filepath.Join(dir, fmt.Sprintf("current.db.gz.part-%04d", index))
+		partFile, err := os.OpenFile(partPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+		if err != nil {
+			return nil, fmt.Errorf("create sqlite bundle part: %w", err)
+		}
+		hash := sha256.New()
+		written, copyErr := io.CopyN(io.MultiWriter(partFile, hash), source, chunkSize)
+		closeErr := partFile.Close()
+		if copyErr != nil && copyErr != io.EOF {
+			return nil, fmt.Errorf("write sqlite bundle part: %w", copyErr)
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("close sqlite bundle part: %w", closeErr)
+		}
+		if written == 0 && copyErr == io.EOF {
+			_ = os.Remove(partPath)
+			break
+		}
+		parts = append(parts, SQLiteBundlePartFile{
+			SQLiteBundlePart: SQLiteBundlePart{
+				Index:  index,
+				Key:    SQLiteBundlePartKey(app, archive, index),
+				Size:   written,
+				SHA256: fmt.Sprintf("%x", hash.Sum(nil)),
+			},
+			Path: partPath,
+		})
+		if copyErr == io.EOF {
+			break
+		}
+	}
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("compressed sqlite bundle is empty")
+	}
+	return parts, nil
+}
+
+func fileSHA256(ctx context.Context, path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open file for sha256: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	hash := sha256.New()
+	if err := copyWithContext(ctx, hash, file); err != nil {
+		return "", fmt.Errorf("hash file: %w", err)
+	}
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
+func copyWithContext(ctx context.Context, dst io.Writer, src io.Reader) error {
+	buf := make([]byte, 1024*1024)
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		n, readErr := src.Read(buf)
+		if n > 0 {
+			if _, err := dst.Write(buf[:n]); err != nil {
+				return err
+			}
+		}
+		if readErr == io.EOF {
+			return nil
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add gzip chunk bundle manifest/build helpers for SQLite archive snapshots
- add remote client helpers for uploading bundle parts and manifests through the existing sqlite route
- expose sqlite bundle metadata in remote status payloads

## Validation
- `GOWORK=off go mod tidy`
- `git diff --exit-code -- go.mod go.sum`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test -count=1 ./...`
