### PR TITLE
ci: add Go security gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,14 @@ jobs:
       - run: GOWORK=off go vet ./...
       - run: |
           output_file=$(mktemp)
-          GOWORK=off go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./... > "$output_file"
+          GOWORK=off go run golang.org/x/tools/cmd/deadcode@v0.46.0 -test ./... > "$output_file"
           if [ -s "$output_file" ]; then
             cat "$output_file"
             exit 1
           fi
+      - run: GOWORK=off go run golang.org/x/vuln/cmd/govulncheck@v1.4.0 ./...
       - run: GOWORK=off go test ./...
+      - run: GOWORK=off go test -race ./...
 
   windows-test:
     runs-on: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Update Go to 1.26.4 for current standard-library security fixes and add race and vulnerability CI gates.
 - Allow managed sidecar trees to prune selected generated files while preserving unrelated files.
 - Add non-mutating archive tag validation and rebase-based write synchronization for durable multi-machine backup retries.
 - Add reusable Git snapshot history/tag/ref restoration, SQLite bundle snapshots, managed snapshot sidecars, mapped sync-state adapters, FTS5 helpers, and the shared contact-export contract; refresh stable dependencies.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openclaw/crawlkit
 
-go 1.26.2
+go 1.26.4
 
 require (
 	filippo.io/age v1.3.1


### PR DESCRIPTION
## Summary

- require Go 1.26.4, which includes the current standard-library security fixes
- add govulncheck v1.4.0 and race tests to normal CI
- update deadcode to x/tools v0.46.0

Runtime module APIs and dependencies are unchanged.

## Proof

- `GOWORK=off go mod verify`
- clean `GOWORK=off go mod tidy`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test -count=1 ./...`
- `GOWORK=off go test -race -count=1 ./...`
- deadcode v0.46.0 and actionlint clean
- govulncheck v1.4.0: no vulnerabilities
- built `crawlctl` help, version, init, status, and dry-run install smoke passed with a temporary config/home
- gitcrawl, discrawl, slacrawl, wacrawl, notcrawl, telecrawl, and graincrawl all pass their full test suites against this exact local module through temporary Go workspaces
- built help/version/metadata smokes pass for the same seven consumers with temporary homes; private values were suppressed
- autoreview: clean, no accepted/actionable findings

Additional static/security audit found only existing non-gating findings: deprecated Bubble Tea/viewport APIs and one error-string style warning; gosec flags quoted SQL identifier construction, intentionally public scheduler unit files, and `os.Remove` calls that remove directory entries without following symlinks. None is introduced by this patch.

No CrawlKit release version bump, release, tag, or publish action.
