### PR TITLE
fix: preserve private mirror branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Update Go to 1.26.4 for current standard-library security fixes and add race and vulnerability CI gates.
+- Preserve unpublished local mirror branches during pulls and support caller-selected private repository directory modes.
 - Allow managed sidecar trees to prune selected generated files while preserving unrelated files.
 - Add non-mutating archive tag validation and rebase-based write synchronization for durable multi-machine backup retries.
 - Add reusable Git snapshot history/tag/ref restoration, SQLite bundle snapshots, managed snapshot sidecars, mapped sync-state adapters, FTS5 helpers, and the shared contact-export contract; refresh stable dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Update Go to 1.26.4 for current standard-library security fixes and add race and vulnerability CI gates.
-- Preserve unpublished local mirror branches during pulls and support caller-selected private repository directory modes.
+- Preserve unpublished local mirror branches during pulls, clone the requested remote branch, and support caller-selected private repository directory modes.
 - Allow managed sidecar trees to prune selected generated files while preserving unrelated files.
 - Add non-mutating archive tag validation and rebase-based write synchronization for durable multi-machine backup retries.
 - Add reusable Git snapshot history/tag/ref restoration, SQLite bundle snapshots, managed snapshot sidecars, mapped sync-state adapters, FTS5 helpers, and the shared contact-export contract; refresh stable dependencies.

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -15,6 +15,7 @@ type Options struct {
 	Remote   string
 	Branch   string
 	Git      string
+	DirMode  os.FileMode
 }
 
 func EnsureRepo(ctx context.Context, opts Options) error {
@@ -23,28 +24,43 @@ func EnsureRepo(ctx context.Context, opts Options) error {
 		return errors.New("repo path is required")
 	}
 	if _, err := os.Stat(filepath.Join(opts.RepoPath, ".git")); err == nil {
+		if opts.DirMode != 0 {
+			if err := os.Chmod(opts.RepoPath, opts.DirMode); err != nil {
+				return fmt.Errorf("secure repo path: %w", err)
+			}
+		}
 		if opts.Remote != "" {
 			return setOrigin(ctx, opts)
 		}
 		return nil
 	}
 	if opts.Remote != "" {
-		if err := os.MkdirAll(filepath.Dir(opts.RepoPath), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(opts.RepoPath), creationDirMode(opts)); err != nil {
 			return fmt.Errorf("create repo parent: %w", err)
 		}
 		if err := run(ctx, "", opts.Git, "clone", opts.Remote, opts.RepoPath); err != nil {
 			return err
+		}
+		if opts.DirMode != 0 {
+			if err := os.Chmod(opts.RepoPath, opts.DirMode); err != nil {
+				return fmt.Errorf("set repo permissions: %w", err)
+			}
 		}
 		if opts.Branch != "" {
 			return run(ctx, opts.RepoPath, opts.Git, "checkout", "-B", opts.Branch)
 		}
 		return nil
 	}
-	if err := os.MkdirAll(opts.RepoPath, 0o755); err != nil {
+	if err := os.MkdirAll(opts.RepoPath, creationDirMode(opts)); err != nil {
 		return fmt.Errorf("create repo path: %w", err)
 	}
 	if err := run(ctx, opts.RepoPath, opts.Git, "init"); err != nil {
 		return err
+	}
+	if opts.DirMode != 0 {
+		if err := os.Chmod(opts.RepoPath, opts.DirMode); err != nil {
+			return fmt.Errorf("set repo permissions: %w", err)
+		}
 	}
 	if opts.Branch != "" {
 		return run(ctx, opts.RepoPath, opts.Git, "checkout", "-B", opts.Branch)
@@ -92,11 +108,24 @@ func PullCurrent(ctx context.Context, opts Options) error {
 	if err := run(ctx, opts.RepoPath, opts.Git, "fetch", "--prune", "origin"); err != nil {
 		return err
 	}
-	if _, err := output(ctx, opts.RepoPath, opts.Git, "rev-parse", "--verify", "refs/heads/"+opts.Branch); err != nil {
+	remoteRef := "refs/remotes/origin/" + opts.Branch
+	_, remoteErr := output(ctx, opts.RepoPath, opts.Git, "rev-parse", "--verify", remoteRef)
+	_, localErr := output(ctx, opts.RepoPath, opts.Git, "rev-parse", "--verify", "refs/heads/"+opts.Branch)
+	if localErr != nil && remoteErr != nil {
+		return run(ctx, opts.RepoPath, opts.Git, "checkout", "-B", opts.Branch)
+	}
+	if localErr != nil {
 		return run(ctx, opts.RepoPath, opts.Git, "checkout", "-B", opts.Branch, "origin/"+opts.Branch)
 	}
 	if err := run(ctx, opts.RepoPath, opts.Git, "checkout", opts.Branch); err != nil {
 		return err
+	}
+	if remoteErr != nil {
+		trackedRemote, err := output(ctx, opts.RepoPath, opts.Git, "config", "--get", "branch."+opts.Branch+".remote")
+		if err == nil && strings.TrimSpace(trackedRemote) == "origin" {
+			return fmt.Errorf("tracked remote branch origin/%s is missing", opts.Branch)
+		}
+		return nil
 	}
 	return run(ctx, opts.RepoPath, opts.Git, "pull", "--ff-only", "origin", opts.Branch)
 }
@@ -337,6 +366,13 @@ func normalize(opts Options) Options {
 		opts.Git = "git"
 	}
 	return opts
+}
+
+func creationDirMode(opts Options) os.FileMode {
+	if opts.DirMode != 0 {
+		return opts.DirMode
+	}
+	return 0o755
 }
 
 func setOrigin(ctx context.Context, opts Options) error {

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -15,7 +15,8 @@ type Options struct {
 	Remote   string
 	Branch   string
 	Git      string
-	DirMode  os.FileMode
+	// DirMode enforces repository-root permissions on POSIX filesystems when nonzero.
+	DirMode os.FileMode
 }
 
 func EnsureRepo(ctx context.Context, opts Options) error {

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -47,6 +47,10 @@ func EnsureRepo(ctx context.Context, opts Options) error {
 			}
 		}
 		if opts.Branch != "" {
+			remoteRef := "refs/remotes/origin/" + opts.Branch
+			if _, err := output(ctx, opts.RepoPath, opts.Git, "rev-parse", "--verify", remoteRef); err == nil {
+				return run(ctx, opts.RepoPath, opts.Git, "checkout", "-B", opts.Branch, "origin/"+opts.Branch)
+			}
 			return run(ctx, opts.RepoPath, opts.Git, "checkout", "-B", opts.Branch)
 		}
 		return nil

--- a/mirror/mirror_test.go
+++ b/mirror/mirror_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -78,6 +79,9 @@ func TestEnsureRepoAppliesPrivateDirectoryMode(t *testing.T) {
 	if err := EnsureRemote(ctx, Options{RepoPath: repo, Remote: remote, Branch: "main", DirMode: 0o750}); err != nil {
 		t.Fatal(err)
 	}
+	if runtime.GOOS == "windows" {
+		return
+	}
 	info, err := os.Stat(repo)
 	if err != nil {
 		t.Fatal(err)
@@ -135,7 +139,7 @@ func TestEnsureRepoClonesRequestedRemoteBranch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(body) != "release\n" {
+	if strings.ReplaceAll(string(body), "\r\n", "\n") != "release\n" {
 		t.Fatalf("manifest = %q, want release", body)
 	}
 }

--- a/mirror/mirror_test.go
+++ b/mirror/mirror_test.go
@@ -67,6 +67,40 @@ func TestEnsureRepoUpdatesExistingOrigin(t *testing.T) {
 	}
 }
 
+func TestEnsureRepoAppliesPrivateDirectoryMode(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	remote := filepath.Join(dir, "remote.git")
+	if err := run(ctx, "", "git", "init", "--bare", remote); err != nil {
+		t.Fatal(err)
+	}
+	repo := filepath.Join(dir, "share")
+	if err := EnsureRemote(ctx, Options{RepoPath: repo, Remote: remote, Branch: "main", DirMode: 0o750}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o750 {
+		t.Fatalf("repo mode = %o, want 750", mode)
+	}
+	localRepo := filepath.Join(dir, "local-share")
+	if err := os.Mkdir(localRepo, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureRepo(ctx, Options{RepoPath: localRepo, Branch: "main", DirMode: 0o750}); err != nil {
+		t.Fatal(err)
+	}
+	info, err = os.Stat(localRepo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o750 {
+		t.Fatalf("local repo mode = %o, want 750", mode)
+	}
+}
+
 func TestPushWritesCurrentBranchToOrigin(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -224,6 +258,80 @@ func TestPullCurrentUsesExistingOrigin(t *testing.T) {
 	}
 	if strings.ReplaceAll(string(data), "\r\n", "\n") != "two\n" {
 		t.Fatalf("manifest = %q, want updated content", data)
+	}
+}
+
+func TestPullCurrentPreservesUnpublishedLocalBranch(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	remote := filepath.Join(dir, "remote.git")
+	repo := filepath.Join(dir, "share")
+	if err := run(ctx, "", "git", "init", "--bare", remote); err != nil {
+		t.Fatal(err)
+	}
+	opts := Options{RepoPath: repo, Remote: remote, Branch: "private"}
+	if err := EnsureRemote(ctx, opts); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "manifest.json"), []byte("local\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if committed, err := Commit(ctx, opts, "local snapshot"); err != nil || !committed {
+		t.Fatalf("commit = %v, %v", committed, err)
+	}
+	headBefore, err := output(ctx, repo, "git", "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := PullCurrent(ctx, Options{RepoPath: repo, Branch: "private"}); err != nil {
+		t.Fatal(err)
+	}
+	headAfter, err := output(ctx, repo, "git", "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(headAfter) != strings.TrimSpace(headBefore) {
+		t.Fatalf("HEAD moved from %s to %s", strings.TrimSpace(headBefore), strings.TrimSpace(headAfter))
+	}
+}
+
+func TestPullCurrentRejectsDeletedTrackedBranch(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	remote := filepath.Join(dir, "remote.git")
+	seed := filepath.Join(dir, "seed")
+	repo := filepath.Join(dir, "share")
+	if err := run(ctx, "", "git", "init", "--bare", remote); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(ctx, "", "git", "clone", remote, seed); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(ctx, seed, "git", "checkout", "-B", "main"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(seed, "manifest.json"), []byte("remote\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	seedOpts := Options{RepoPath: seed, Remote: remote, Branch: "main"}
+	if committed, err := Commit(ctx, seedOpts, "remote snapshot"); err != nil || !committed {
+		t.Fatalf("commit = %v, %v", committed, err)
+	}
+	if err := Push(ctx, seedOpts); err != nil {
+		t.Fatal(err)
+	}
+	if err := Pull(ctx, Options{RepoPath: repo, Remote: remote, Branch: "main"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(ctx, repo, "git", "branch", "--set-upstream-to", "origin/main", "main"); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(ctx, remote, "git", "update-ref", "-d", "refs/heads/main"); err != nil {
+		t.Fatal(err)
+	}
+	err := PullCurrent(ctx, Options{RepoPath: repo, Branch: "main"})
+	if err == nil || !strings.Contains(err.Error(), "tracked remote branch origin/main is missing") {
+		t.Fatalf("PullCurrent error = %v", err)
 	}
 }
 

--- a/mirror/mirror_test.go
+++ b/mirror/mirror_test.go
@@ -101,6 +101,45 @@ func TestEnsureRepoAppliesPrivateDirectoryMode(t *testing.T) {
 	}
 }
 
+func TestEnsureRepoClonesRequestedRemoteBranch(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	seed := filepath.Join(dir, "seed")
+	remote := filepath.Join(dir, "remote.git")
+	repo := filepath.Join(dir, "share")
+	if err := run(ctx, "", "git", "init", "-b", "main", seed); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(seed, "manifest.json"), []byte("release\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if committed, err := Commit(ctx, Options{RepoPath: seed, Branch: "main"}, "release"); err != nil || !committed {
+		t.Fatalf("commit = %v, %v", committed, err)
+	}
+	if err := run(ctx, seed, "git", "branch", "release"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(seed, "manifest.json"), []byte("main\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if committed, err := Commit(ctx, Options{RepoPath: seed, Branch: "main"}, "main"); err != nil || !committed {
+		t.Fatalf("commit = %v, %v", committed, err)
+	}
+	if err := run(ctx, "", "git", "clone", "--bare", seed, remote); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureRepo(ctx, Options{RepoPath: repo, Remote: remote, Branch: "release"}); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(filepath.Join(repo, "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "release\n" {
+		t.Fatalf("manifest = %q, want release", body)
+	}
+}
+
 func TestPushWritesCurrentBranchToOrigin(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

- preserve unpublished local mirror branches while still rejecting deleted tracked branches
- let callers enforce private mirror repository directory modes
- cover local initialization, clone permissions, unpublished branches, and deleted tracked branches

## Proof

- `go test ./...`
- `go test -race ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- autoreview clean
