### PR TITLE
fix(ci): keep CodeQL action updates in lockstep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      - uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           languages: go
-      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      - uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4


### PR DESCRIPTION
## Summary

- update both CodeQL `init` and `analyze` steps to the v4.36.3 full SHA
- group future `github/codeql-action/*` Dependabot updates so the paired steps stay in lockstep
- replace the individually broken split updates in #43 and #45

## Why

CodeQL stores versioned state between `init` and `analyze`. Each split Dependabot PR updated only one step and its live CodeQL run failed with a v4.36.2/v4.36.3 configuration mismatch.

## Validation

- `actionlint .github/workflows/*.yml`
- YAML parse for `.github/dependabot.yml` and `.github/workflows/codeql.yml`
- `GOWORK=off go mod tidy`
- `git diff --exit-code -- go.mod go.sum`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test -count=1 ./...`
- structured autoreview: clean, no accepted/actionable findings
- hosted CodeQL/CI/security checks required before merge
