### PR TITLE
feat(vector): add turbovec search backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add shared `vector.Search` backends, including the existing exact cosine
+  scorer and an optional Python `turbovec` bridge for downstream semantic
+  search over dimensions divisible by 8 up to 8,192. Thanks @vincentkoc.
 - Add a `remote.Client.UploadSQLite` helper, SQLite object metadata in remote
   status payloads, and contract metadata for publisher-side raw SQLite archive
   uploads.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See `docs/boundary.md` for the crawlkit-versus-app ownership boundary and
 - `mirror`: clone/init/pull/commit/push helpers for private snapshot repos.
 - `state`: generic crawler cursor and freshness records.
 - `embed`: reusable OpenAI-compatible, Ollama, and llama.cpp embedding providers plus local probe diagnostics.
-- `vector`: float32 vector encoding, dimension validation, cosine scoring, top-k helpers, and reciprocal-rank fusion.
+- `vector`: float32 vector encoding, dimension validation, exact cosine search, optional turbovec-backed search for dimensions divisible by 8 up to 8,192, top-k helpers, and reciprocal-rank fusion.
 - `releasecheck`: GitHub release checks, 24-hour cache handling, scripted-output
   suppression, and stderr update notice formatting for crawl app CLIs.
 - `remote`: provider-neutral HTTP client, config, query, ingest, auth, status,

--- a/vector/search.go
+++ b/vector/search.go
@@ -1,0 +1,153 @@
+package vector
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+)
+
+type InvalidVectorPolicy string
+
+const (
+	InvalidVectorError InvalidVectorPolicy = "error"
+	InvalidVectorSkip  InvalidVectorPolicy = "skip"
+)
+
+type SearchCandidate[T any] struct {
+	Item   T
+	Vector []float32
+}
+
+type SearchResult[T any] struct {
+	Item  T
+	Score float64
+}
+
+type SearchOptions[T any] struct {
+	Backend       SearchBackend
+	Limit         int
+	MinScore      *float64
+	Exclude       func(T) bool
+	TieLess       func(left, right T) bool
+	InvalidVector InvalidVectorPolicy
+	TurboVec      TurboVecOptions
+}
+
+func Search[T any](ctx context.Context, query []float32, candidates []SearchCandidate[T], opts SearchOptions[T]) ([]SearchResult[T], error) {
+	if opts.Limit <= 0 {
+		opts.Limit = 20
+	}
+	backend := SearchBackend(strings.ToLower(strings.TrimSpace(string(opts.Backend))))
+	if backend == "" {
+		backend = BackendExact
+	}
+	if err := validateSearchVector(query, len(query), "query", true); err != nil {
+		return nil, err
+	}
+	filtered := filterCandidates(candidates, opts.Exclude)
+	switch backend {
+	case BackendExact:
+		return exactSearch(ctx, query, filtered, opts)
+	case BackendTurboVec:
+		return turboVecSearch(ctx, query, filtered, opts)
+	default:
+		return nil, fmt.Errorf("unsupported vector backend %q", opts.Backend)
+	}
+}
+
+func filterCandidates[T any](candidates []SearchCandidate[T], exclude func(T) bool) []SearchCandidate[T] {
+	if exclude == nil {
+		return candidates
+	}
+	out := make([]SearchCandidate[T], 0, len(candidates))
+	for _, candidate := range candidates {
+		if exclude(candidate.Item) {
+			continue
+		}
+		out = append(out, candidate)
+	}
+	return out
+}
+
+func exactSearch[T any](ctx context.Context, query []float32, candidates []SearchCandidate[T], opts SearchOptions[T]) ([]SearchResult[T], error) {
+	queryNorm := Norm(query)
+	scored := make([]Scored[SearchResult[T]], 0, len(candidates))
+	for _, candidate := range candidates {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := validateSearchVector(candidate.Vector, len(query), "candidate", true); err != nil {
+			if opts.InvalidVector == InvalidVectorSkip {
+				continue
+			}
+			return nil, err
+		}
+		score, err := CosineSimilarity(query, queryNorm, candidate.Vector)
+		if err != nil {
+			if opts.InvalidVector == InvalidVectorSkip {
+				continue
+			}
+			return nil, err
+		}
+		if !validScore(score, opts.MinScore) {
+			continue
+		}
+		result := SearchResult[T]{Item: candidate.Item, Score: score}
+		scored = append(scored, Scored[SearchResult[T]]{Item: result, Score: score})
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	top := TopK(scored, opts.Limit, func(left, right SearchResult[T]) bool {
+		if opts.TieLess == nil {
+			return false
+		}
+		return opts.TieLess(left.Item, right.Item)
+	})
+	out := make([]SearchResult[T], len(top))
+	for i, item := range top {
+		out[i] = item.Item
+	}
+	return out, nil
+}
+
+func validateSearchVector(values []float32, dimensions int, name string, requireNonZero bool) error {
+	if len(values) == 0 {
+		return fmt.Errorf("%s vector is empty", name)
+	}
+	if err := ValidateDimensions(values, dimensions); err != nil {
+		return err
+	}
+	var sum float64
+	for i, value := range values {
+		if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+			return fmt.Errorf("%s vector contains non-finite value at index %d", name, i)
+		}
+		sum += float64(value) * float64(value)
+	}
+	if requireNonZero && sum == 0 {
+		return fmt.Errorf("%s vector is zero", name)
+	}
+	return nil
+}
+
+func validScore(score float64, minScore *float64) bool {
+	if math.IsNaN(score) || math.IsInf(score, 0) {
+		return false
+	}
+	return minScore == nil || score >= *minScore
+}
+
+func sortSearchResults[T any](results []SearchResult[T], tieLess func(left, right T) bool) {
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].Score != results[j].Score {
+			return results[i].Score > results[j].Score
+		}
+		if tieLess == nil {
+			return false
+		}
+		return tieLess(results[i].Item, results[j].Item)
+	})
+}

--- a/vector/search_test.go
+++ b/vector/search_test.go
@@ -1,0 +1,314 @@
+package vector
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSearchExact(t *testing.T) {
+	minScore := 0.01
+	results, err := Search(t.Context(), []float32{1, 0}, []SearchCandidate[string]{
+		{Item: "b", Vector: []float32{0.5, 0}},
+		{Item: "a", Vector: []float32{0.5, 0}},
+		{Item: "c", Vector: []float32{0, 1}},
+		{Item: "excluded", Vector: []float32{1, 0}},
+		{Item: "bad-dim", Vector: []float32{1}},
+		{Item: "bad-zero", Vector: []float32{0, 0}},
+		{Item: "bad-float", Vector: []float32{float32(math.NaN()), 0}},
+	}, SearchOptions[string]{
+		Limit:         2,
+		MinScore:      &minScore,
+		Exclude:       func(value string) bool { return value == "excluded" },
+		TieLess:       func(left, right string) bool { return left < right },
+		InvalidVector: InvalidVectorSkip,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []SearchResult[string]{
+		{Item: "a", Score: 1},
+		{Item: "b", Score: 1},
+	}, results)
+}
+
+func TestSearchExactErrorsOnInvalidCandidateByDefault(t *testing.T) {
+	_, err := Search(t.Context(), []float32{1, 0}, []SearchCandidate[string]{
+		{Item: "bad", Vector: []float32{1}},
+	}, SearchOptions[string]{})
+	require.ErrorContains(t, err, "dimensions mismatch")
+}
+
+func TestSearchRejectsInvalidQuery(t *testing.T) {
+	_, err := Search(t.Context(), nil, nil, SearchOptions[string]{})
+	require.ErrorContains(t, err, "query vector is empty")
+	_, err = Search(t.Context(), []float32{0, 0}, nil, SearchOptions[string]{})
+	require.ErrorContains(t, err, "query vector is zero")
+	_, err = Search(t.Context(), []float32{float32(math.Inf(1)), 0}, nil, SearchOptions[string]{})
+	require.ErrorContains(t, err, "non-finite")
+}
+
+func TestSearchExactHonorsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := Search(ctx, []float32{1, 0}, []SearchCandidate[string]{
+		{Item: "first", Vector: []float32{1, 0}},
+	}, SearchOptions[string]{})
+	require.ErrorContains(t, err, context.Canceled.Error())
+}
+
+func TestSearchTurboVecHonorsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := Search(ctx, []float32{1, 0, 0, 0, 0, 0, 0, 0}, nil, SearchOptions[string]{
+		Backend: BackendTurboVec,
+	})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestSearchTurboVecBridge(t *testing.T) {
+	t.Setenv("CRAWLKIT_TEST_TURBOVEC_HELPER", "normal")
+	results, err := Search(t.Context(), []float32{2, 0, 0, 0, 0, 0, 0, 0}, []SearchCandidate[string]{
+		{Item: "first", Vector: []float32{100, 0, 0, 0, 0, 0, 0, 0}},
+		{Item: "second", Vector: []float32{80, 20, 0, 0, 0, 0, 0, 0}},
+	}, SearchOptions[string]{
+		Backend: BackendTurboVec,
+		Limit:   2,
+		TurboVec: TurboVecOptions{
+			Command: []string{os.Args[0], "-test.run=TestTurboVecHelperProcess", "--"},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []SearchResult[string]{
+		{Item: "second", Score: 0.9},
+		{Item: "first", Score: 0.8},
+	}, results)
+
+	_, err = Search(t.Context(), []float32{2, 0, 0, 0, 0, 0, 0, 0}, []SearchCandidate[string]{
+		{Item: "first", Vector: []float32{100, 0, 0, 0, 0, 0, 0, 0}},
+	}, SearchOptions[string]{
+		Backend: BackendTurboVec,
+		Limit:   1,
+		TurboVec: TurboVecOptions{
+			BitWidth: 3,
+			Command:  []string{os.Args[0], "-test.run=TestTurboVecHelperProcess", "--"},
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestSearchTurboVecSortsAndBreaksTies(t *testing.T) {
+	t.Setenv("CRAWLKIT_TEST_TURBOVEC_HELPER", "unsorted")
+	results, err := Search(t.Context(), []float32{1, 0, 0, 0, 0, 0, 0, 0}, []SearchCandidate[string]{
+		{Item: "b", Vector: []float32{1, 0, 0, 0, 0, 0, 0, 0}},
+		{Item: "a", Vector: []float32{0.9, 0.1, 0, 0, 0, 0, 0, 0}},
+		{Item: "c", Vector: []float32{0.8, 0.2, 0, 0, 0, 0, 0, 0}},
+	}, SearchOptions[string]{
+		Backend: BackendTurboVec,
+		Limit:   2,
+		TieLess: func(left, right string) bool { return left < right },
+		TurboVec: TurboVecOptions{
+			Command: []string{os.Args[0], "-test.run=TestTurboVecHelperProcess", "--"},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []SearchResult[string]{
+		{Item: "a", Score: 1},
+		{Item: "b", Score: 1},
+	}, results)
+}
+
+func TestSearchTurboVecRejectsBadBridgeResults(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want string
+	}{
+		{name: "duplicate", want: "duplicate"},
+		{name: "out-of-range", want: "outside"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CRAWLKIT_TEST_TURBOVEC_HELPER", tc.name)
+			_, err := Search(t.Context(), []float32{1, 0, 0, 0, 0, 0, 0, 0}, []SearchCandidate[string]{
+				{Item: "first", Vector: []float32{1, 0, 0, 0, 0, 0, 0, 0}},
+				{Item: "second", Vector: []float32{0.8, 0.2, 0, 0, 0, 0, 0, 0}},
+			}, SearchOptions[string]{
+				Backend: BackendTurboVec,
+				Limit:   2,
+				TurboVec: TurboVecOptions{
+					Command: []string{os.Args[0], "-test.run=TestTurboVecHelperProcess", "--"},
+				},
+			})
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
+}
+
+func TestSearchTurboVecRejectsUnsupportedDimensions(t *testing.T) {
+	_, err := Search(t.Context(), []float32{1, 0}, []SearchCandidate[string]{
+		{Item: "first", Vector: []float32{1, 0}},
+	}, SearchOptions[string]{Backend: BackendTurboVec})
+	require.ErrorContains(t, err, "positive multiple of 8")
+
+	tooWide := make([]float32, MaxTurboVecDimensions+8)
+	tooWide[0] = 1
+	_, err = Search(t.Context(), tooWide, []SearchCandidate[string]{
+		{Item: "first", Vector: tooWide},
+	}, SearchOptions[string]{Backend: BackendTurboVec})
+	require.ErrorContains(t, err, "<= 8192")
+}
+
+func TestRunTurboVecLimitsAndErrors(t *testing.T) {
+	_, err := runTurboVec(t.Context(), TurboVecOptions{Command: []string{os.Args[0], "-test.run=TestTurboVecHelperProcess", "--"}, MaxInputBytes: 10}, turboVecRequest{
+		Dimensions: 8,
+		BitWidth:   4,
+		Limit:      1,
+		Query:      []float32{1, 0, 0, 0, 0, 0, 0, 0},
+		Vectors:    [][]float32{{1, 0, 0, 0, 0, 0, 0, 0}},
+	})
+	require.ErrorContains(t, err, "over max")
+
+	_, err = runTurboVec(t.Context(), TurboVecOptions{Command: []string{os.Args[0], "-test.run=TestTurboVecHelperProcess", "--"}, MaxOutputBytes: 10}, turboVecRequest{
+		Dimensions: 8,
+		BitWidth:   4,
+		Limit:      1,
+		Query:      []float32{1, 0, 0, 0, 0, 0, 0, 0},
+		Vectors:    [][]float32{{1, 0, 0, 0, 0, 0, 0, 0}},
+	})
+	require.ErrorContains(t, err, "response estimate")
+
+	t.Setenv("CRAWLKIT_TEST_TURBOVEC_HELPER", "sleep")
+	_, err = runTurboVec(t.Context(), TurboVecOptions{Timeout: time.Millisecond, Command: []string{os.Args[0], "-test.run=TestTurboVecHelperProcess", "--"}}, turboVecRequest{
+		Dimensions: 8,
+		BitWidth:   4,
+		Limit:      1,
+		Query:      []float32{1, 0, 0, 0, 0, 0, 0, 0},
+		Vectors:    [][]float32{{1, 0, 0, 0, 0, 0, 0, 0}},
+	})
+	require.ErrorContains(t, err, "timed out")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	_, err = runTurboVec(t.Context(), TurboVecOptions{Command: []string{"/path/to/missing/turbovec-helper"}}, turboVecRequest{})
+	require.ErrorContains(t, err, "run turbovec bridge")
+}
+
+func TestTurboVecDefaultCommandUsesSafePythonMode(t *testing.T) {
+	command, defaultCommand, err := turboVecCommand(TurboVecOptions{Python: "/usr/bin/python3"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"/usr/bin/python3", "-E", "-c", turboVecBridgeScript}, command)
+	require.Equal(t, true, defaultCommand)
+}
+
+func TestTurboVecCommandResolvesRelativePythonBeforeWorkingDirChange(t *testing.T) {
+	dir := t.TempDir()
+	python := filepath.Join(dir, "python")
+	if err := os.WriteFile(python, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatalf("write python shim: %v", err)
+	}
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	}()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	command, defaultCommand, err := turboVecCommand(TurboVecOptions{Python: "./python"})
+	require.NoError(t, err)
+	wantPython, err := filepath.EvalSymlinks(python)
+	require.NoError(t, err)
+	gotPython, err := filepath.EvalSymlinks(command[0])
+	require.NoError(t, err)
+	require.Equal(t, wantPython, gotPython)
+	require.Equal(t, []string{"-E", "-c", turboVecBridgeScript}, command[1:])
+	require.Equal(t, true, defaultCommand)
+}
+
+func TestTurboVecTieLessRequiresBoundedCandidateSet(t *testing.T) {
+	candidates := make([]SearchCandidate[string], turboVecMaxTieCandidates+1)
+	for i := range candidates {
+		candidates[i] = SearchCandidate[string]{Item: "item", Vector: []float32{1, 0, 0, 0, 0, 0, 0, 0}}
+	}
+	_, err := Search(t.Context(), []float32{1, 0, 0, 0, 0, 0, 0, 0}, candidates, SearchOptions[string]{
+		Backend: BackendTurboVec,
+		Limit:   2,
+		TieLess: func(left, right string) bool { return left < right },
+	})
+	require.ErrorContains(t, err, "TieLess requires fetching all")
+}
+
+func TestSearchTurboVecRealPython(t *testing.T) {
+	if os.Getenv("CRAWLKIT_TURBOVEC_INTEGRATION") != "1" {
+		t.Skip("set CRAWLKIT_TURBOVEC_INTEGRATION=1 with turbovec installed")
+	}
+	results, err := Search(t.Context(), []float32{1, 0, 0, 0, 0, 0, 0, 0}, []SearchCandidate[string]{
+		{Item: "first", Vector: []float32{1, 0, 0, 0, 0, 0, 0, 0}},
+		{Item: "second", Vector: []float32{0.8, 0.2, 0, 0, 0, 0, 0, 0}},
+		{Item: "third", Vector: []float32{0, 1, 0, 0, 0, 0, 0, 0}},
+	}, SearchOptions[string]{Backend: BackendTurboVec, Limit: 2})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	require.Equal(t, "first", results[0].Item)
+	require.Equal(t, "second", results[1].Item)
+}
+
+func TestTurboVecHelperProcess(t *testing.T) {
+	mode := os.Getenv("CRAWLKIT_TEST_TURBOVEC_HELPER")
+	if mode == "" {
+		return
+	}
+	defer os.Exit(0)
+	if mode == "sleep" {
+		time.Sleep(time.Second)
+	}
+
+	var request turboVecRequest
+	if err := json.NewDecoder(os.Stdin).Decode(&request); err != nil {
+		panic(err)
+	}
+	if request.Dimensions != 8 || (request.BitWidth != 3 && request.BitWidth != 4) || request.Limit < 1 || len(request.Vectors) < 1 {
+		panic("unexpected turbovec request")
+	}
+	requireUnitVector(request.Query)
+	for _, vector := range request.Vectors {
+		requireUnitVector(vector)
+	}
+	response := turboVecResponse{}
+	switch mode {
+	case "normal", "sleep":
+		if len(request.Vectors) == 1 {
+			response.Results = []turboVecResult{{Index: 0, Score: 0.9}}
+		} else {
+			response.Results = []turboVecResult{{Index: 1, Score: 0.9}, {Index: 0, Score: 0.8}}
+		}
+	case "unsorted":
+		response.Results = []turboVecResult{{Index: 2, Score: 0.2}, {Index: 1, Score: 1}, {Index: 0, Score: 1}}
+	case "duplicate":
+		response.Results = []turboVecResult{{Index: 0, Score: 1}, {Index: 0, Score: 0.9}}
+	case "out-of-range":
+		response.Results = []turboVecResult{{Index: 99, Score: 1}}
+	default:
+		panic("unknown helper mode")
+	}
+	if len(response.Results) > request.Limit {
+		response.Results = response.Results[:request.Limit]
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(response); err != nil {
+		panic(err)
+	}
+}
+
+func requireUnitVector(values []float32) {
+	norm := Norm(values)
+	if math.Abs(norm-1) > 0.0001 {
+		panic("expected unit vector")
+	}
+	for _, value := range values {
+		if value <= -1e16 || value >= 1e16 {
+			panic("turbovec payload magnitude too large")
+		}
+	}
+}

--- a/vector/turbovec.go
+++ b/vector/turbovec.go
@@ -1,0 +1,431 @@
+package vector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+const (
+	TurboVecPythonEnv           = "CRAWLKIT_TURBOVEC_PYTHON"
+	DefaultTurboVecBitWidth     = 4
+	DefaultTurboVecTimeout      = 30 * time.Second
+	DefaultTurboVecMaxInputSize = int64(64 << 20)
+	DefaultTurboVecMaxOutput    = int64(4 << 20)
+	MaxTurboVecDimensions       = 8192
+	turboVecMaxTieCandidates    = 16 * 1024
+)
+
+type TurboVecOptions struct {
+	BitWidth       int
+	Command        []string
+	Python         string
+	Timeout        time.Duration
+	MaxInputBytes  int64
+	MaxOutputBytes int64
+}
+
+type turboVecRequest struct {
+	Dimensions int         `json:"dimensions"`
+	BitWidth   int         `json:"bit_width"`
+	Limit      int         `json:"limit"`
+	Query      []float32   `json:"query"`
+	Vectors    [][]float32 `json:"vectors"`
+}
+
+type turboVecResponse struct {
+	Results []turboVecResult `json:"results"`
+}
+
+type turboVecResult struct {
+	Index int     `json:"index"`
+	Score float64 `json:"score"`
+}
+
+func turboVecSearch[T any](ctx context.Context, query []float32, candidates []SearchCandidate[T], opts SearchOptions[T]) ([]SearchResult[T], error) {
+	if len(query)%8 != 0 {
+		return nil, fmt.Errorf("turbovec dimensions must be a positive multiple of 8, got %d", len(query))
+	}
+	if len(query) > MaxTurboVecDimensions {
+		return nil, fmt.Errorf("turbovec dimensions must be <= %d, got %d", MaxTurboVecDimensions, len(query))
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	indexed := make([]SearchCandidate[T], 0, len(candidates))
+	vectors := make([][]float32, 0, len(candidates))
+	for _, candidate := range candidates {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := validateSearchVector(candidate.Vector, len(query), "candidate", true); err != nil {
+			if opts.InvalidVector == InvalidVectorSkip {
+				continue
+			}
+			return nil, err
+		}
+		indexed = append(indexed, candidate)
+		vectors = append(vectors, candidate.Vector)
+	}
+	if len(vectors) == 0 {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+	maxInput := effectiveTurboVecMaxInput(opts.TurboVec.MaxInputBytes)
+	if err := preflightTurboVecInput(len(query), len(vectors), maxInput); err != nil {
+		return nil, err
+	}
+	bridgeQuery := normalizeVector(query)
+	bridgeVectors := make([][]float32, len(vectors))
+	for i, vector := range vectors {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		bridgeVectors[i] = normalizeVector(vector)
+	}
+	if err := validateTurboVecPayloadVector(bridgeQuery, "query"); err != nil {
+		return nil, err
+	}
+	for i, vector := range bridgeVectors {
+		if err := validateTurboVecPayloadVector(vector, fmt.Sprintf("candidate %d", i)); err != nil {
+			return nil, err
+		}
+	}
+	bitWidth := opts.TurboVec.BitWidth
+	if bitWidth == 0 {
+		bitWidth = DefaultTurboVecBitWidth
+	}
+	if bitWidth != 2 && bitWidth != 3 && bitWidth != 4 {
+		return nil, fmt.Errorf("turbovec bit width must be 2, 3, or 4, got %d", bitWidth)
+	}
+	resultLimit, err := turboVecResultLimit(len(bridgeVectors), opts.Limit, opts.TieLess != nil)
+	if err != nil {
+		return nil, err
+	}
+	response, err := runTurboVec(ctx, opts.TurboVec, turboVecRequest{
+		Dimensions: len(query),
+		BitWidth:   bitWidth,
+		Limit:      resultLimit,
+		Query:      bridgeQuery,
+		Vectors:    bridgeVectors,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]SearchResult[T], 0, min(len(response.Results), opts.Limit))
+	seen := make(map[int]struct{}, len(response.Results))
+	for _, result := range response.Results {
+		if result.Index < 0 || result.Index >= len(indexed) {
+			return nil, fmt.Errorf("turbovec returned candidate index %d outside 0..%d", result.Index, len(indexed)-1)
+		}
+		if _, ok := seen[result.Index]; ok {
+			return nil, fmt.Errorf("turbovec returned duplicate candidate index %d", result.Index)
+		}
+		seen[result.Index] = struct{}{}
+		if !validScore(result.Score, opts.MinScore) {
+			continue
+		}
+		out = append(out, SearchResult[T]{
+			Item:  indexed[result.Index].Item,
+			Score: result.Score,
+		})
+	}
+	sortSearchResults(out, opts.TieLess)
+	if len(out) > opts.Limit {
+		out = out[:opts.Limit]
+	}
+	return out, nil
+}
+
+func turboVecResultLimit(candidateCount, requestedLimit int, needsTieOverfetch bool) (int, error) {
+	if requestedLimit <= 0 || requestedLimit > candidateCount {
+		requestedLimit = candidateCount
+	}
+	if !needsTieOverfetch {
+		return requestedLimit, nil
+	}
+	if candidateCount > turboVecMaxTieCandidates {
+		return 0, fmt.Errorf("turbovec TieLess requires fetching all %d candidates; use the exact backend or omit TieLess for large candidate sets", candidateCount)
+	}
+	return candidateCount, nil
+}
+
+func normalizeVector(values []float32) []float32 {
+	norm := Norm(values)
+	out := make([]float32, len(values))
+	for i, value := range values {
+		out[i] = float32(float64(value) / norm)
+	}
+	return out
+}
+
+func validateTurboVecPayloadVector(values []float32, name string) error {
+	for i, value := range values {
+		if value <= -1e16 || value >= 1e16 {
+			return fmt.Errorf("turbovec %s vector value at index %d has magnitude >= 1e16", name, i)
+		}
+	}
+	return nil
+}
+
+func runTurboVec(ctx context.Context, opts TurboVecOptions, request turboVecRequest) (turboVecResponse, error) {
+	maxInput := effectiveTurboVecMaxInput(opts.MaxInputBytes)
+	if err := preflightTurboVecInput(request.Dimensions, len(request.Vectors), maxInput); err != nil {
+		return turboVecResponse{}, err
+	}
+	maxOutput := effectiveTurboVecMaxOutput(opts.MaxOutputBytes)
+	if err := preflightTurboVecOutput(request.Limit, maxOutput); err != nil {
+		return turboVecResponse{}, err
+	}
+	var payload limitedBuffer
+	if maxInput > 0 {
+		payload.limit = maxInput
+	}
+	if err := json.NewEncoder(&payload).Encode(request); err != nil {
+		return turboVecResponse{}, fmt.Errorf("marshal turbovec request: %w", err)
+	}
+	if payload.truncated {
+		return turboVecResponse{}, fmt.Errorf("turbovec request is over max %d bytes", maxInput)
+	}
+	runCtx, cancel := turboVecContext(ctx, opts.Timeout)
+	defer cancel()
+	command, defaultCommand, err := turboVecCommand(opts)
+	if err != nil {
+		return turboVecResponse{}, err
+	}
+
+	cmd := exec.CommandContext(runCtx, command[0], command[1:]...)
+	cmd.WaitDelay = 2 * time.Second
+	if defaultCommand {
+		dir, err := os.MkdirTemp("", "crawlkit-turbovec-*")
+		if err != nil {
+			return turboVecResponse{}, fmt.Errorf("create turbovec working dir: %w", err)
+		}
+		defer func() { _ = os.RemoveAll(dir) }()
+		cmd.Dir = dir
+	}
+	cmd.Stdin = bytes.NewReader(payload.Bytes())
+	var stdout, stderr limitedBuffer
+	stdout.limit = maxOutput
+	stderr.limit = maxOutput
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	if ctxErr := runCtx.Err(); ctxErr != nil {
+		if errors.Is(ctxErr, context.DeadlineExceeded) {
+			return turboVecResponse{}, fmt.Errorf("run turbovec bridge: timed out after %s: %w", effectiveTurboVecTimeout(opts.Timeout), ctxErr)
+		}
+		return turboVecResponse{}, fmt.Errorf("run turbovec bridge: %w", ctxErr)
+	}
+	if stderr.truncated {
+		return turboVecResponse{}, errors.New("run turbovec bridge: stderr exceeded output limit")
+	}
+	if stdout.truncated {
+		return turboVecResponse{}, errors.New("run turbovec bridge: stdout exceeded output limit")
+	}
+	if err != nil {
+		return turboVecResponse{}, fmt.Errorf("run turbovec bridge: %w: %s", err, firstLine(stderr.String()))
+	}
+	var response turboVecResponse
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		return turboVecResponse{}, fmt.Errorf("decode turbovec response: %w", err)
+	}
+	return response, nil
+}
+
+func effectiveTurboVecMaxInput(maxInput int64) int64 {
+	if maxInput == 0 {
+		return DefaultTurboVecMaxInputSize
+	}
+	return maxInput
+}
+
+func preflightTurboVecInput(dimensions, vectorCount int, maxInput int64) error {
+	if maxInput <= 0 || dimensions <= 0 || vectorCount <= 0 {
+		return nil
+	}
+	const floatJSONBudget = int64(16)
+	coordinates := int64(dimensions) * int64(vectorCount+1)
+	estimate := int64(256) + coordinates*floatJSONBudget + int64(vectorCount*4)
+	if estimate > maxInput {
+		return fmt.Errorf("turbovec request estimate is %d bytes, over max %d", estimate, maxInput)
+	}
+	return nil
+}
+
+func effectiveTurboVecMaxOutput(maxOutput int64) int64 {
+	if maxOutput == 0 {
+		return DefaultTurboVecMaxOutput
+	}
+	return maxOutput
+}
+
+func preflightTurboVecOutput(limit int, maxOutput int64) error {
+	if maxOutput <= 0 || limit <= 0 {
+		return nil
+	}
+	const resultJSONBudget = int64(48)
+	estimate := int64(32) + int64(limit)*resultJSONBudget
+	if estimate > maxOutput {
+		return fmt.Errorf("turbovec response estimate is %d bytes, over max %d", estimate, maxOutput)
+	}
+	return nil
+}
+
+func turboVecContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout < 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, effectiveTurboVecTimeout(timeout))
+}
+
+func effectiveTurboVecTimeout(timeout time.Duration) time.Duration {
+	if timeout == 0 {
+		return DefaultTurboVecTimeout
+	}
+	return timeout
+}
+
+func turboVecCommand(opts TurboVecOptions) ([]string, bool, error) {
+	if len(opts.Command) > 0 {
+		return opts.Command, false, nil
+	}
+	python := opts.Python
+	if python == "" {
+		python = os.Getenv(TurboVecPythonEnv)
+	}
+	if python == "" {
+		var err error
+		python, err = exec.LookPath("python3")
+		if err != nil {
+			python, err = exec.LookPath("python")
+		}
+		if err != nil {
+			return nil, false, fmt.Errorf("find Python for turbovec bridge: %w; set %s or TurboVecOptions.Command", err, TurboVecPythonEnv)
+		}
+	}
+	python, err := resolvePythonPath(python)
+	if err != nil {
+		return nil, false, err
+	}
+	return []string{python, "-E", "-c", turboVecBridgeScript}, true, nil
+}
+
+func resolvePythonPath(python string) (string, error) {
+	if filepath.IsAbs(python) {
+		return python, nil
+	}
+	if filepath.Base(python) == python {
+		resolved, err := exec.LookPath(python)
+		if err != nil {
+			return "", fmt.Errorf("find Python %q: %w", python, err)
+		}
+		return resolved, nil
+	}
+	abs, err := filepath.Abs(python)
+	if err != nil {
+		return "", fmt.Errorf("resolve Python path %q: %w", python, err)
+	}
+	return abs, nil
+}
+
+func firstLine(value string) string {
+	for i, r := range value {
+		if r == '\n' || r == '\r' {
+			return value[:i]
+		}
+	}
+	return value
+}
+
+type limitedBuffer struct {
+	buf       bytes.Buffer
+	limit     int64
+	truncated bool
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	if b.limit <= 0 {
+		return b.buf.Write(p)
+	}
+	remaining := b.limit - int64(b.buf.Len())
+	if remaining <= 0 {
+		b.truncated = true
+		return len(p), nil
+	}
+	if int64(len(p)) > remaining {
+		b.truncated = true
+		_, _ = b.buf.Write(p[:remaining])
+		return len(p), nil
+	}
+	_, _ = b.buf.Write(p)
+	return len(p), nil
+}
+
+func (b *limitedBuffer) Bytes() []byte {
+	return b.buf.Bytes()
+}
+
+func (b *limitedBuffer) String() string {
+	return b.buf.String()
+}
+
+const turboVecBridgeScript = `
+import sys
+sys.path = [p for p in sys.path if p not in ("", ".")]
+import os
+_cwd = os.getcwd()
+sys.path = [p for p in sys.path if p and os.path.abspath(p) != _cwd]
+
+import json
+import math
+
+try:
+    import numpy as np
+    from turbovec import IdMapIndex
+except Exception as exc:
+    print("install the Python turbovec package to use the turbovec vector backend: %s" % exc, file=sys.stderr)
+    sys.exit(3)
+
+req = json.load(sys.stdin)
+dim = int(req["dimensions"])
+bit_width = int(req.get("bit_width") or 4)
+limit = int(req.get("limit") or 20)
+vectors = np.asarray(req["vectors"], dtype=np.float32)
+query = np.asarray(req["query"], dtype=np.float32)
+if dim <= 0 or dim % 8 != 0:
+    raise ValueError("dimensions must be a positive multiple of 8")
+if vectors.ndim != 2 or vectors.shape[1] != dim:
+    raise ValueError("vector matrix shape does not match dimensions")
+if query.ndim != 1 or query.shape[0] != dim:
+    raise ValueError("query shape does not match dimensions")
+if not np.all(np.isfinite(vectors)) or not np.all(np.isfinite(query)):
+    raise ValueError("vectors must contain only finite values")
+
+index = IdMapIndex(dim=dim, bit_width=bit_width)
+ids = np.arange(vectors.shape[0], dtype=np.uint64)
+index.add_with_ids(vectors, ids)
+try:
+    scores, found = index.search(query, k=limit)
+except TypeError:
+    scores, found = index.search(query.reshape(1, dim), k=limit)
+scores = np.asarray(scores).reshape(-1)
+found = np.asarray(found).reshape(-1)
+results = []
+for score, idx in zip(scores, found):
+    if int(idx) < 0 or not math.isfinite(float(score)):
+        continue
+    results.append({"index": int(idx), "score": float(score)})
+print(json.dumps({"results": results}, separators=(",", ":")))
+`
+
+var _ io.Writer = (*limitedBuffer)(nil)

--- a/vector/vector.go
+++ b/vector/vector.go
@@ -52,22 +52,6 @@ func DecodeFloat32(blob []byte) ([]float32, error) {
 	return out, nil
 }
 
-func Float64To32(values []float64) []float32 {
-	out := make([]float32, len(values))
-	for i, value := range values {
-		out[i] = float32(value)
-	}
-	return out
-}
-
-func Float64BatchTo32(vectors [][]float64) [][]float32 {
-	out := make([][]float32, len(vectors))
-	for i, values := range vectors {
-		out[i] = Float64To32(values)
-	}
-	return out
-}
-
 func ValidateDimensions(values []float32, dimensions int) error {
 	if dimensions <= 0 {
 		return errors.New("dimensions must be positive")

--- a/vector/vector.go
+++ b/vector/vector.go
@@ -11,6 +11,13 @@ import (
 
 const DefaultRRFK = 60.0
 
+type SearchBackend = string
+
+const (
+	BackendExact    SearchBackend = "exact"
+	BackendTurboVec SearchBackend = "turbovec"
+)
+
 type Scored[T any] struct {
 	Item  T
 	Score float64
@@ -43,6 +50,22 @@ func DecodeFloat32(blob []byte) ([]float32, error) {
 		}
 	}
 	return out, nil
+}
+
+func Float64To32(values []float64) []float32 {
+	out := make([]float32, len(values))
+	for i, value := range values {
+		out[i] = float32(value)
+	}
+	return out
+}
+
+func Float64BatchTo32(vectors [][]float64) [][]float32 {
+	out := make([][]float32, len(vectors))
+	for i, values := range vectors {
+		out[i] = Float64To32(values)
+	}
+	return out
 }
 
 func ValidateDimensions(values []float32, dimensions int) error {

--- a/vector/vector_test.go
+++ b/vector/vector_test.go
@@ -1,6 +1,7 @@
 package vector
 
 import (
+	"errors"
 	"math"
 	"reflect"
 	"strings"
@@ -120,6 +121,13 @@ func (requireAPI) ErrorContains(t *testing.T, err error, needle string) {
 	}
 	if !strings.Contains(err.Error(), needle) {
 		t.Fatalf("expected error containing %q, got %q", needle, err.Error())
+	}
+}
+
+func (requireAPI) ErrorIs(t *testing.T, err, target error) {
+	t.Helper()
+	if !errors.Is(err, target) {
+		t.Fatalf("expected error %v to match %v", err, target)
 	}
 }
 


### PR DESCRIPTION
## Summary

Supersedes #18 with a maintainer-owned branch because the contributor head is not editable.

- adds shared `vector.Search` with exact cosine as the default backend
- adds optional Python `turbovec` bridge backend for dimensions divisible by 8 up to 8,192
- preserves string-compatible backend config for downstream callers
- hardens the bridge protocol: normalized cosine inputs, finite/vector validation, cancellation, timeout and size bounds, response validation, duplicate/out-of-range index checks, temp working directory isolation, and deterministic result ordering
- keeps the older remote SQLite bundle commit out of this PR because equivalent content already landed on `main` via #15

Contributor credit preserved in the commit body via `Co-authored-by: Vincent Koc <vincentkoc@ieee.org>` and in `CHANGELOG.md` with thanks to @vincentkoc.

## Verification

- `GOWORK=off go mod tidy`
- `git diff --exit-code -- go.mod go.sum`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test -count=1 ./...`
- `GOWORK=off go test -race -count=1 ./vector`
- `CRAWLKIT_TURBOVEC_INTEGRATION=1 CRAWLKIT_TURBOVEC_PYTHON=<temp-venv>/bin/python GOWORK=off go test -count=1 ./vector -run TestSearchTurboVecRealPython -v` after installing `turbovec==0.7.0` and `numpy` into an isolated temp venv
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local --parallel-tests "GOWORK=off go test -count=1 ./..."` exited clean: `autoreview clean: no accepted/actionable findings reported`
