### PR TITLE
fix: preserve edits during mirror sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve unrelated tracked mirror edits across write synchronization rebases.
 - Retry atomic branch-and-tag snapshot pushes after rebasing and retargeting unpublished tags.
 - Update Go to 1.26.4 for current standard-library security fixes and add race and vulnerability CI gates.
 - Preserve unpublished local mirror branches during pulls, clone the requested remote branch, and support caller-selected private repository directory modes.

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -190,30 +190,57 @@ func syncBranchForWrite(ctx context.Context, opts Options) error {
 	if err != nil {
 		return err
 	}
+	stashed, err := stashLocalChanges(ctx, opts)
+	if err != nil {
+		return err
+	}
 	if err := run(ctx, opts.RepoPath, opts.Git,
 		"-c", "commit.gpgsign=false",
 		"-c", "user.name=crawlkit",
 		"-c", "user.email=crawlkit@example.invalid",
 		"rebase", "--reapply-cherry-picks", "--empty=keep", "origin/"+opts.Branch,
 	); err != nil {
+		if stashed {
+			return fmt.Errorf("rebase archive branch (local changes remain in git stash): %w", err)
+		}
 		return err
 	}
-	if len(tagMoves) == 0 {
-		return nil
-	}
-	newCommits, err := localCommits(ctx, opts, remoteRef, localRef)
-	if err != nil {
-		return err
-	}
-	if len(newCommits) != len(oldCommits) {
-		return fmt.Errorf("archive rebase changed local commit count from %d to %d; snapshot tags were not moved", len(oldCommits), len(newCommits))
-	}
-	for _, move := range tagMoves {
-		if err := run(ctx, opts.RepoPath, opts.Git, "update-ref", "refs/tags/"+move.tag, newCommits[move.commitIndex], move.oldCommit); err != nil {
-			return fmt.Errorf("retarget local snapshot tag %q after rebase: %w", move.tag, err)
+	var syncErr error
+	if len(tagMoves) > 0 {
+		newCommits, err := localCommits(ctx, opts, remoteRef, localRef)
+		if err != nil {
+			syncErr = err
+		} else if len(newCommits) != len(oldCommits) {
+			syncErr = fmt.Errorf("archive rebase changed local commit count from %d to %d; snapshot tags were not moved", len(oldCommits), len(newCommits))
+		} else {
+			for _, move := range tagMoves {
+				if err := run(ctx, opts.RepoPath, opts.Git, "update-ref", "refs/tags/"+move.tag, newCommits[move.commitIndex], move.oldCommit); err != nil {
+					syncErr = fmt.Errorf("retarget local snapshot tag %q after rebase: %w", move.tag, err)
+					break
+				}
+			}
 		}
 	}
-	return nil
+	if stashed {
+		if err := run(ctx, opts.RepoPath, opts.Git, "stash", "pop", "--index"); err != nil {
+			syncErr = errors.Join(syncErr, fmt.Errorf("restore local changes after archive rebase: %w", err))
+		}
+	}
+	return syncErr
+}
+
+func stashLocalChanges(ctx context.Context, opts Options) (bool, error) {
+	status, err := output(ctx, opts.RepoPath, opts.Git, "status", "--porcelain", "--untracked-files=all")
+	if err != nil {
+		return false, fmt.Errorf("inspect local mirror changes: %w", err)
+	}
+	if strings.TrimSpace(status) == "" {
+		return false, nil
+	}
+	if err := run(ctx, opts.RepoPath, opts.Git, "stash", "push", "--include-untracked", "--message", "crawlkit mirror sync"); err != nil {
+		return false, fmt.Errorf("stash local mirror changes: %w", err)
+	}
+	return true, nil
 }
 
 type tagMove struct {

--- a/mirror/mirror_test.go
+++ b/mirror/mirror_test.go
@@ -480,7 +480,7 @@ func TestSyncForWriteRebasesUnpushedCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(dirtyBody) != "unrelated dirty edit\n" {
+	if strings.ReplaceAll(string(dirtyBody), "\r\n", "\n") != "unrelated dirty edit\n" {
 		t.Fatalf("dirty edit was not restored: %q", dirtyBody)
 	}
 }

--- a/mirror/mirror_test.go
+++ b/mirror/mirror_test.go
@@ -434,6 +434,9 @@ func TestSyncForWriteRebasesUnpushedCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(repo, "local.txt"), []byte("unrelated dirty edit\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	peerOpts := Options{RepoPath: peer, Branch: "main"}
 	if err := os.WriteFile(filepath.Join(peer, "remote.txt"), []byte("remote\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -472,6 +475,84 @@ func TestSyncForWriteRebasesUnpushedCommit(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(repo, name)); err != nil {
 			t.Fatalf("%s missing after sync: %v", name, err)
 		}
+	}
+	dirtyBody, err := os.ReadFile(filepath.Join(repo, "local.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(dirtyBody) != "unrelated dirty edit\n" {
+		t.Fatalf("dirty edit was not restored: %q", dirtyBody)
+	}
+}
+
+func TestSyncForWriteRetargetsTagsBeforeConflictedStashRestore(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	remote := filepath.Join(dir, "remote.git")
+	seed := filepath.Join(dir, "seed")
+	repo := filepath.Join(dir, "share")
+	peer := filepath.Join(dir, "peer")
+	if err := run(ctx, "", "git", "init", "--bare", remote); err != nil {
+		t.Fatal(err)
+	}
+	seedOpts := Options{RepoPath: seed, Remote: remote, Branch: "main"}
+	if err := EnsureRemote(ctx, seedOpts); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(seed, "manifest.json"), []byte("base\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if committed, err := Commit(ctx, seedOpts, "seed"); err != nil || !committed {
+		t.Fatalf("seed commit = %v, %v", committed, err)
+	}
+	if err := Push(ctx, seedOpts); err != nil {
+		t.Fatal(err)
+	}
+	for _, clone := range []string{repo, peer} {
+		if err := run(ctx, "", "git", "clone", "--branch", "main", remote, clone); err != nil {
+			t.Fatal(err)
+		}
+	}
+	localOpts := Options{RepoPath: repo, Branch: "main"}
+	if err := os.WriteFile(filepath.Join(repo, "local.txt"), []byte("local\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if committed, err := Commit(ctx, localOpts, "local snapshot"); err != nil || !committed {
+		t.Fatalf("local commit = %v, %v", committed, err)
+	}
+	if tag, err := CreateImmutableTag(ctx, localOpts, "snapshot/conflict"); err != nil || tag != "snapshot/conflict" {
+		t.Fatalf("local tag = %q, %v", tag, err)
+	}
+	oldTag, err := ResolveCommit(ctx, localOpts, "snapshot/conflict")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "manifest.json"), []byte("dirty local\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	peerOpts := Options{RepoPath: peer, Branch: "main"}
+	if err := os.WriteFile(filepath.Join(peer, "manifest.json"), []byte("remote update\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if committed, err := Commit(ctx, peerOpts, "remote update"); err != nil || !committed {
+		t.Fatalf("remote commit = %v, %v", committed, err)
+	}
+	if err := Push(ctx, peerOpts); err != nil {
+		t.Fatal(err)
+	}
+	if err := SyncForWrite(ctx, localOpts); err == nil || !strings.Contains(err.Error(), "restore local changes") {
+		t.Fatalf("SyncForWrite error = %v", err)
+	}
+	newTag, err := ResolveCommit(ctx, localOpts, "snapshot/conflict")
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := ResolveCommit(ctx, localOpts, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newTag == oldTag || newTag != head {
+		t.Fatalf("tag after conflicted restore = %s, old %s, HEAD %s", newTag, oldTag, head)
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve unrelated tracked and untracked edits during mirror write rebases
- retarget local snapshot tags before restoring stashed edits
- keep tag mappings correct even when stash restoration conflicts

## Proof

- `go test ./...`
- `go test -race ./...`
- `GOWORK=off go vet ./...`
- autoreview clean
