### PR TITLE
feat: add durable archive synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add non-mutating archive tag validation and rebase-based write synchronization for durable multi-machine backup retries.
 - Add reusable Git snapshot history/tag/ref restoration, SQLite bundle snapshots, managed snapshot sidecars, mapped sync-state adapters, FTS5 helpers, and the shared contact-export contract; refresh stable dependencies.
 
 ## v0.12.2 - 2026-06-17

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -143,16 +143,19 @@ func writeShard(ctx context.Context, cfg Config, old Manifest, table, rel string
 	}
 	hash := SHA256Hex(plaintext)
 	targetRel := rel
-	if oldEntry, ok := old.Entry(rel); ok {
+	oldEntry, hasOldEntry := old.logicalEntry(table, rel)
+	if hasOldEntry {
 		if oldEntry.SHA256 != hash || !reuseEncrypted {
 			targetRel = versionedShardPath(rel, hash)
+		} else {
+			targetRel = oldEntry.Path
 		}
 	}
 	target, err := ResolveShardPath(cfg.Repo, targetRel)
 	if err != nil {
 		return ShardEntry{}, err
 	}
-	if oldEntry, ok := old.Entry(targetRel); reuseEncrypted && ok && oldEntry.SHA256 == hash {
+	if reuseEncrypted && hasOldEntry && oldEntry.Path == targetRel && oldEntry.SHA256 == hash {
 		if info, err := os.Stat(target); err == nil {
 			oldEntry.Bytes = info.Size()
 			return oldEntry, nil
@@ -175,6 +178,18 @@ func writeShard(ctx context.Context, cfg Config, old Manifest, table, rel string
 		return ShardEntry{}, err
 	}
 	return ShardEntry{Table: table, Path: targetRel, Rows: rows, SHA256: hash, Bytes: int64(len(encrypted))}, nil
+}
+
+func (m Manifest) logicalEntry(table, rel string) (ShardEntry, bool) {
+	if entry, ok := m.Entry(rel); ok {
+		return entry, true
+	}
+	for _, entry := range m.Shards {
+		if entry.Table == table && entry.Path == versionedShardPath(rel, entry.SHA256) {
+			return entry, true
+		}
+	}
+	return ShardEntry{}, false
 }
 
 func versionedShardPath(rel, hash string) string {

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -33,9 +33,10 @@ type Manifest struct {
 }
 
 type Shard struct {
-	Table string
-	Path  string
-	Rows  any
+	Table    string
+	CountKey string
+	Path     string
+	Rows     any
 }
 
 type ShardEntry struct {
@@ -82,7 +83,11 @@ func WriteSnapshot(ctx context.Context, cfg Config, shards []Shard, old Manifest
 		if err := ctx.Err(); err != nil {
 			return Manifest{}, err
 		}
-		manifest.Counts[shard.Table] += rows
+		countKey := strings.TrimSpace(shard.CountKey)
+		if countKey == "" {
+			countKey = shard.Table
+		}
+		manifest.Counts[countKey] += rows
 		manifest.Shards = append(manifest.Shards, entry)
 	}
 	sort.Slice(manifest.Shards, func(i, j int) bool { return manifest.Shards[i].Path < manifest.Shards[j].Path })

--- a/backup/backup_test.go
+++ b/backup/backup_test.go
@@ -82,6 +82,28 @@ func TestWriteSnapshotHonorsCanceledContext(t *testing.T) {
 	}
 }
 
+func TestWriteSnapshotSupportsStableCountKeys(t *testing.T) {
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "age.key")
+	recipient, err := EnsureIdentity(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := Config{Repo: filepath.Join(dir, "repo"), Identity: identity, Recipients: []string{recipient}}
+	manifest, err := WriteSnapshot(context.Background(), cfg, []Shard{
+		{Table: "group_participants", CountKey: "participants", Path: "data/participants.jsonl.gz.age", Rows: []row{{ID: "1"}}},
+	}, Manifest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Counts["participants"] != 1 {
+		t.Fatalf("stable count key missing: %+v", manifest.Counts)
+	}
+	if _, ok := manifest.Counts["group_participants"]; ok {
+		t.Fatalf("table name leaked into counts: %+v", manifest.Counts)
+	}
+}
+
 func TestWriteShardVersionsChangedExistingManifestPath(t *testing.T) {
 	dir := t.TempDir()
 	identity := filepath.Join(dir, "age.key")

--- a/backup/backup_test.go
+++ b/backup/backup_test.go
@@ -150,6 +150,14 @@ func TestWriteShardVersionsChangedExistingManifestPath(t *testing.T) {
 	if entry.Path == rel {
 		t.Fatalf("re-encrypted shard reused old path %q", rel)
 	}
+	rotated := entry
+	entry, err = writeShard(context.Background(), cfg, Manifest{Shards: []ShardEntry{rotated}}, "messages", rel, []byte("new plaintext\n"), 1, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry != rotated {
+		t.Fatalf("unchanged versioned shard was rewritten: got %+v, want %+v", entry, rotated)
+	}
 }
 
 func TestPublicBackupHelpers(t *testing.T) {

--- a/mirror/history.go
+++ b/mirror/history.go
@@ -103,10 +103,10 @@ func CreateImmutableTag(ctx context.Context, opts Options, tag string) (string, 
 	if tag == "" {
 		return "", nil
 	}
-	fullRef := "refs/tags/" + tag
-	if err := run(ctx, opts.RepoPath, opts.Git, "check-ref-format", fullRef); err != nil {
-		return "", fmt.Errorf("invalid snapshot tag %q: %w", tag, err)
+	if err := ValidateTag(ctx, opts, tag); err != nil {
+		return "", err
 	}
+	fullRef := "refs/tags/" + tag
 	head, err := ResolveCommit(ctx, opts, "HEAD")
 	if err != nil {
 		return "", err
@@ -122,6 +122,19 @@ func CreateImmutableTag(ctx context.Context, opts Options, tag string) (string, 
 		return "", err
 	}
 	return tag, nil
+}
+
+// ValidateTag checks a proposed tag without changing repository refs.
+func ValidateTag(ctx context.Context, opts Options, tag string) error {
+	opts = normalize(opts)
+	tag = strings.TrimSpace(tag)
+	if tag == "" {
+		return nil
+	}
+	if err := run(ctx, opts.RepoPath, opts.Git, "check-ref-format", "refs/tags/"+tag); err != nil {
+		return fmt.Errorf("invalid snapshot tag %q: %w", tag, err)
+	}
+	return nil
 }
 
 func PushAtomic(ctx context.Context, opts Options, refs ...string) error {

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -101,6 +101,38 @@ func PullCurrent(ctx context.Context, opts Options) error {
 	return run(ctx, opts.RepoPath, opts.Git, "pull", "--ff-only", "origin", opts.Branch)
 }
 
+// SyncForWrite updates the archive branch while preserving local commits from a
+// previous failed push. Repositories without an origin or remote branch remain
+// local-only.
+func SyncForWrite(ctx context.Context, opts Options) error {
+	opts = normalize(opts)
+	if err := EnsureRepo(ctx, opts); err != nil {
+		return err
+	}
+	remotes, err := output(ctx, opts.RepoPath, opts.Git, "remote")
+	if err != nil {
+		return fmt.Errorf("list git remotes: %w", err)
+	}
+	if !containsField(remotes, "origin") {
+		return nil
+	}
+	if err := run(ctx, opts.RepoPath, opts.Git, "fetch", "--prune", "--tags", "origin"); err != nil {
+		return err
+	}
+	remoteRef := "refs/remotes/origin/" + opts.Branch
+	if _, err := output(ctx, opts.RepoPath, opts.Git, "rev-parse", "--verify", remoteRef); err != nil {
+		return nil
+	}
+	localRef := "refs/heads/" + opts.Branch
+	if _, err := output(ctx, opts.RepoPath, opts.Git, "rev-parse", "--verify", localRef); err != nil {
+		return run(ctx, opts.RepoPath, opts.Git, "checkout", "-B", opts.Branch, "origin/"+opts.Branch)
+	}
+	if err := run(ctx, opts.RepoPath, opts.Git, "checkout", opts.Branch); err != nil {
+		return err
+	}
+	return run(ctx, opts.RepoPath, opts.Git, "rebase", "origin/"+opts.Branch)
+}
+
 func Commit(ctx context.Context, opts Options, message string) (bool, error) {
 	return CommitPaths(ctx, opts, message, []string{"."})
 }

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -152,12 +153,73 @@ func syncBranchForWrite(ctx context.Context, opts Options) error {
 	if err := run(ctx, opts.RepoPath, opts.Git, "checkout", opts.Branch); err != nil {
 		return err
 	}
-	return run(ctx, opts.RepoPath, opts.Git,
+	tags, oldHead, err := localOnlyHeadTags(ctx, opts, remoteRef, localRef)
+	if err != nil {
+		return err
+	}
+	if err := run(ctx, opts.RepoPath, opts.Git,
 		"-c", "commit.gpgsign=false",
 		"-c", "user.name=crawlkit",
 		"-c", "user.email=crawlkit@example.invalid",
 		"rebase", "origin/"+opts.Branch,
-	)
+	); err != nil {
+		return err
+	}
+	if len(tags) == 0 {
+		return nil
+	}
+	newHead, err := ResolveCommit(ctx, opts, "HEAD")
+	if err != nil {
+		return err
+	}
+	for _, tag := range tags {
+		if err := run(ctx, opts.RepoPath, opts.Git, "update-ref", "refs/tags/"+tag, newHead, oldHead); err != nil {
+			return fmt.Errorf("retarget local snapshot tag %q after rebase: %w", tag, err)
+		}
+	}
+	return nil
+}
+
+func localOnlyHeadTags(ctx context.Context, opts Options, remoteRef, localRef string) ([]string, string, error) {
+	aheadRaw, err := output(ctx, opts.RepoPath, opts.Git, "rev-list", "--count", remoteRef+".."+localRef)
+	if err != nil {
+		return nil, "", fmt.Errorf("count local archive commits: %w", err)
+	}
+	ahead, err := strconv.Atoi(strings.TrimSpace(aheadRaw))
+	if err != nil {
+		return nil, "", fmt.Errorf("parse local archive commit count %q: %w", strings.TrimSpace(aheadRaw), err)
+	}
+	if ahead == 0 {
+		return nil, "", nil
+	}
+	oldHead, err := ResolveCommit(ctx, opts, "HEAD")
+	if err != nil {
+		return nil, "", err
+	}
+	tagsRaw, err := output(ctx, opts.RepoPath, opts.Git, "tag", "--points-at", oldHead)
+	if err != nil {
+		return nil, "", fmt.Errorf("list local snapshot tags: %w", err)
+	}
+	var tags []string
+	for _, tag := range strings.Fields(tagsRaw) {
+		fullRef := "refs/tags/" + tag
+		objectType, err := output(ctx, opts.RepoPath, opts.Git, "cat-file", "-t", fullRef)
+		if err != nil {
+			return nil, "", fmt.Errorf("inspect snapshot tag %q: %w", tag, err)
+		}
+		if strings.TrimSpace(objectType) != "commit" {
+			return nil, "", fmt.Errorf("annotated local tag %q prevents archive rebase", tag)
+		}
+		remoteTag, err := output(ctx, opts.RepoPath, opts.Git, "ls-remote", "--tags", "origin", fullRef)
+		if err != nil {
+			return nil, "", fmt.Errorf("check remote snapshot tag %q: %w", tag, err)
+		}
+		if strings.TrimSpace(remoteTag) != "" {
+			return nil, "", fmt.Errorf("published snapshot tag %q prevents archive rebase", tag)
+		}
+		tags = append(tags, tag)
+	}
+	return tags, oldHead, nil
 }
 
 func Commit(ctx context.Context, opts Options, message string) (bool, error) {

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 )
 
@@ -153,7 +152,7 @@ func syncBranchForWrite(ctx context.Context, opts Options) error {
 	if err := run(ctx, opts.RepoPath, opts.Git, "checkout", opts.Branch); err != nil {
 		return err
 	}
-	tags, oldHead, err := localOnlyHeadTags(ctx, opts, remoteRef, localRef)
+	tagMoves, oldCommits, err := localOnlyTags(ctx, opts, remoteRef, localRef)
 	if err != nil {
 		return err
 	}
@@ -161,65 +160,73 @@ func syncBranchForWrite(ctx context.Context, opts Options) error {
 		"-c", "commit.gpgsign=false",
 		"-c", "user.name=crawlkit",
 		"-c", "user.email=crawlkit@example.invalid",
-		"rebase", "origin/"+opts.Branch,
+		"rebase", "--reapply-cherry-picks", "--empty=keep", "origin/"+opts.Branch,
 	); err != nil {
 		return err
 	}
-	if len(tags) == 0 {
+	if len(tagMoves) == 0 {
 		return nil
 	}
-	newHead, err := ResolveCommit(ctx, opts, "HEAD")
+	newCommits, err := localCommits(ctx, opts, remoteRef, localRef)
 	if err != nil {
 		return err
 	}
-	for _, tag := range tags {
-		if err := run(ctx, opts.RepoPath, opts.Git, "update-ref", "refs/tags/"+tag, newHead, oldHead); err != nil {
-			return fmt.Errorf("retarget local snapshot tag %q after rebase: %w", tag, err)
+	if len(newCommits) != len(oldCommits) {
+		return fmt.Errorf("archive rebase changed local commit count from %d to %d; snapshot tags were not moved", len(oldCommits), len(newCommits))
+	}
+	for _, move := range tagMoves {
+		if err := run(ctx, opts.RepoPath, opts.Git, "update-ref", "refs/tags/"+move.tag, newCommits[move.commitIndex], move.oldCommit); err != nil {
+			return fmt.Errorf("retarget local snapshot tag %q after rebase: %w", move.tag, err)
 		}
 	}
 	return nil
 }
 
-func localOnlyHeadTags(ctx context.Context, opts Options, remoteRef, localRef string) ([]string, string, error) {
-	aheadRaw, err := output(ctx, opts.RepoPath, opts.Git, "rev-list", "--count", remoteRef+".."+localRef)
+type tagMove struct {
+	tag         string
+	oldCommit   string
+	commitIndex int
+}
+
+func localCommits(ctx context.Context, opts Options, remoteRef, localRef string) ([]string, error) {
+	raw, err := output(ctx, opts.RepoPath, opts.Git, "rev-list", "--reverse", remoteRef+".."+localRef)
 	if err != nil {
-		return nil, "", fmt.Errorf("count local archive commits: %w", err)
+		return nil, fmt.Errorf("list local archive commits: %w", err)
 	}
-	ahead, err := strconv.Atoi(strings.TrimSpace(aheadRaw))
+	return strings.Fields(raw), nil
+}
+
+func localOnlyTags(ctx context.Context, opts Options, remoteRef, localRef string) ([]tagMove, []string, error) {
+	commits, err := localCommits(ctx, opts, remoteRef, localRef)
 	if err != nil {
-		return nil, "", fmt.Errorf("parse local archive commit count %q: %w", strings.TrimSpace(aheadRaw), err)
+		return nil, nil, err
 	}
-	if ahead == 0 {
-		return nil, "", nil
-	}
-	oldHead, err := ResolveCommit(ctx, opts, "HEAD")
-	if err != nil {
-		return nil, "", err
-	}
-	tagsRaw, err := output(ctx, opts.RepoPath, opts.Git, "tag", "--points-at", oldHead)
-	if err != nil {
-		return nil, "", fmt.Errorf("list local snapshot tags: %w", err)
-	}
-	var tags []string
-	for _, tag := range strings.Fields(tagsRaw) {
-		fullRef := "refs/tags/" + tag
-		objectType, err := output(ctx, opts.RepoPath, opts.Git, "cat-file", "-t", fullRef)
+	var moves []tagMove
+	for index, commit := range commits {
+		tagsRaw, err := output(ctx, opts.RepoPath, opts.Git, "tag", "--points-at", commit)
 		if err != nil {
-			return nil, "", fmt.Errorf("inspect snapshot tag %q: %w", tag, err)
+			return nil, nil, fmt.Errorf("list local snapshot tags at %s: %w", ShortRef(commit), err)
 		}
-		if strings.TrimSpace(objectType) != "commit" {
-			return nil, "", fmt.Errorf("annotated local tag %q prevents archive rebase", tag)
+		for _, tag := range strings.Fields(tagsRaw) {
+			fullRef := "refs/tags/" + tag
+			objectType, err := output(ctx, opts.RepoPath, opts.Git, "cat-file", "-t", fullRef)
+			if err != nil {
+				return nil, nil, fmt.Errorf("inspect snapshot tag %q: %w", tag, err)
+			}
+			if strings.TrimSpace(objectType) != "commit" {
+				return nil, nil, fmt.Errorf("annotated local tag %q prevents archive rebase", tag)
+			}
+			remoteTag, err := output(ctx, opts.RepoPath, opts.Git, "ls-remote", "--tags", "origin", fullRef)
+			if err != nil {
+				return nil, nil, fmt.Errorf("check remote snapshot tag %q: %w", tag, err)
+			}
+			if strings.TrimSpace(remoteTag) != "" {
+				return nil, nil, fmt.Errorf("published snapshot tag %q prevents archive rebase", tag)
+			}
+			moves = append(moves, tagMove{tag: tag, oldCommit: commit, commitIndex: index})
 		}
-		remoteTag, err := output(ctx, opts.RepoPath, opts.Git, "ls-remote", "--tags", "origin", fullRef)
-		if err != nil {
-			return nil, "", fmt.Errorf("check remote snapshot tag %q: %w", tag, err)
-		}
-		if strings.TrimSpace(remoteTag) != "" {
-			return nil, "", fmt.Errorf("published snapshot tag %q prevents archive rebase", tag)
-		}
-		tags = append(tags, tag)
 	}
-	return tags, oldHead, nil
+	return moves, commits, nil
 }
 
 func Commit(ctx context.Context, opts Options, message string) (bool, error) {

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -109,6 +109,28 @@ func SyncForWrite(ctx context.Context, opts Options) error {
 	if err := EnsureRepo(ctx, opts); err != nil {
 		return err
 	}
+	return syncBranchForWrite(ctx, opts)
+}
+
+// SyncCurrentForWrite rebases the checked-out branch, preserving repositories
+// created before a caller standardized its default branch name.
+func SyncCurrentForWrite(ctx context.Context, opts Options) error {
+	opts = normalize(opts)
+	if err := EnsureRepo(ctx, opts); err != nil {
+		return err
+	}
+	branch, err := output(ctx, opts.RepoPath, opts.Git, "symbolic-ref", "--quiet", "--short", "HEAD")
+	if err != nil {
+		return fmt.Errorf("resolve current git branch: %w", err)
+	}
+	opts.Branch = strings.TrimSpace(branch)
+	if opts.Branch == "" {
+		return errors.New("current git branch is empty")
+	}
+	return syncBranchForWrite(ctx, opts)
+}
+
+func syncBranchForWrite(ctx context.Context, opts Options) error {
 	remotes, err := output(ctx, opts.RepoPath, opts.Git, "remote")
 	if err != nil {
 		return fmt.Errorf("list git remotes: %w", err)

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -130,7 +130,12 @@ func SyncForWrite(ctx context.Context, opts Options) error {
 	if err := run(ctx, opts.RepoPath, opts.Git, "checkout", opts.Branch); err != nil {
 		return err
 	}
-	return run(ctx, opts.RepoPath, opts.Git, "rebase", "origin/"+opts.Branch)
+	return run(ctx, opts.RepoPath, opts.Git,
+		"-c", "commit.gpgsign=false",
+		"-c", "user.name=crawlkit",
+		"-c", "user.email=crawlkit@example.invalid",
+		"rebase", "origin/"+opts.Branch,
+	)
 }
 
 func Commit(ctx context.Context, opts Options, message string) (bool, error) {

--- a/mirror/mirror_test.go
+++ b/mirror/mirror_test.go
@@ -266,6 +266,19 @@ func TestSyncForWriteRebasesUnpushedCommit(t *testing.T) {
 	if tag, err := CreateImmutableTag(ctx, localOpts, "snapshot/local"); err != nil || tag != "snapshot/local" {
 		t.Fatalf("local tag = %q, %v", tag, err)
 	}
+	oldFirst, err := ResolveCommit(ctx, localOpts, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "local-two.txt"), []byte("local two\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if committed, err := Commit(ctx, localOpts, "archive: local two"); err != nil || !committed {
+		t.Fatalf("second local commit = %v, %v", committed, err)
+	}
+	if tag, err := CreateImmutableTag(ctx, localOpts, "snapshot/local-two"); err != nil || tag != "snapshot/local-two" {
+		t.Fatalf("second local tag = %q, %v", tag, err)
+	}
 	oldLocal, err := ResolveCommit(ctx, localOpts, "HEAD")
 	if err != nil {
 		t.Fatal(err)
@@ -290,12 +303,19 @@ func TestSyncForWriteRebasesUnpushedCommit(t *testing.T) {
 	if newLocal == oldLocal {
 		t.Fatal("local commit was not rebased")
 	}
-	tagged, err := ResolveCommit(ctx, localOpts, "snapshot/local")
+	firstTagged, err := ResolveCommit(ctx, localOpts, "snapshot/local")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if tagged != newLocal {
-		t.Fatalf("local tag = %s, want rebased HEAD %s", tagged, newLocal)
+	if firstTagged == oldFirst || firstTagged == newLocal {
+		t.Fatalf("first local tag was not mapped to its rebased commit: %s", firstTagged)
+	}
+	secondTagged, err := ResolveCommit(ctx, localOpts, "snapshot/local-two")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secondTagged != newLocal {
+		t.Fatalf("second local tag = %s, want rebased HEAD %s", secondTagged, newLocal)
 	}
 	for _, name := range []string{"local.txt", "remote.txt"} {
 		if _, err := os.Stat(filepath.Join(repo, name)); err != nil {

--- a/mirror/mirror_test.go
+++ b/mirror/mirror_test.go
@@ -283,6 +283,58 @@ func TestSyncForWriteRebasesUnpushedCommit(t *testing.T) {
 	}
 }
 
+func TestSyncCurrentForWritePreservesLegacyBranch(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	remote := filepath.Join(dir, "remote.git")
+	seed := filepath.Join(dir, "seed")
+	repo := filepath.Join(dir, "share")
+	if err := run(ctx, "", "git", "init", "--bare", remote); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(ctx, "", "git", "clone", remote, seed); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(ctx, seed, "git", "checkout", "-B", "legacy"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(seed, "manifest.json"), []byte("one\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	seedOpts := Options{RepoPath: seed, Branch: "legacy"}
+	if committed, err := Commit(ctx, seedOpts, "archive: seed"); err != nil || !committed {
+		t.Fatalf("seed commit = %v, %v", committed, err)
+	}
+	if err := PushAtomic(ctx, seedOpts, "HEAD"); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(ctx, "", "git", "clone", "--branch", "legacy", remote, repo); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(seed, "remote.txt"), []byte("remote\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if committed, err := Commit(ctx, seedOpts, "archive: remote"); err != nil || !committed {
+		t.Fatalf("remote commit = %v, %v", committed, err)
+	}
+	if err := PushAtomic(ctx, seedOpts, "HEAD"); err != nil {
+		t.Fatal(err)
+	}
+	if err := SyncCurrentForWrite(ctx, Options{RepoPath: repo, Branch: "main"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, "remote.txt")); err != nil {
+		t.Fatalf("legacy branch did not sync: %v", err)
+	}
+	branch, err := output(ctx, repo, "git", "branch", "--show-current")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(branch) != "legacy" {
+		t.Fatalf("branch = %q, want legacy", strings.TrimSpace(branch))
+	}
+}
+
 func TestCleanSQLiteSidecars(t *testing.T) {
 	dir := t.TempDir()
 	files := []string{"archive.db", "archive.db-wal", "archive.db-shm", "notes.txt"}

--- a/mirror/mirror_test.go
+++ b/mirror/mirror_test.go
@@ -227,6 +227,62 @@ func TestPullCurrentUsesExistingOrigin(t *testing.T) {
 	}
 }
 
+func TestSyncForWriteRebasesUnpushedCommit(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	remote := filepath.Join(dir, "remote.git")
+	seed := filepath.Join(dir, "seed")
+	repo := filepath.Join(dir, "share")
+	peer := filepath.Join(dir, "peer")
+	if err := run(ctx, "", "git", "init", "--bare", remote); err != nil {
+		t.Fatal(err)
+	}
+	opts := Options{RepoPath: seed, Remote: remote, Branch: "main"}
+	if err := EnsureRemote(ctx, opts); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(seed, "manifest.json"), []byte("one\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if committed, err := Commit(ctx, opts, "archive: seed"); err != nil || !committed {
+		t.Fatalf("seed commit = %v, %v", committed, err)
+	}
+	if err := Push(ctx, opts); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(ctx, "", "git", "clone", "--branch", "main", remote, repo); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(ctx, "", "git", "clone", "--branch", "main", remote, peer); err != nil {
+		t.Fatal(err)
+	}
+	localOpts := Options{RepoPath: repo, Branch: "main"}
+	if err := os.WriteFile(filepath.Join(repo, "local.txt"), []byte("local\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if committed, err := Commit(ctx, localOpts, "archive: local"); err != nil || !committed {
+		t.Fatalf("local commit = %v, %v", committed, err)
+	}
+	peerOpts := Options{RepoPath: peer, Branch: "main"}
+	if err := os.WriteFile(filepath.Join(peer, "remote.txt"), []byte("remote\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if committed, err := Commit(ctx, peerOpts, "archive: remote"); err != nil || !committed {
+		t.Fatalf("remote commit = %v, %v", committed, err)
+	}
+	if err := Push(ctx, peerOpts); err != nil {
+		t.Fatal(err)
+	}
+	if err := SyncForWrite(ctx, localOpts); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"local.txt", "remote.txt"} {
+		if _, err := os.Stat(filepath.Join(repo, name)); err != nil {
+			t.Fatalf("%s missing after sync: %v", name, err)
+		}
+	}
+}
+
 func TestCleanSQLiteSidecars(t *testing.T) {
 	dir := t.TempDir()
 	files := []string{"archive.db", "archive.db-wal", "archive.db-shm", "notes.txt"}
@@ -383,6 +439,12 @@ func TestHistoryValidationAndLocalFetch(t *testing.T) {
 	}
 	if _, err := CreateImmutableTag(ctx, opts, "bad tag"); err == nil {
 		t.Fatal("invalid tag should fail")
+	}
+	if err := ValidateTag(ctx, opts, "bad tag"); err == nil {
+		t.Fatal("invalid tag validation should fail")
+	}
+	if err := ValidateTag(ctx, opts, ""); err != nil {
+		t.Fatalf("empty optional tag: %v", err)
 	}
 	if got := ShortRef("123456789012345"); got != "123456789012" {
 		t.Fatalf("short ref = %q", got)

--- a/mirror/mirror_test.go
+++ b/mirror/mirror_test.go
@@ -263,6 +263,13 @@ func TestSyncForWriteRebasesUnpushedCommit(t *testing.T) {
 	if committed, err := Commit(ctx, localOpts, "archive: local"); err != nil || !committed {
 		t.Fatalf("local commit = %v, %v", committed, err)
 	}
+	if tag, err := CreateImmutableTag(ctx, localOpts, "snapshot/local"); err != nil || tag != "snapshot/local" {
+		t.Fatalf("local tag = %q, %v", tag, err)
+	}
+	oldLocal, err := ResolveCommit(ctx, localOpts, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
 	peerOpts := Options{RepoPath: peer, Branch: "main"}
 	if err := os.WriteFile(filepath.Join(peer, "remote.txt"), []byte("remote\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -275,6 +282,20 @@ func TestSyncForWriteRebasesUnpushedCommit(t *testing.T) {
 	}
 	if err := SyncForWrite(ctx, localOpts); err != nil {
 		t.Fatal(err)
+	}
+	newLocal, err := ResolveCommit(ctx, localOpts, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newLocal == oldLocal {
+		t.Fatal("local commit was not rebased")
+	}
+	tagged, err := ResolveCommit(ctx, localOpts, "snapshot/local")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tagged != newLocal {
+		t.Fatalf("local tag = %s, want rebased HEAD %s", tagged, newLocal)
 	}
 	for _, name := range []string{"local.txt", "remote.txt"} {
 		if _, err := os.Stat(filepath.Join(repo, name)); err != nil {


### PR DESCRIPTION
## Summary

- validate optional snapshot tags without changing refs
- synchronize archive branches with fetch + rebase, preserving commits left by failed pushes
- keep local-only repositories and not-yet-created remote branches working

## Proof

- `GOWORK=off go test -count=1 ./...`
- `GOWORK=off go test -race -count=1 ./...`
- `GOWORK=off go vet ./...`
- autoreview: no accepted/actionable findings

No release or tag requested.
