### PR TITLE
fix: harden crawlkit audit findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - run: go mod tidy
+      - run: GOWORK=off go mod tidy
       - run: git diff --exit-code -- go.mod go.sum
-      - run: go vet ./...
+      - run: GOWORK=off go vet ./...
       - run: |
           output_file=$(mktemp)
           GOWORK=off go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./... > "$output_file"
@@ -27,4 +27,4 @@ jobs:
             cat "$output_file"
             exit 1
           fi
-      - run: go test ./...
+      - run: GOWORK=off go test ./...

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -67,6 +67,12 @@ jobs:
               exit 2
               ;;
           esac
+          case "$job" in
+            ''|*[!A-Za-z0-9._-]*)
+              echo "Invalid crabbox_job" >&2
+              exit 2
+              ;;
+          esac
           mkdir -p "$HOME/.crabbox/actions"
           state="$HOME/.crabbox/actions/${CRABBOX_ID}.env"
           env_file="$HOME/.crabbox/actions/${CRABBOX_ID}.env.sh"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -57,7 +57,7 @@ jobs:
           extra_args: --only-verified --debug
 
       - name: Notify on failure
-        if: steps.trufflehog.outcome == 'failure'
+        if: failure() && steps.trufflehog.outcome == 'failure'
         run: |
           echo "::error::Verified secrets found. Rotate the credential before merging."
           exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Harden crawlkit maintenance surfaces found by `clawpatch`: safer `crawlctl`
+  log tailing, GOWORK-isolated validation, atomic backup/cache/store writes,
+  safer snapshot incremental imports, scoped state schemas, scheduler lock and
+  interval handling, release/version checks, remote bearer-token transport
+  validation, and path-scoped mirror commits.
+
 ## v0.12.0 - 2026-06-10
 
 - Add shared `vector.Search` backends, including the existing exact cosine

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,13 @@
 .PHONY: test vet tidy check
 
 test:
-	go test ./...
+	GOWORK=off go test ./...
 
 vet:
-	go vet ./...
+	GOWORK=off go vet ./...
 
 tidy:
-	go mod tidy
+	GOWORK=off go mod tidy
 
 check: tidy vet test
 	git diff --exit-code -- go.mod go.sum
-

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -272,10 +272,6 @@ func writeManifest(ctx context.Context, repo string, manifest Manifest) error {
 	return writeFileAtomicContext(ctx, filepath.Join(repo, "manifest.json"), data, 0o600)
 }
 
-func writeFileAtomic(target string, data []byte, perm os.FileMode) error {
-	return writeFileAtomicContext(context.Background(), target, data, perm)
-}
-
 func writeFileAtomicContext(ctx context.Context, target string, data []byte, perm os.FileMode) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -414,7 +410,7 @@ func removeStaleShards(ctx context.Context, repo string, shards []ShardEntry) er
 }
 
 func EncryptShard(plaintext []byte, recipients []string) ([]byte, string, error) {
-	return encryptShard(plaintext, recipients)
+	return encryptShardContext(context.Background(), plaintext, recipients)
 }
 
 func DecryptShard(ciphertext []byte, identityPath string) ([]byte, error) {

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -52,7 +52,9 @@ type DecodedShard struct {
 }
 
 func WriteSnapshot(ctx context.Context, cfg Config, shards []Shard, old Manifest) (Manifest, error) {
-	_ = ctx
+	if err := ctx.Err(); err != nil {
+		return Manifest{}, err
+	}
 	recipients := normalizedStrings(cfg.Recipients)
 	reuseEncrypted := sameStrings(old.Recipients, recipients)
 	manifest := Manifest{
@@ -63,12 +65,21 @@ func WriteSnapshot(ctx context.Context, cfg Config, shards []Shard, old Manifest
 		Counts:     map[string]int{},
 	}
 	for _, shard := range shards {
-		plaintext, rows, err := EncodeJSONL(shard.Rows)
+		if err := ctx.Err(); err != nil {
+			return Manifest{}, err
+		}
+		plaintext, rows, err := encodeJSONL(ctx, shard.Rows)
 		if err != nil {
 			return Manifest{}, fmt.Errorf("encode %s: %w", shard.Table, err)
 		}
-		entry, err := WriteShard(cfg, old, shard.Table, shard.Path, plaintext, rows, reuseEncrypted)
+		if err := ctx.Err(); err != nil {
+			return Manifest{}, err
+		}
+		entry, err := writeShard(ctx, cfg, old, shard.Table, shard.Path, plaintext, rows, reuseEncrypted)
 		if err != nil {
+			return Manifest{}, err
+		}
+		if err := ctx.Err(); err != nil {
 			return Manifest{}, err
 		}
 		manifest.Counts[shard.Table] += rows
@@ -78,10 +89,16 @@ func WriteSnapshot(ctx context.Context, cfg Config, shards []Shard, old Manifest
 	if EquivalentManifest(old, manifest) {
 		return old, nil
 	}
-	if err := RemoveStaleShards(cfg.Repo, manifest.Shards); err != nil {
+	if err := ctx.Err(); err != nil {
 		return Manifest{}, err
 	}
-	if err := WriteManifest(cfg.Repo, manifest); err != nil {
+	if err := writeManifest(ctx, cfg.Repo, manifest); err != nil {
+		return Manifest{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return Manifest{}, err
+	}
+	if err := removeStaleShards(ctx, cfg.Repo, manifest.Shards); err != nil {
 		return Manifest{}, err
 	}
 	return manifest, nil
@@ -106,28 +123,55 @@ func ReadSnapshot(cfg Config, manifest Manifest) ([]DecodedShard, error) {
 }
 
 func WriteShard(cfg Config, old Manifest, table, rel string, plaintext []byte, rows int, reuseEncrypted bool) (ShardEntry, error) {
+	return writeShard(context.Background(), cfg, old, table, rel, plaintext, rows, reuseEncrypted)
+}
+
+func writeShard(ctx context.Context, cfg Config, old Manifest, table, rel string, plaintext []byte, rows int, reuseEncrypted bool) (ShardEntry, error) {
+	if err := ctx.Err(); err != nil {
+		return ShardEntry{}, err
+	}
 	hash := SHA256Hex(plaintext)
-	target, err := ResolveShardPath(cfg.Repo, rel)
+	targetRel := rel
+	if oldEntry, ok := old.Entry(rel); ok {
+		if oldEntry.SHA256 != hash || !reuseEncrypted {
+			targetRel = versionedShardPath(rel, hash)
+		}
+	}
+	target, err := ResolveShardPath(cfg.Repo, targetRel)
 	if err != nil {
 		return ShardEntry{}, err
 	}
-	if oldEntry, ok := old.Entry(rel); reuseEncrypted && ok && oldEntry.SHA256 == hash {
+	if oldEntry, ok := old.Entry(targetRel); reuseEncrypted && ok && oldEntry.SHA256 == hash {
 		if info, err := os.Stat(target); err == nil {
 			oldEntry.Bytes = info.Size()
 			return oldEntry, nil
 		}
 	}
-	encrypted, _, err := EncryptShard(plaintext, cfg.Recipients)
+	if err := ctx.Err(); err != nil {
+		return ShardEntry{}, err
+	}
+	encrypted, _, err := encryptShardContext(ctx, plaintext, cfg.Recipients)
 	if err != nil {
+		return ShardEntry{}, err
+	}
+	if err := ctx.Err(); err != nil {
 		return ShardEntry{}, err
 	}
 	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
 		return ShardEntry{}, err
 	}
-	if err := os.WriteFile(target, encrypted, 0o600); err != nil {
+	if err := writeFileAtomicContext(ctx, target, encrypted, 0o600); err != nil {
 		return ShardEntry{}, err
 	}
-	return ShardEntry{Table: table, Path: rel, Rows: rows, SHA256: hash, Bytes: int64(len(encrypted))}, nil
+	return ShardEntry{Table: table, Path: targetRel, Rows: rows, SHA256: hash, Bytes: int64(len(encrypted))}, nil
+}
+
+func versionedShardPath(rel, hash string) string {
+	prefix := strings.TrimSuffix(rel, ".age")
+	if len(hash) > 12 {
+		hash = hash[:12]
+	}
+	return prefix + "-" + hash + ".age"
 }
 
 func DecryptShardFile(cfg Config, shard ShardEntry) ([]byte, error) {
@@ -160,6 +204,10 @@ func ResolveShardPath(repo, rel string) (string, error) {
 }
 
 func EncodeJSONL(rows any) ([]byte, int, error) {
+	return encodeJSONL(context.Background(), rows)
+}
+
+func encodeJSONL(ctx context.Context, rows any) ([]byte, int, error) {
 	value := reflect.ValueOf(rows)
 	if value.Kind() != reflect.Slice {
 		return nil, 0, fmt.Errorf("unsupported JSONL rows %T", rows)
@@ -167,6 +215,9 @@ func EncodeJSONL(rows any) ([]byte, int, error) {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	for i := 0; i < value.Len(); i++ {
+		if err := ctx.Err(); err != nil {
+			return nil, 0, err
+		}
 		if err := enc.Encode(value.Index(i).Interface()); err != nil {
 			return nil, 0, err
 		}
@@ -200,12 +251,92 @@ func ReadManifest(repo string) (Manifest, error) {
 }
 
 func WriteManifest(repo string, manifest Manifest) error {
+	return writeManifest(context.Background(), repo, manifest)
+}
+
+func writeManifest(ctx context.Context, repo string, manifest Manifest) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	data, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
 		return err
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	data = append(data, '\n')
-	return os.WriteFile(filepath.Join(repo, "manifest.json"), data, 0o600)
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		return err
+	}
+	return writeFileAtomicContext(ctx, filepath.Join(repo, "manifest.json"), data, 0o600)
+}
+
+func writeFileAtomic(target string, data []byte, perm os.FileMode) error {
+	return writeFileAtomicContext(context.Background(), target, data, perm)
+}
+
+func writeFileAtomicContext(ctx context.Context, target string, data []byte, perm os.FileMode) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	dir := filepath.Dir(target)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(target)+".tmp-")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, target); err != nil {
+		return err
+	}
+	_ = syncDir(dir)
+	cleanup = false
+	return nil
+}
+
+func syncDir(dir string) error {
+	file, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return file.Sync()
 }
 
 func (m Manifest) Entry(path string) (ShardEntry, bool) {
@@ -232,6 +363,13 @@ func EquivalentManifest(a, b Manifest) bool {
 }
 
 func RemoveStaleShards(repo string, shards []ShardEntry) error {
+	return removeStaleShards(context.Background(), repo, shards)
+}
+
+func removeStaleShards(ctx context.Context, repo string, shards []ShardEntry) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	keep := map[string]struct{}{}
 	for _, shard := range shards {
 		keep[filepath.Clean(filepath.Join(repo, filepath.FromSlash(shard.Path)))] = struct{}{}
@@ -242,6 +380,9 @@ func RemoveStaleShards(repo string, shards []ShardEntry) error {
 	}
 	var stale []string
 	if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		if err != nil || d == nil || d.IsDir() {
 			return err
 		}
@@ -258,6 +399,9 @@ func RemoveStaleShards(repo string, shards []ShardEntry) error {
 		return err
 	}
 	for _, path := range stale {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		rel, err := filepath.Rel(root, path)
 		if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
 			return fmt.Errorf("stale shard path escapes backup root: %s", path)

--- a/backup/backup_test.go
+++ b/backup/backup_test.go
@@ -128,6 +128,56 @@ func TestWriteShardVersionsChangedExistingManifestPath(t *testing.T) {
 	}
 }
 
+func TestPublicBackupHelpers(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "age.key")
+	recipient, err := EnsureIdentity(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := Config{Repo: filepath.Join(dir, "repo"), Identity: identity, Recipients: []string{recipient}}
+	plaintext, rows, err := EncodeJSONL([]row{{ID: "1", Body: "hello"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows != 1 || len(plaintext) == 0 {
+		t.Fatalf("encoded rows=%d bytes=%d", rows, len(plaintext))
+	}
+	ciphertext, hash, err := EncryptShard(plaintext, cfg.Recipients)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hash != SHA256Hex(plaintext) || len(ciphertext) == 0 {
+		t.Fatalf("hash=%q ciphertext=%d", hash, len(ciphertext))
+	}
+	entry, err := WriteShard(cfg, Manifest{}, "messages", "data/messages/2026/05.jsonl.gz.age", plaintext, rows, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry.Path == "" || entry.SHA256 != hash {
+		t.Fatalf("entry = %+v", entry)
+	}
+	if err := WriteManifest(cfg.Repo, Manifest{Format: FormatVersion, Encrypted: true, Shards: []ShardEntry{entry}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadManifest(cfg.Repo); err != nil {
+		t.Fatal(err)
+	}
+	stale := filepath.Join(cfg.Repo, "data", "messages", "stale.age")
+	if err := os.MkdirAll(filepath.Dir(stale), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stale, []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveStaleShards(cfg.Repo, []ShardEntry{entry}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("stale shard stat err = %v", err)
+	}
+}
+
 func TestResolveShardPathRejectsEscapes(t *testing.T) {
 	for _, rel := range []string{"../x.age", "data/../x.age", "data/x.txt", "/data/x.age"} {
 		if _, err := ResolveShardPath(t.TempDir(), rel); err == nil {

--- a/backup/backup_test.go
+++ b/backup/backup_test.go
@@ -59,6 +59,75 @@ func TestWriteReadEncryptedSnapshot(t *testing.T) {
 	}
 }
 
+func TestWriteSnapshotHonorsCanceledContext(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "age.key")
+	recipient, err := EnsureIdentity(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := Config{Repo: filepath.Join(dir, "repo"), Identity: identity, Recipients: []string{recipient}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = WriteSnapshot(ctx, cfg, []Shard{
+		{Table: "messages", Path: "data/messages/2026/05.jsonl.gz.age", Rows: []row{{ID: "1", Body: "hello"}}},
+	}, Manifest{})
+	if err != context.Canceled {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(cfg.Repo, "manifest.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("manifest stat err = %v", statErr)
+	}
+}
+
+func TestWriteShardVersionsChangedExistingManifestPath(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "age.key")
+	recipient, err := EnsureIdentity(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := Config{Repo: filepath.Join(dir, "repo"), Identity: identity, Recipients: []string{recipient}}
+	rel := "data/messages/2026/05.jsonl.gz.age"
+	oldPath, err := ResolveShardPath(cfg.Repo, rel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(oldPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(oldPath, []byte("old encrypted shard"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := Manifest{Shards: []ShardEntry{{Table: "messages", Path: rel, SHA256: "old-hash"}}}
+	entry, err := writeShard(context.Background(), cfg, old, "messages", rel, []byte("new plaintext\n"), 1, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry.Path == rel {
+		t.Fatalf("changed shard reused old path %q", rel)
+	}
+	data, err := os.ReadFile(oldPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "old encrypted shard" {
+		t.Fatalf("old shard was overwritten: %q", data)
+	}
+	if _, err := os.Stat(filepath.Join(cfg.Repo, filepath.FromSlash(entry.Path))); err != nil {
+		t.Fatalf("new shard missing: %v", err)
+	}
+
+	sameHashOld := Manifest{Shards: []ShardEntry{{Table: "messages", Path: rel, SHA256: SHA256Hex([]byte("new plaintext\n"))}}}
+	entry, err = writeShard(context.Background(), cfg, sameHashOld, "messages", rel, []byte("new plaintext\n"), 1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry.Path == rel {
+		t.Fatalf("re-encrypted shard reused old path %q", rel)
+	}
+}
+
 func TestResolveShardPathRejectsEscapes(t *testing.T) {
 	for _, rel := range []string{"../x.age", "data/../x.age", "data/x.txt", "/data/x.age"} {
 		if _, err := ResolveShardPath(t.TempDir(), rel); err == nil {

--- a/backup/crypto.go
+++ b/backup/crypto.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -54,8 +55,18 @@ func RecipientFromIdentity(path string) (string, error) {
 }
 
 func encryptShard(plaintext []byte, recipientStrings []string) ([]byte, string, error) {
+	return encryptShardContext(context.Background(), plaintext, recipientStrings)
+}
+
+func encryptShardContext(ctx context.Context, plaintext []byte, recipientStrings []string) ([]byte, string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, "", err
+	}
 	recipients, err := parseRecipients(recipientStrings)
 	if err != nil {
+		return nil, "", err
+	}
+	if err := ctx.Err(); err != nil {
 		return nil, "", err
 	}
 	var compressed bytes.Buffer
@@ -63,14 +74,23 @@ func encryptShard(plaintext []byte, recipientStrings []string) ([]byte, string, 
 	gz.ModTime = time.Unix(0, 0).UTC()
 	_, _ = gz.Write(plaintext)
 	_ = gz.Close()
+	if err := ctx.Err(); err != nil {
+		return nil, "", err
+	}
 
 	var encrypted bytes.Buffer
 	w, err := age.Encrypt(&encrypted, recipients...)
 	if err != nil {
 		return nil, "", err
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, "", err
+	}
 	_, _ = w.Write(compressed.Bytes())
 	if err := w.Close(); err != nil {
+		return nil, "", err
+	}
+	if err := ctx.Err(); err != nil {
 		return nil, "", err
 	}
 	return encrypted.Bytes(), sha256Hex(plaintext), nil

--- a/backup/crypto.go
+++ b/backup/crypto.go
@@ -54,10 +54,6 @@ func RecipientFromIdentity(path string) (string, error) {
 	return identity.Recipient().String(), nil
 }
 
-func encryptShard(plaintext []byte, recipientStrings []string) ([]byte, string, error) {
-	return encryptShardContext(context.Background(), plaintext, recipientStrings)
-}
-
 func encryptShardContext(ctx context.Context, plaintext []byte, recipientStrings []string) ([]byte, string, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, "", err

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -48,26 +48,52 @@ func SnapshotFile(opts SnapshotOptions) (Snapshot, error) {
 	if err := os.MkdirAll(opts.CacheDir, 0o755); err != nil {
 		return Snapshot{}, fmt.Errorf("create cache dir: %w", err)
 	}
+	createdAt := now().UTC()
 	name := opts.Name
 	if name == "" {
 		name = filepath.Base(opts.SourcePath)
 	}
-	target := filepath.Join(opts.CacheDir, now().UTC().Format("20060102T150405Z")+"-"+name)
+	target := filepath.Join(opts.CacheDir, createdAt.Format("20060102T150405Z")+"-"+name)
 	src, err := os.Open(opts.SourcePath)
 	if err != nil {
 		return Snapshot{}, fmt.Errorf("open source: %w", err)
 	}
 	defer src.Close()
-	dst, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	tmp, err := os.CreateTemp(opts.CacheDir, "."+filepath.Base(target)+".tmp-")
 	if err != nil {
 		return Snapshot{}, fmt.Errorf("create snapshot: %w", err)
 	}
-	if _, err := io.Copy(dst, src); err != nil {
-		_ = dst.Close()
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return Snapshot{}, fmt.Errorf("chmod snapshot: %w", err)
+	}
+	var copied int64
+	if opts.MaxFileBytes > 0 {
+		limited := &io.LimitedReader{R: src, N: opts.MaxFileBytes + 1}
+		copied, err = io.Copy(tmp, limited)
+		if err == nil && copied > opts.MaxFileBytes {
+			err = fmt.Errorf("source file exceeds limit %d", opts.MaxFileBytes)
+		}
+	} else {
+		copied, err = io.Copy(tmp, src)
+	}
+	if err != nil {
+		_ = tmp.Close()
 		return Snapshot{}, fmt.Errorf("copy snapshot: %w", err)
 	}
-	if err := dst.Close(); err != nil {
+	if err := tmp.Close(); err != nil {
 		return Snapshot{}, fmt.Errorf("close snapshot: %w", err)
 	}
-	return Snapshot{SourcePath: opts.SourcePath, Path: target, SizeBytes: info.Size(), CreatedAt: now().UTC()}, nil
+	if err := os.Rename(tmpPath, target); err != nil {
+		return Snapshot{}, fmt.Errorf("commit snapshot: %w", err)
+	}
+	cleanup = false
+	return Snapshot{SourcePath: opts.SourcePath, Path: target, SizeBytes: copied, CreatedAt: createdAt}, nil
 }

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -50,3 +50,22 @@ func TestSnapshotFileSizeGuard(t *testing.T) {
 		t.Fatal("expected size guard error")
 	}
 }
+
+func TestSnapshotFileAllowsExactCopyLimit(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.db")
+	if err := os.WriteFile(source, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	snap, err := SnapshotFile(SnapshotOptions{
+		SourcePath:   source,
+		CacheDir:     filepath.Join(dir, "cache"),
+		MaxFileBytes: 4,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snap.SizeBytes != 4 {
+		t.Fatalf("size = %d", snap.SizeBytes)
+	}
+}

--- a/cmd/crawlctl/main.go
+++ b/cmd/crawlctl/main.go
@@ -18,6 +18,8 @@ import (
 
 var version = "dev"
 
+const maxLogLineBytes = 10 * 1024 * 1024
+
 type app struct {
 	stdout io.Writer
 	stderr io.Writer
@@ -313,17 +315,17 @@ func (a *app) runLogs(args []string) error {
 			if i+1 >= len(args) {
 				return usageError{fmt.Errorf("--tail requires a line count")}
 			}
-			var parsed int
-			if _, err := fmt.Sscanf(args[i+1], "%d", &parsed); err != nil {
-				return usageError{fmt.Errorf("invalid --tail value %q", args[i+1])}
+			parsed, err := parseTail(args[i+1])
+			if err != nil {
+				return usageError{err}
 			}
 			tail = parsed
 			i++
 		default:
 			if strings.HasPrefix(args[i], "--tail=") {
-				var parsed int
-				if _, err := fmt.Sscanf(strings.TrimPrefix(args[i], "--tail="), "%d", &parsed); err != nil {
-					return usageError{fmt.Errorf("invalid --tail value %q", args[i])}
+				parsed, err := parseTail(strings.TrimPrefix(args[i], "--tail="))
+				if err != nil {
+					return usageError{err}
 				}
 				tail = parsed
 				continue
@@ -351,6 +353,17 @@ func (a *app) runLogs(args []string) error {
 		}
 	}
 	return fmt.Errorf("no logs found")
+}
+
+func parseTail(value string) (int, error) {
+	var parsed int
+	if _, err := fmt.Sscanf(value, "%d", &parsed); err != nil {
+		return 0, fmt.Errorf("invalid --tail value %q", value)
+	}
+	if parsed <= 0 {
+		return 0, errors.New("--tail must be greater than zero")
+	}
+	return parsed, nil
 }
 
 func (a *app) runInstall(args []string) error {
@@ -453,9 +466,10 @@ func printTail(w io.Writer, path string, limit int) error {
 	defer file.Close()
 	var lines []string
 	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxLogLineBytes)
 	for scanner.Scan() {
 		lines = append(lines, scanner.Text())
-		if limit > 0 && len(lines) > limit {
+		if len(lines) > limit {
 			lines = lines[1:]
 		}
 	}

--- a/cmd/crawlctl/main_test.go
+++ b/cmd/crawlctl/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -71,8 +72,35 @@ every = "7m"
 	if err := a.runInstall([]string{"--backend", "systemd", "--dry-run"}); err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(stdout.String(), "OnUnitActiveSec=7min") {
+	if !strings.Contains(stdout.String(), "OnUnitActiveSec=420s") {
 		t.Fatalf("install output = %s", stdout.String())
+	}
+}
+
+func TestRunLogsRejectsInvalidTail(t *testing.T) {
+	var stdout bytes.Buffer
+	a := app{stdout: &stdout, stderr: ioDiscard{}}
+	err := a.runLogs([]string{"--tail=-1"})
+	var usage usageError
+	if !errors.As(err, &usage) {
+		t.Fatalf("err = %v, want usageError", err)
+	}
+}
+
+func TestPrintTailHandlesLongLines(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "crawlctl.log")
+	longLine := strings.Repeat("x", 128*1024)
+	if err := os.WriteFile(logPath, []byte("first\n"+longLine+"\nlast\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	if err := printTail(&stdout, logPath, 2); err != nil {
+		t.Fatal(err)
+	}
+	want := longLine + "\nlast\n"
+	if stdout.String() != want {
+		t.Fatalf("stdout len = %d, want %d", len(stdout.String()), len(want))
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -69,14 +69,17 @@ func (a App) DefaultPaths() (Paths, error) {
 	if err != nil {
 		return Paths{}, err
 	}
-	paths := app.defaultPaths()
+	paths, err := app.defaultPaths()
+	if err != nil {
+		return Paths{}, err
+	}
 	if app.PlatformDirs && strings.TrimSpace(app.BaseDir) == "" {
 		paths = app.withExistingLegacyPaths(paths)
 	}
 	return paths, nil
 }
 
-func (app App) defaultPaths() Paths {
+func (app App) defaultPaths() (Paths, error) {
 	if app.PlatformDirs && strings.TrimSpace(app.BaseDir) == "" {
 		return platformPaths(app.Name)
 	}
@@ -88,7 +91,7 @@ func (app App) defaultPaths() Paths {
 		CacheDir:   filepath.Join(base, "cache"),
 		LogDir:     filepath.Join(base, "logs"),
 		ShareDir:   filepath.Join(base, "share"),
-	}
+	}, nil
 }
 
 func (a App) LegacyPaths() (Paths, bool, error) {
@@ -121,7 +124,10 @@ func (a App) ResolveConfigPath(flagPath string) (string, error) {
 	if envPath := strings.TrimSpace(os.Getenv(app.ConfigEnv)); envPath != "" {
 		return ExpandHome(envPath), nil
 	}
-	paths := app.defaultPaths()
+	paths, err := app.defaultPaths()
+	if err != nil {
+		return "", err
+	}
 	if app.PlatformDirs && strings.TrimSpace(app.BaseDir) == "" {
 		if legacy, ok, err := app.LegacyPaths(); err != nil {
 			return "", err
@@ -180,11 +186,14 @@ func EnsureRuntimeDirs(cfg RuntimeConfig) error {
 	return nil
 }
 
-func platformPaths(name string) Paths {
+func platformPaths(name string) (Paths, error) {
 	xdgMu.Lock()
 	defer xdgMu.Unlock()
 
-	configHome, dataHome, cacheHome, stateHome := platformHomes()
+	configHome, dataHome, cacheHome, stateHome, err := platformHomes()
+	if err != nil {
+		return Paths{}, err
+	}
 	dataDir := filepath.Join(dataHome, name)
 	configDir := filepath.Join(configHome, name)
 	cacheDir := filepath.Join(cacheHome, name)
@@ -196,11 +205,17 @@ func platformPaths(name string) Paths {
 		CacheDir:   cacheDir,
 		LogDir:     filepath.Join(stateDir, "logs"),
 		ShareDir:   filepath.Join(dataDir, "share"),
-	}
+	}, nil
 }
 
-func platformHomes() (configHome, dataHome, cacheHome, stateHome string) {
-	home, _ := os.UserHomeDir()
+func platformHomes() (configHome, dataHome, cacheHome, stateHome string, err error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", "", "", "", fmt.Errorf("resolve user home for platform dirs: %w", err)
+	}
+	if !filepath.IsAbs(home) {
+		return "", "", "", "", fmt.Errorf("resolve user home for platform dirs: %q is not absolute", home)
+	}
 	switch runtime.GOOS {
 	case "darwin":
 		appSupport := filepath.Join(home, "Library", "Application Support")
@@ -220,7 +235,7 @@ func platformHomes() (configHome, dataHome, cacheHome, stateHome string) {
 		cacheHome = absoluteEnv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
 		stateHome = absoluteEnv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
 	}
-	return configHome, dataHome, cacheHome, stateHome
+	return configHome, dataHome, cacheHome, stateHome, nil
 }
 
 func absoluteEnv(name, fallback string) string {

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -121,19 +121,22 @@ func CommitPaths(ctx context.Context, opts Options, message string, paths []stri
 	if err := run(ctx, opts.RepoPath, opts.Git, args...); err != nil {
 		return false, err
 	}
-	staged, err := staged(ctx, opts)
+	staged, err := staged(ctx, opts, pathspecs)
 	if err != nil {
 		return false, err
 	}
 	if !staged {
 		return false, nil
 	}
-	if err := run(ctx, opts.RepoPath, opts.Git,
+	commitArgs := []string{
 		"-c", "commit.gpgsign=false",
 		"-c", "user.name=crawlkit",
 		"-c", "user.email=crawlkit@example.invalid",
 		"commit", "-m", message,
-	); err != nil {
+		"--",
+	}
+	commitArgs = append(commitArgs, pathspecs...)
+	if err := run(ctx, opts.RepoPath, opts.Git, commitArgs...); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -242,9 +245,11 @@ func cleanPathspecs(paths []string) ([]string, error) {
 	return out, nil
 }
 
-func staged(ctx context.Context, opts Options) (bool, error) {
+func staged(ctx context.Context, opts Options, pathspecs []string) (bool, error) {
 	opts = normalize(opts)
-	out, err := output(ctx, opts.RepoPath, opts.Git, "diff", "--cached", "--quiet")
+	args := []string{"diff", "--cached", "--quiet", "--"}
+	args = append(args, pathspecs...)
+	out, err := output(ctx, opts.RepoPath, opts.Git, args...)
 	if err == nil {
 		return false, nil
 	}
@@ -252,7 +257,7 @@ func staged(ctx context.Context, opts Options) (bool, error) {
 	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
 		return true, nil
 	}
-	return false, fmt.Errorf("git diff --cached --quiet: %w\n%s", err, strings.TrimSpace(out))
+	return false, fmt.Errorf("git diff --cached --quiet -- %s: %w\n%s", strings.Join(pathspecs, " "), err, strings.TrimSpace(out))
 }
 
 func isSQLiteSidecar(path string) bool {

--- a/mirror/mirror_test.go
+++ b/mirror/mirror_test.go
@@ -134,6 +134,45 @@ func TestCommitPathsDoesNotStageUnrelatedFiles(t *testing.T) {
 	}
 }
 
+func TestCommitPathsDoesNotCommitPrestagedUnrelatedFiles(t *testing.T) {
+	ctx := context.Background()
+	repo := filepath.Join(t.TempDir(), "share")
+	opts := Options{RepoPath: repo, Branch: "main"}
+	if err := EnsureRepo(ctx, opts); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "manifest.json"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "notes.txt"), []byte("local draft\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(ctx, repo, "git", "add", "notes.txt"); err != nil {
+		t.Fatal(err)
+	}
+	committed, err := CommitPaths(ctx, opts, "archive: manifest", []string{"manifest.json"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !committed {
+		t.Fatal("expected commit")
+	}
+	tree, err := output(ctx, repo, "git", "ls-tree", "--name-only", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(tree, "notes.txt") {
+		t.Fatalf("unrelated file was committed: %q", tree)
+	}
+	status, err := output(ctx, repo, "git", "status", "--porcelain")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(status) != "A  notes.txt" {
+		t.Fatalf("status = %q, want staged notes.txt", strings.TrimSpace(status))
+	}
+}
+
 func TestPullCurrentUsesExistingOrigin(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -63,7 +63,19 @@ func (t *Tracker) Add(delta int64, attrs ...any) {
 	if t == nil || delta == 0 {
 		return
 	}
-	t.Set(t.current()+delta, attrs...)
+	now := t.now()
+	t.mu.Lock()
+	done := clampDone(t.done+delta, t.total)
+	t.done = done
+	shouldLog := t.shouldLogLocked(done, now)
+	if shouldLog {
+		t.lastDone = done
+		t.lastLog = now
+	}
+	t.mu.Unlock()
+	if shouldLog {
+		t.log("progress", now, done, attrs)
+	}
 }
 
 func (t *Tracker) Set(done int64, attrs ...any) {
@@ -72,25 +84,17 @@ func (t *Tracker) Set(done int64, attrs ...any) {
 	}
 	now := t.now()
 	t.mu.Lock()
-	if done < 0 {
-		done = 0
-	}
-	if t.total > 0 && done > t.total {
-		done = t.total
-	}
+	done = clampDone(done, t.total)
 	t.done = done
-	shouldLog := done == t.total ||
-		done == 0 ||
-		done-t.lastDone >= t.minDelta ||
-		now.Sub(t.lastLog) >= t.logEvery
-	if !shouldLog {
-		t.mu.Unlock()
-		return
+	shouldLog := t.shouldLogLocked(done, now)
+	if shouldLog {
+		t.lastDone = done
+		t.lastLog = now
 	}
-	t.lastDone = done
-	t.lastLog = now
 	t.mu.Unlock()
-	t.log("progress", now, done, attrs)
+	if shouldLog {
+		t.log("progress", now, done, attrs)
+	}
 }
 
 func (t *Tracker) Finish(err error, attrs ...any) {
@@ -114,6 +118,23 @@ func (t *Tracker) current() int64 {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.done
+}
+
+func (t *Tracker) shouldLogLocked(done int64, now time.Time) bool {
+	return done == t.total ||
+		done == 0 ||
+		done-t.lastDone >= t.minDelta ||
+		now.Sub(t.lastLog) >= t.logEvery
+}
+
+func clampDone(done, total int64) int64 {
+	if done < 0 {
+		return 0
+	}
+	if total > 0 && done > total {
+		return total
+	}
+	return done
 }
 
 func (t *Tracker) log(state string, now time.Time, done int64, attrs []any) {

--- a/progress/progress_test.go
+++ b/progress/progress_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -61,6 +62,23 @@ func TestTrackerFinishReportsFailure(t *testing.T) {
 		if !strings.Contains(logs, want) {
 			t.Fatalf("missing %q in logs:\n%s", want, logs)
 		}
+	}
+}
+
+func TestTrackerAddIsAtomic(t *testing.T) {
+	var out bytes.Buffer
+	tracker := New(testLogger(&out), Options{Name: "sync", Total: 100, MinDelta: 1000})
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tracker.Add(1)
+		}()
+	}
+	wg.Wait()
+	if got := tracker.current(); got != 100 {
+		t.Fatalf("done = %d, want 100", got)
 	}
 }
 

--- a/releasecheck/releasecheck.go
+++ b/releasecheck/releasecheck.go
@@ -89,13 +89,16 @@ func Check(ctx context.Context, opts Options) (Result, error) {
 	}
 
 	if !opts.Force {
-		if cached, ok := readCache(opts); ok && opts.Now().Sub(cached.CheckedAt) < opts.Interval {
-			result.CheckedAt = cached.CheckedAt
-			result.LatestVersion = normalizeVersion(cached.LatestVersion)
-			result.LatestURL = cached.LatestURL
-			result.FromCache = true
-			result.UpdateAvailable = versionLess(current, result.LatestVersion)
-			return result, nil
+		if cached, ok := readCache(opts); ok {
+			age := opts.Now().Sub(cached.CheckedAt)
+			if age >= 0 && age < opts.Interval {
+				result.CheckedAt = cached.CheckedAt
+				result.LatestVersion = normalizeVersion(cached.LatestVersion)
+				result.LatestURL = cached.LatestURL
+				result.FromCache = true
+				result.UpdateAvailable = versionLess(current, result.LatestVersion)
+				return result, nil
+			}
 		}
 	}
 
@@ -288,8 +291,8 @@ func cachePath(opts Options) string {
 }
 
 func versionLess(current, latest string) bool {
-	curParts, curOK := versionParts(current)
-	latParts, latOK := versionParts(latest)
+	curParts, curPre, curOK := versionParts(current)
+	latParts, latPre, latOK := versionParts(latest)
 	if !curOK || !latOK {
 		return false
 	}
@@ -301,16 +304,25 @@ func versionLess(current, latest string) bool {
 			return false
 		}
 	}
-	return false
+	if curPre == latPre {
+		return false
+	}
+	if curPre == "" {
+		return false
+	}
+	if latPre == "" {
+		return true
+	}
+	return prereleaseLess(curPre, latPre)
 }
 
-var versionRE = regexp.MustCompile(`(?i)^v?([0-9]+)(?:\.([0-9]+))?(?:\.([0-9]+))?`)
+var versionRE = regexp.MustCompile(`(?i)^v?([0-9]+)(?:\.([0-9]+))?(?:\.([0-9]+))?(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$`)
 
-func versionParts(v string) ([3]int, bool) {
+func versionParts(v string) ([3]int, string, bool) {
 	var out [3]int
 	match := versionRE.FindStringSubmatch(strings.TrimSpace(v))
 	if match == nil {
-		return out, false
+		return out, "", false
 	}
 	for i := 1; i <= 3; i++ {
 		if match[i] == "" {
@@ -318,11 +330,35 @@ func versionParts(v string) ([3]int, bool) {
 		}
 		n, err := strconv.Atoi(match[i])
 		if err != nil {
-			return out, false
+			return out, "", false
 		}
 		out[i-1] = n
 	}
-	return out, true
+	return out, match[4], true
+}
+
+func prereleaseLess(current, latest string) bool {
+	curParts := strings.Split(current, ".")
+	latParts := strings.Split(latest, ".")
+	for i := 0; i < len(curParts) && i < len(latParts); i++ {
+		curNum, curErr := strconv.Atoi(curParts[i])
+		latNum, latErr := strconv.Atoi(latParts[i])
+		switch {
+		case curErr == nil && latErr == nil:
+			if curNum != latNum {
+				return curNum < latNum
+			}
+		case curErr == nil:
+			return true
+		case latErr == nil:
+			return false
+		default:
+			if curParts[i] != latParts[i] {
+				return curParts[i] < latParts[i]
+			}
+		}
+	}
+	return len(curParts) < len(latParts)
 }
 
 func normalizeVersion(v string) string {

--- a/releasecheck/releasecheck_test.go
+++ b/releasecheck/releasecheck_test.go
@@ -63,6 +63,57 @@ func TestCheckReportsNewReleaseAndCaches(t *testing.T) {
 	}
 }
 
+func TestCheckIgnoresFutureDatedCache(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"tag_name": "v0.4.0",
+			"html_url": "https://github.com/openclaw/gitcrawl/releases/tag/v0.4.0",
+		})
+	}))
+	defer server.Close()
+	oldAPI := GitHubAPI
+	GitHubAPI = server.URL
+	defer func() { GitHubAPI = oldAPI }()
+
+	now := time.Date(2026, 5, 17, 10, 0, 0, 0, time.UTC)
+	cacheDir := t.TempDir()
+	path := filepath.Join(cacheDir, "releasecheck", "gitcrawl.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(cacheFile{
+		CheckedAt:     now.Add(time.Hour),
+		LatestVersion: "v0.3.9",
+		LatestURL:     "https://example.invalid/stale",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	result, err := Check(context.Background(), Options{
+		AppName:        "gitcrawl",
+		Owner:          "openclaw",
+		Repo:           "gitcrawl",
+		CurrentVersion: "v0.3.2",
+		CacheDir:       cacheDir,
+		Now:            func() time.Time { return now },
+		Client:         server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if result.FromCache || result.LatestVersion != "v0.4.0" {
+		t.Fatalf("result = %+v", result)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d", requests)
+	}
+}
+
 func TestCheckSkipsDevelopmentVersions(t *testing.T) {
 	for _, version := range []string{"dev", "ci", "0.0.0-dev", "v0.4.0-dirty"} {
 		t.Run(version, func(t *testing.T) {
@@ -177,6 +228,9 @@ func TestVersionLess(t *testing.T) {
 		{"v0.3.2", "v0.4.0", true},
 		{"0.9.0", "v0.9.0", false},
 		{"v1.10.0", "v1.9.9", false},
+		{"v1.0.0-rc.1", "v1.0.0", true},
+		{"v1.0.0", "v1.0.0-rc.1", false},
+		{"v1.0.0-rc.1", "v1.0.0-rc.2", true},
 		{"dev", "v1.0.0", false},
 	}
 	for _, tt := range tests {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -142,6 +142,9 @@ func NewClient(opts Options) (*Client, error) {
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return nil, fmt.Errorf("invalid remote endpoint %q", endpoint)
 	}
+	if opts.TokenProvider != nil && parsed.Scheme != "https" && !isLocalHTTPHost(parsed.Hostname()) {
+		return nil, fmt.Errorf("remote endpoint %q cannot use bearer auth over %s", endpoint, parsed.Scheme)
+	}
 	client := opts.HTTPClient
 	if client == nil {
 		client = &http.Client{Timeout: 30 * time.Second}
@@ -156,6 +159,11 @@ func NewClient(opts Options) (*Client, error) {
 		tokenProvider: opts.TokenProvider,
 		userAgent:     userAgent,
 	}, nil
+}
+
+func isLocalHTTPHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
 }
 
 func NewClientFromConfig(cfg Config, opts Options) (*Client, error) {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -86,6 +86,16 @@ func TestClientQuerySendsBearerAndEscapedArchive(t *testing.T) {
 	}
 }
 
+func TestClientRejectsBearerTokenOverRemoteHTTP(t *testing.T) {
+	_, err := NewClient(Options{Endpoint: "http://remote.example", TokenProvider: StaticToken("secret")})
+	if err == nil {
+		t.Fatal("expected plaintext remote auth error")
+	}
+	if !strings.Contains(err.Error(), "bearer auth over http") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
 func TestClientArchiveOperations(t *testing.T) {
 	var requests []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/scheduler/native.go
+++ b/scheduler/native.go
@@ -75,13 +75,19 @@ func PlanInstall(opts InstallOptions) (InstallPlan, error) {
 		home, _ := os.UserHomeDir()
 		return InstallPlan{Backend: backend, Path: filepath.Join(home, ".config", "systemd", "user", "crawlctl.service"), Content: service + "\n--- crawlctl.timer ---\n" + timer}, nil
 	case "windows":
+		if duration%time.Minute != 0 {
+			return InstallPlan{}, fmt.Errorf("windows scheduler interval must be whole minutes: %s", duration)
+		}
 		minutes := int(duration / time.Minute)
 		tr := quoteWindows(args)
 		return InstallPlan{Backend: backend, Command: []string{"schtasks", "/Create", "/TN", "CrawlCtl", "/SC", "MINUTE", "/MO", strconv.Itoa(minutes), "/TR", tr, "/F"}}, nil
 	case "cron":
+		if duration%time.Minute != 0 {
+			return InstallPlan{}, fmt.Errorf("cron interval must be whole minutes: %s", duration)
+		}
 		minutes := int(duration / time.Minute)
-		if minutes < 1 {
-			minutes = 1
+		if minutes < 1 || minutes > 59 {
+			return InstallPlan{}, fmt.Errorf("cron interval must be between 1m and 59m: %s", duration)
 		}
 		line := fmt.Sprintf("*/%d * * * * %s >> %s 2>&1 # crawlctl\n", minutes, shellQuoteArgs(args), shellQuote(filepath.Join(paths.LogDir, "crawlctl-cron.log")))
 		return InstallPlan{Backend: backend, Content: line}, nil
@@ -231,11 +237,7 @@ func xmlText(value string) string {
 }
 
 func durationSystemd(d time.Duration) string {
-	minutes := int(d / time.Minute)
-	if minutes <= 0 {
-		minutes = 1
-	}
-	return fmt.Sprintf("%dmin", minutes)
+	return fmt.Sprintf("%ds", int(d/time.Second))
 }
 
 func shellQuoteArgs(args []string) string {

--- a/scheduler/run.go
+++ b/scheduler/run.go
@@ -13,7 +13,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -334,6 +336,12 @@ func acquireLock(path string) (func(), error) {
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if err != nil {
 		if errors.Is(err, os.ErrExist) {
+			if stale, staleErr := lockIsStale(path); staleErr == nil && stale {
+				if removeErr := os.Remove(path); removeErr != nil {
+					return nil, fmt.Errorf("remove stale crawlctl lock %s: %w", path, removeErr)
+				}
+				return acquireLock(path)
+			}
 			return nil, fmt.Errorf("crawlctl already running: %s", path)
 		}
 		return nil, err
@@ -341,6 +349,34 @@ func acquireLock(path string) (func(), error) {
 	_, _ = fmt.Fprintf(file, "pid=%d\nstarted_at=%s\n", os.Getpid(), time.Now().UTC().Format(time.RFC3339))
 	_ = file.Close()
 	return func() { _ = os.Remove(path) }, nil
+}
+
+func lockIsStale(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || key != "pid" {
+			continue
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil || pid <= 0 {
+			return true, nil
+		}
+		return !processExists(pid), nil
+	}
+	return true, nil
+}
+
+func processExists(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = proc.Signal(syscall.Signal(0))
+	return err == nil || !errors.Is(err, os.ErrProcessDone)
 }
 
 func safeName(value string) string {

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -44,6 +44,25 @@ func TestPlanInstallBackends(t *testing.T) {
 	}
 }
 
+func TestPlanInstallRejectsInexactMinuteBackends(t *testing.T) {
+	paths := Paths{ConfigPath: "/tmp/crawlctl.toml", LogDir: "/tmp/logs"}
+	plan, err := PlanInstall(InstallOptions{Backend: "systemd", Every: "90s", Executable: "/bin/crawlctl", Paths: paths})
+	if err != nil {
+		t.Fatalf("systemd plan: %v", err)
+	}
+	if !strings.Contains(plan.Content, "OnUnitActiveSec=90s") {
+		t.Fatalf("systemd content = %s", plan.Content)
+	}
+	for _, backend := range []string{"windows", "cron"} {
+		if _, err := PlanInstall(InstallOptions{Backend: backend, Every: "90s", Executable: "/bin/crawlctl", Paths: paths}); err == nil {
+			t.Fatalf("expected %s to reject 90s", backend)
+		}
+	}
+	if _, err := PlanInstall(InstallOptions{Backend: "cron", Every: "90m", Executable: "/bin/crawlctl", Paths: paths}); err == nil {
+		t.Fatal("expected cron to reject 90m")
+	}
+}
+
 func TestPlanInstallLaunchdEscapesXML(t *testing.T) {
 	paths := Paths{ConfigPath: "/tmp/a&b/crawlctl.toml", LogDir: "/tmp/logs<private>"}
 	plan, err := PlanInstall(InstallOptions{Backend: "launchd", Every: "5m", Executable: "/bin/crawlctl", Paths: paths})
@@ -79,6 +98,29 @@ func TestRunRecordsHistory(t *testing.T) {
 	}
 	if len(history) != 1 {
 		t.Fatalf("history len = %d", len(history))
+	}
+}
+
+func TestRunRecoversInvalidStaleLock(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell command path differs on windows")
+	}
+	dir := t.TempDir()
+	paths := Paths{LogDir: filepath.Join(dir, "logs"), StateDir: filepath.Join(dir, "state"), LockPath: filepath.Join(dir, "state", "lock"), History: filepath.Join(dir, "state", "runs.jsonl")}
+	if err := os.MkdirAll(paths.StateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.LockPath, []byte("pid=0\nstarted_at=2026-01-01T00:00:00Z\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := DefaultConfig()
+	cfg.Jobs["ok"] = Job{Enabled: true, Command: []string{"sh", "-c", "echo ok"}}
+	records, err := Run(context.Background(), RunOptions{Config: cfg, Paths: paths})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(records) != 1 || records[0].Status != "success" {
+		t.Fatalf("records = %#v", records)
 	}
 }
 

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -392,6 +392,10 @@ func WriteManifest(rootDir string, manifest Manifest) error {
 }
 
 func exportTable(ctx context.Context, db *sql.DB, rootDir, table string, maxShardBytes int64, filter RowFilter) (TableManifest, error) {
+	relDir, err := tableShardDir(table)
+	if err != nil {
+		return TableManifest{}, err
+	}
 	rows, err := db.QueryContext(ctx, "select * from "+store.QuoteIdent(table))
 	if err != nil {
 		return TableManifest{}, fmt.Errorf("query table %s: %w", table, err)
@@ -403,10 +407,10 @@ func exportTable(ctx context.Context, db *sql.DB, rootDir, table string, maxShar
 	}
 	writer := &shardWriter{
 		rootDir:       rootDir,
-		relDir:        filepath.ToSlash(filepath.Join("tables", table)),
+		relDir:        relDir,
 		maxShardBytes: maxShardBytes,
 	}
-	if err := os.MkdirAll(filepath.Join(rootDir, "tables", table), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(rootDir, filepath.FromSlash(relDir)), 0o755); err != nil {
 		return TableManifest{}, fmt.Errorf("create table dir %s: %w", table, err)
 	}
 	defer writer.close()
@@ -716,10 +720,7 @@ func planTableIncrement(previous, current TableManifest) TableImportPlan {
 			return TableImportPlan{Table: current, Mode: TableImportReplace, Files: currentFiles, Reason: "tail path changed"}
 		}
 		if !sameFileManifest(oldTail, newTail) {
-			if newTail.Rows < oldTail.Rows {
-				return TableImportPlan{Table: current, Mode: TableImportReplace, Files: currentFiles, Reason: "tail rows removed"}
-			}
-			changed = append(changed, newTail)
+			return TableImportPlan{Table: current, Mode: TableImportReplace, Files: currentFiles, Reason: "tail file changed"}
 		}
 	}
 	for i := len(previousFiles); i < len(currentFiles); i++ {
@@ -729,6 +730,17 @@ func planTableIncrement(previous, current TableManifest) TableImportPlan {
 		return TableImportPlan{Table: current, Mode: TableImportSkip, Reason: "unchanged"}
 	}
 	return TableImportPlan{Table: current, Mode: TableImportFiles, Files: changed, Reason: "tail files changed"}
+}
+
+func tableShardDir(table string) (string, error) {
+	table = strings.TrimSpace(table)
+	if table == "" {
+		return "", fmt.Errorf("table name is required")
+	}
+	if filepath.IsAbs(table) || strings.ContainsAny(table, `/\`) || table == "." || table == ".." || strings.Contains(table, "\x00") {
+		return "", fmt.Errorf("table name %q is not safe for snapshot paths", table)
+	}
+	return filepath.ToSlash(filepath.Join("tables", table)), nil
 }
 
 func tableFileManifests(table TableManifest) []FileManifest {

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -105,19 +105,43 @@ func TestExportRotatesShards(t *testing.T) {
 	}
 }
 
+func TestExportRejectsUnsafeTablePath(t *testing.T) {
+	ctx := context.Background()
+	src, err := store.Open(ctx, store.Options{
+		Path:   filepath.Join(t.TempDir(), "src.db"),
+		Schema: `create table "../escape"(id text primary key);`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer src.Close()
+	root := t.TempDir()
+	_, err = Export(ctx, ExportOptions{
+		DB:      src.DB(),
+		RootDir: root,
+		Tables:  []string{"../escape"},
+	})
+	if err == nil {
+		t.Fatal("expected unsafe table path error")
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "..", "escape")); !os.IsNotExist(statErr) {
+		t.Fatalf("unexpected escaped path stat err = %v", statErr)
+	}
+}
+
 func TestPlanIncrementalImportDetectsTailFiles(t *testing.T) {
 	previous := Manifest{
 		Version: 1,
 		Tables: []TableManifest{{
 			Name:    "things",
 			Columns: []string{"id", "body"},
-			Rows:    2,
+			Rows:    1,
 			Files:   []string{"tables/things/000000.jsonl.gz"},
 			FileManifests: []FileManifest{{
 				Path:   "tables/things/000000.jsonl.gz",
-				Rows:   2,
+				Rows:   1,
 				Size:   100,
-				SHA256: "old",
+				SHA256: "same",
 			}},
 		}},
 	}
@@ -126,12 +150,17 @@ func TestPlanIncrementalImportDetectsTailFiles(t *testing.T) {
 		Tables: []TableManifest{{
 			Name:    "things",
 			Columns: []string{"id", "body"},
-			Rows:    3,
-			Files:   []string{"tables/things/000000.jsonl.gz"},
+			Rows:    2,
+			Files:   []string{"tables/things/000000.jsonl.gz", "tables/things/000001.jsonl.gz"},
 			FileManifests: []FileManifest{{
 				Path:   "tables/things/000000.jsonl.gz",
-				Rows:   3,
-				Size:   120,
+				Rows:   1,
+				Size:   100,
+				SHA256: "same",
+			}, {
+				Path:   "tables/things/000001.jsonl.gz",
+				Rows:   1,
+				Size:   20,
 				SHA256: "new",
 			}},
 		}},
@@ -146,7 +175,7 @@ func TestPlanIncrementalImportDetectsTailFiles(t *testing.T) {
 	}
 }
 
-func TestPlanIncrementalImportReplacesUnsafeChanges(t *testing.T) {
+func TestPlanIncrementalImportReplacesUnsafeTailChanges(t *testing.T) {
 	previous := Manifest{
 		Version: 1,
 		Tables: []TableManifest{{
@@ -167,11 +196,11 @@ func TestPlanIncrementalImportReplacesUnsafeChanges(t *testing.T) {
 		Tables: []TableManifest{{
 			Name:    "things",
 			Columns: []string{"id", "body"},
-			Rows:    1,
+			Rows:    2,
 			Files:   []string{"tables/things/000000.jsonl.gz"},
 			FileManifests: []FileManifest{{
 				Path:   "tables/things/000000.jsonl.gz",
-				Rows:   1,
+				Rows:   2,
 				Size:   100,
 				SHA256: "new",
 			}},
@@ -194,12 +223,12 @@ func TestImportIncrementalImportsOnlyPlannedFiles(t *testing.T) {
 	}
 	defer src.Close()
 	mustExec(t, src.DB(), `insert into things(id, body) values('one', 'same')`)
-	mustExec(t, src.DB(), `insert into things(id, body) values('two', 'old')`)
 	root := t.TempDir()
 	previous, err := Export(ctx, ExportOptions{
-		DB:      src.DB(),
-		RootDir: root,
-		Tables:  []string{"things"},
+		DB:            src.DB(),
+		RootDir:       root,
+		Tables:        []string{"things"},
+		MaxShardBytes: 1,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -218,12 +247,12 @@ func TestImportIncrementalImportsOnlyPlannedFiles(t *testing.T) {
 	}
 	mustExec(t, dst.DB(), `insert into things(id, body) values('local', 'keep')`)
 
-	mustExec(t, src.DB(), `update things set body = 'new' where id = 'two'`)
-	mustExec(t, src.DB(), `insert into things(id, body) values('three', 'added')`)
+	mustExec(t, src.DB(), `insert into things(id, body) values('two', 'added')`)
 	current, err := Export(ctx, ExportOptions{
-		DB:      src.DB(),
-		RootDir: root,
-		Tables:  []string{"things"},
+		DB:            src.DB(),
+		RootDir:       root,
+		Tables:        []string{"things"},
+		MaxShardBytes: 1,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -244,7 +273,63 @@ func TestImportIncrementalImportsOnlyPlannedFiles(t *testing.T) {
 	if err := dst.DB().QueryRowContext(ctx, `select group_concat(id || ':' || body, ',') from (select id, body from things order by id)`).Scan(&got); err != nil {
 		t.Fatal(err)
 	}
-	if got != "local:keep,one:same,three:added,two:new" {
+	if got != "local:keep,one:same,two:added" {
+		t.Fatalf("things = %q", got)
+	}
+}
+
+func TestImportIncrementalReplacesChangedTailShard(t *testing.T) {
+	ctx := context.Background()
+	src, err := store.Open(ctx, store.Options{
+		Path:   filepath.Join(t.TempDir(), "src.db"),
+		Schema: `create table things(id text primary key, body text not null);`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer src.Close()
+	mustExec(t, src.DB(), `insert into things(id, body) values('one', 'same')`)
+	mustExec(t, src.DB(), `insert into things(id, body) values('two', 'old')`)
+	root := t.TempDir()
+	previous, err := Export(ctx, ExportOptions{DB: src.DB(), RootDir: root, Tables: []string{"things"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dst, err := store.Open(ctx, store.Options{
+		Path:   filepath.Join(t.TempDir(), "dst.db"),
+		Schema: `create table things(id text primary key, body text not null);`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dst.Close()
+	if _, err := Import(ctx, ImportOptions{DB: dst.DB(), RootDir: root}); err != nil {
+		t.Fatal(err)
+	}
+	mustExec(t, src.DB(), `delete from things where id = 'two'`)
+	mustExec(t, src.DB(), `insert into things(id, body) values('three', 'added')`)
+	current, err := Export(ctx, ExportOptions{DB: src.DB(), RootDir: root, Tables: []string{"things"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, plan, err := ImportIncremental(ctx, IncrementalImportOptions{
+		DB:       dst.DB(),
+		RootDir:  root,
+		Previous: previous,
+		Current:  current,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Tables) != 1 || plan.Tables[0].Mode != TableImportReplace {
+		t.Fatalf("plan = %+v", plan)
+	}
+	var got string
+	if err := dst.DB().QueryRowContext(ctx, `select group_concat(id || ':' || body, ',') from (select id, body from things order by id)`).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != "one:same,three:added" {
 		t.Fatalf("things = %q", got)
 	}
 }

--- a/state/adapters.go
+++ b/state/adapters.go
@@ -8,16 +8,16 @@ import (
 )
 
 const ScopedSchema = `
-create table if not exists sync_state (
+create table if not exists sync_scoped_state (
   scope text primary key,
   cursor text not null,
   updated_at text not null
 );
-create index if not exists idx_sync_state_updated_at on sync_state(updated_at desc);
+create index if not exists idx_sync_scoped_state_updated_at on sync_scoped_state(updated_at desc);
 `
 
 const CursorSchema = `
-create table if not exists sync_state (
+create table if not exists sync_cursor_state (
   source text not null,
   entity_type text not null,
   entity_id text not null,
@@ -25,7 +25,7 @@ create table if not exists sync_state (
   synced_at text not null,
   primary key (source, entity_type, entity_id)
 );
-create index if not exists idx_sync_state_synced_at on sync_state(synced_at desc);
+create index if not exists idx_sync_cursor_state_synced_at on sync_cursor_state(synced_at desc);
 `
 
 type ScopedStore struct {
@@ -54,14 +54,14 @@ type CursorRecord struct {
 
 func EnsureScopedSchema(ctx context.Context, db execQuerier) error {
 	if _, err := db.ExecContext(ctx, ScopedSchema); err != nil {
-		return fmt.Errorf("ensure scoped sync_state schema: %w", err)
+		return fmt.Errorf("ensure scoped sync state schema: %w", err)
 	}
 	return nil
 }
 
 func EnsureCursorSchema(ctx context.Context, db execQuerier) error {
 	if _, err := db.ExecContext(ctx, CursorSchema); err != nil {
-		return fmt.Errorf("ensure cursor sync_state schema: %w", err)
+		return fmt.Errorf("ensure cursor sync state schema: %w", err)
 	}
 	return nil
 }
@@ -80,7 +80,7 @@ func NewScopedWithClock(db execQuerier, now func() time.Time) *ScopedStore {
 func (s *ScopedStore) Set(ctx context.Context, scope, cursor string) error {
 	updatedAt := s.now().UTC()
 	_, err := s.db.ExecContext(ctx, `
-insert into sync_state(scope, cursor, updated_at)
+insert into sync_scoped_state(scope, cursor, updated_at)
 values (?, ?, ?)
 on conflict(scope) do update set
   cursor = excluded.cursor,
@@ -97,7 +97,7 @@ func (s *ScopedStore) Get(ctx context.Context, scope string) (ScopedRecord, bool
 	var updatedAt string
 	err := s.db.QueryRowContext(ctx, `
 select scope, cursor, updated_at
-from sync_state
+from sync_scoped_state
 where scope = ?
 `, scope).Scan(&rec.Scope, &rec.Cursor, &updatedAt)
 	if err == sql.ErrNoRows {
@@ -142,7 +142,7 @@ func NewCursorWithClock(db execQuerier, now func() time.Time) *CursorStore {
 func (s *CursorStore) Set(ctx context.Context, source, entityType, entityID, cursor string) error {
 	syncedAt := s.now().UTC()
 	_, err := s.db.ExecContext(ctx, `
-insert into sync_state(source, entity_type, entity_id, cursor, synced_at)
+insert into sync_cursor_state(source, entity_type, entity_id, cursor, synced_at)
 values (?, ?, ?, ?, ?)
 on conflict(source, entity_type, entity_id) do update set
   cursor = excluded.cursor,
@@ -159,7 +159,7 @@ func (s *CursorStore) Get(ctx context.Context, source, entityType, entityID stri
 	var syncedAt string
 	err := s.db.QueryRowContext(ctx, `
 select source, entity_type, entity_id, cursor, synced_at
-from sync_state
+from sync_cursor_state
 where source = ? and entity_type = ? and entity_id = ?
 `, source, entityType, entityID).Scan(&rec.Source, &rec.EntityType, &rec.EntityID, &rec.Cursor, &syncedAt)
 	if err == sql.ErrNoRows {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -178,3 +178,30 @@ func TestCursorStoreSetGetAndStale(t *testing.T) {
 		t.Fatal("old cursor record reported fresh")
 	}
 }
+
+func TestStateSchemasCoexistInOneDatabase(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := EnsureSchema(ctx, db); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureScopedSchema(ctx, db); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureCursorSchema(ctx, db); err != nil {
+		t.Fatal(err)
+	}
+	if err := New(db).Set(ctx, "share", "repo", "last_import", "value"); err != nil {
+		t.Fatal(err)
+	}
+	if err := NewScoped(db).Set(ctx, "share:last_import_at", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	if err := NewCursor(db).Set(ctx, "share", "manifest", "generated_at", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -147,13 +148,15 @@ func (s *Store) EnsureSchemaVersion(ctx context.Context, version int) error {
 	if current == version {
 		return nil
 	}
-	if _, err := s.db.ExecContext(ctx, `delete from schema_migrations`); err != nil {
-		return fmt.Errorf("clear schema version: %w", err)
-	}
-	if _, err := s.db.ExecContext(ctx, `insert into schema_migrations(version) values(?)`, version); err != nil {
-		return fmt.Errorf("write schema version: %w", err)
-	}
-	return nil
+	return s.WithTx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `delete from schema_migrations`); err != nil {
+			return fmt.Errorf("clear schema version: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `insert into schema_migrations(version) values(?)`, version); err != nil {
+			return fmt.Errorf("write schema version: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *Store) SchemaVersion(ctx context.Context) (int, error) {
@@ -230,7 +233,8 @@ func dsn(path, pragmas string) string {
 		}
 		return path + sep + pragmas
 	}
-	return "file:" + path + "?" + pragmas
+	u := url.URL{Scheme: "file", Path: path}
+	return u.String() + "?" + pragmas
 }
 
 func ensureDBFile(path string) error {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -98,3 +98,41 @@ func TestReadOnlyRejectsWrites(t *testing.T) {
 		t.Fatal("expected readonly write to fail")
 	}
 }
+
+func TestOpenEscapesURIReservedPathCharacters(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "archive?tenant=a#frag.db")
+	st, err := Open(ctx, Options{
+		Path:   path,
+		Schema: `create table things(id text primary key, value text not null);`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `insert into things(id, value) values('a', 'one')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("literal database path missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "archive")); !os.IsNotExist(err) {
+		t.Fatalf("unexpected truncated database stat err = %v", err)
+	}
+
+	ro, err := OpenReadOnly(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ro.Close()
+	var value string
+	if err := ro.DB().QueryRowContext(ctx, `select value from things where id = 'a'`).Scan(&value); err != nil {
+		t.Fatal(err)
+	}
+	if value != "one" {
+		t.Fatalf("value = %q", value)
+	}
+}

--- a/vector/search_test.go
+++ b/vector/search_test.go
@@ -200,7 +200,7 @@ func TestTurboVecDefaultCommandUsesSafePythonMode(t *testing.T) {
 	require.Equal(t, true, defaultCommand)
 }
 
-func TestTurboVecCommandResolvesRelativePythonBeforeWorkingDirChange(t *testing.T) {
+func TestTurboVecDefaultCommandRejectsRelativePythonPath(t *testing.T) {
 	dir := t.TempDir()
 	python := filepath.Join(dir, "python")
 	if err := os.WriteFile(python, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
@@ -216,15 +216,8 @@ func TestTurboVecCommandResolvesRelativePythonBeforeWorkingDirChange(t *testing.
 	if err := os.Chdir(dir); err != nil {
 		t.Fatalf("chdir: %v", err)
 	}
-	command, defaultCommand, err := turboVecCommand(TurboVecOptions{Python: "./python"})
-	require.NoError(t, err)
-	wantPython, err := filepath.EvalSymlinks(python)
-	require.NoError(t, err)
-	gotPython, err := filepath.EvalSymlinks(command[0])
-	require.NoError(t, err)
-	require.Equal(t, wantPython, gotPython)
-	require.Equal(t, []string{"-E", "-c", turboVecBridgeScript}, command[1:])
-	require.Equal(t, true, defaultCommand)
+	_, _, err = turboVecCommand(TurboVecOptions{Python: "./python"})
+	require.ErrorContains(t, err, "must be absolute or resolved from PATH")
 }
 
 func TestTurboVecTieLessRequiresBoundedCandidateSet(t *testing.T) {

--- a/vector/turbovec.go
+++ b/vector/turbovec.go
@@ -331,11 +331,7 @@ func resolvePythonPath(python string) (string, error) {
 		}
 		return resolved, nil
 	}
-	abs, err := filepath.Abs(python)
-	if err != nil {
-		return "", fmt.Errorf("resolve Python path %q: %w", python, err)
-	}
-	return abs, nil
+	return "", fmt.Errorf("Python path %q must be absolute or resolved from PATH", python)
 }
 
 func firstLine(value string) string {


### PR DESCRIPTION
## Summary
- harden crawlctl log tailing, scheduler locking/interval rendering, release checks, remote auth transport, mirror commits, and vector Python path handling
- make backup/cache/store writes safer and isolate sync state schemas
- run clawpatch findings to zero open/uncertain findings and add regression coverage

## Checks
- GOWORK=off go mod tidy
- git diff --exit-code -- go.mod go.sum
- GOWORK=off go vet ./...
- GOWORK=off go test -count=1 ./...
- clawpatch report: open=0, uncertain=0
