### PR TITLE
feat(remote): add archive snapshot provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.13.5 - Unreleased
 
 - Require notarized, single-architecture `crawlctl` release binaries bound to the repository-pinned signed tag and protected remote `main` commit, restore signing-keychain state before credential-free candidate probes, roll back partial artifact promotion, and keep naturally quarantined Gatekeeper execution plus Full Disk Access continuity as separate clean-VM gates because raw binaries and ZIP submission carriers cannot carry stapled tickets and raw-CLI `spctl` assessment is not an app-launch verdict.
-- Add provider-neutral remote archive snapshot and publish provenance fields so cloud readers can bind query results to one immutable source image.
+- Add provider-neutral remote archive snapshot and publish provenance fields, pinned queries, mutation generations, and explicit snapshot cutover support so cloud readers can bind results to one immutable source image.
 
 ## v0.13.4 - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 ## v0.13.5 - Unreleased
 
 - Require notarized, single-architecture `crawlctl` release binaries bound to the repository-pinned signed tag and protected remote `main` commit, restore signing-keychain state before credential-free candidate probes, roll back partial artifact promotion, and keep naturally quarantined Gatekeeper execution plus Full Disk Access continuity as separate clean-VM gates because raw binaries and ZIP submission carriers cannot carry stapled tickets and raw-CLI `spctl` assessment is not an app-launch verdict.
-- Add provider-neutral remote archive snapshot and publish provenance fields, pinned queries, mutation generations, and explicit snapshot cutover support so cloud readers can bind results to one immutable source image.
-
 ## v0.13.4 - 2026-07-09
 
 - Add stable Developer ID signing, verification, and atomic installation for macOS `crawlctl` release artifacts so Full Disk Access survives updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v0.13.5 - Unreleased
 
 - Require notarized, single-architecture `crawlctl` release binaries bound to the repository-pinned signed tag and protected remote `main` commit, restore signing-keychain state before credential-free candidate probes, roll back partial artifact promotion, and keep naturally quarantined Gatekeeper execution plus Full Disk Access continuity as separate clean-VM gates because raw binaries and ZIP submission carriers cannot carry stapled tickets and raw-CLI `spctl` assessment is not an app-launch verdict.
+- Add immutable SQLite snapshot bundle manifests with deterministic source and representation digests, digest-scoped compressed objects and chunks, and explicit snapshot publishing helpers while preserving the legacy `current.*` bundle layout.
+
 ## v0.13.4 - 2026-07-09
 
 - Add stable Developer ID signing, verification, and atomic installation for macOS `crawlctl` release artifacts so Full Disk Access survives updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.13.5 - Unreleased
 
 - Require notarized, single-architecture `crawlctl` release binaries bound to the repository-pinned signed tag and protected remote `main` commit, restore signing-keychain state before credential-free candidate probes, roll back partial artifact promotion, and keep naturally quarantined Gatekeeper execution plus Full Disk Access continuity as separate clean-VM gates because raw binaries and ZIP submission carriers cannot carry stapled tickets and raw-CLI `spctl` assessment is not an app-launch verdict.
+- Add provider-neutral remote archive snapshot and publish provenance fields so cloud readers can bind query results to one immutable source image.
 
 ## v0.13.4 - 2026-07-09
 

--- a/remote/contract.go
+++ b/remote/contract.go
@@ -22,6 +22,7 @@ const (
 type Contract struct {
 	ProtocolVersion string      `json:"protocol_version"`
 	Service         string      `json:"service,omitempty"`
+	ReleaseSHA      string      `json:"release_sha,omitempty"`
 	Routes          []RouteSpec `json:"routes"`
 	Apps            []AppSpec   `json:"apps"`
 	Auth            []AuthSpec  `json:"auth,omitempty"`
@@ -74,6 +75,7 @@ func BaseContract() Contract {
 			{Method: http.MethodPost, Path: "/v1/apps/:app/archives/:archive/query", Auth: AuthReader},
 			{Method: http.MethodPost, Path: "/v1/apps/:app/archives/:archive/batch-read", Auth: AuthReader},
 			{Method: http.MethodPost, Path: "/v1/apps/:app/archives/:archive/ingest", Auth: AuthPublisher},
+			{Method: http.MethodPost, Path: "/v1/apps/:app/archives/:archive/cutover", Auth: AuthPublisher},
 			{Method: http.MethodPut, Path: "/v1/apps/:app/archives/:archive/sqlite", Auth: AuthPublisher},
 		},
 		Auth: []AuthSpec{

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -186,11 +186,16 @@ type Identity struct {
 }
 
 type ArchiveSnapshot struct {
-	ID           string `json:"id"`
-	SourceSHA256 string `json:"source_sha256,omitempty"`
-	SchemaHash   string `json:"schema_hash,omitempty"`
-	SourceSyncAt string `json:"source_sync_at,omitempty"`
-	PublishedAt  string `json:"published_at,omitempty"`
+	ID                 string `json:"id"`
+	SourceSHA256       string `json:"source_sha256,omitempty"`
+	SchemaName         string `json:"schema_name,omitempty"`
+	SchemaVersion      int    `json:"schema_version,omitempty"`
+	SchemaHash         string `json:"schema_hash,omitempty"`
+	SourceSyncAt       string `json:"source_sync_at,omitempty"`
+	DatasetGeneratedAt string `json:"dataset_generated_at,omitempty"`
+	CoverageComplete   bool   `json:"coverage_complete,omitempty"`
+	PublishedAt        string `json:"published_at,omitempty"`
+	CutoverAt          string `json:"cutover_at,omitempty"`
 }
 
 type ArchivePublish struct {
@@ -214,35 +219,64 @@ type Archive struct {
 }
 
 type Status struct {
-	App          string           `json:"app"`
-	Archive      string           `json:"archive"`
-	Mode         string           `json:"mode,omitempty"`
-	GeneratedAt  string           `json:"generated_at,omitempty"`
-	LastSyncAt   string           `json:"last_sync_at,omitempty"`
-	LastIngestAt string           `json:"last_ingest_at,omitempty"`
-	Counts       []control.Count  `json:"counts,omitempty"`
-	Capabilities []string         `json:"capabilities,omitempty"`
-	SQLiteObject *SQLiteObject    `json:"sqlite_object,omitempty"`
-	SQLiteBundle *SQLiteBundle    `json:"sqlite_bundle,omitempty"`
-	Snapshot     *ArchiveSnapshot `json:"snapshot,omitempty"`
-	Publish      *ArchivePublish  `json:"publish,omitempty"`
-	Warnings     []string         `json:"warnings,omitempty"`
+	App                string            `json:"app"`
+	Archive            string            `json:"archive"`
+	Mode               string            `json:"mode,omitempty"`
+	GeneratedAt        string            `json:"generated_at,omitempty"`
+	SchemaName         string            `json:"schema_name,omitempty"`
+	SchemaVersion      int               `json:"schema_version,omitempty"`
+	SchemaHash         string            `json:"schema_hash,omitempty"`
+	LastSyncAt         string            `json:"last_sync_at,omitempty"`
+	LastIngestAt       string            `json:"last_ingest_at,omitempty"`
+	Counts             []control.Count   `json:"counts,omitempty"`
+	Capabilities       []string          `json:"capabilities,omitempty"`
+	SQLiteObject       *SQLiteObject     `json:"sqlite_object,omitempty"`
+	SQLiteBundle       *SQLiteBundle     `json:"sqlite_bundle,omitempty"`
+	SnapshotMode       string            `json:"snapshot_mode,omitempty"`
+	SnapshotCutoverAt  string            `json:"snapshot_cutover_at,omitempty"`
+	ActiveSnapshotID   string            `json:"active_snapshot_id,omitempty"`
+	SourceSyncAt       string            `json:"source_sync_at,omitempty"`
+	DatasetGeneratedAt string            `json:"dataset_generated_at,omitempty"`
+	CoverageComplete   bool              `json:"coverage_complete,omitempty"`
+	Datasets           []DatasetCoverage `json:"datasets,omitempty"`
+	Snapshot           *ArchiveSnapshot  `json:"snapshot,omitempty"`
+	Publish            *ArchivePublish   `json:"publish,omitempty"`
+	Warnings           []string          `json:"warnings,omitempty"`
+}
+
+type DatasetCoverage struct {
+	Dataset            string `json:"dataset"`
+	RowCount           int64  `json:"row_count,omitempty"`
+	EligibleCount      int64  `json:"eligible_count,omitempty"`
+	CoveredCount       int64  `json:"covered_count,omitempty"`
+	FreshCount         int64  `json:"fresh_count,omitempty"`
+	MaxSourceAt        string `json:"max_source_at,omitempty"`
+	DatasetGeneratedAt string `json:"dataset_generated_at,omitempty"`
+	Complete           bool   `json:"complete,omitempty"`
 }
 
 type QueryRequest struct {
-	App     string         `json:"app,omitempty"`
-	Archive string         `json:"archive,omitempty"`
-	Name    string         `json:"name"`
-	Args    map[string]any `json:"args,omitempty"`
-	Limit   int            `json:"limit,omitempty"`
-	Cursor  string         `json:"cursor,omitempty"`
+	App        string         `json:"app,omitempty"`
+	Archive    string         `json:"archive,omitempty"`
+	Name       string         `json:"name"`
+	Args       map[string]any `json:"args,omitempty"`
+	Limit      int            `json:"limit,omitempty"`
+	Cursor     string         `json:"cursor,omitempty"`
+	SnapshotID string         `json:"snapshot_id,omitempty"`
 }
 
 type QueryStats struct {
-	RowsRead    int64  `json:"rows_read,omitempty"`
-	RowsWritten int64  `json:"rows_written,omitempty"`
-	DurationMS  int64  `json:"duration_ms,omitempty"`
-	ServedBy    string `json:"served_by,omitempty"`
+	RowsRead           int64  `json:"rows_read,omitempty"`
+	RowsWritten        int64  `json:"rows_written,omitempty"`
+	DurationMS         int64  `json:"duration_ms,omitempty"`
+	ServedBy           string `json:"served_by,omitempty"`
+	SnapshotID         string `json:"snapshot_id,omitempty"`
+	SourceSyncAt       string `json:"source_sync_at,omitempty"`
+	DatasetGeneratedAt string `json:"dataset_generated_at,omitempty"`
+	CoverageComplete   bool   `json:"coverage_complete,omitempty"`
+	SchemaVersion      int    `json:"schema_version,omitempty"`
+	ObservationOrder   string `json:"observation_order,omitempty"`
+	NextCursor         string `json:"next_cursor,omitempty"`
 }
 
 type QueryResult struct {
@@ -256,36 +290,46 @@ type QueryResult struct {
 }
 
 type IngestManifest struct {
-	App           string `json:"app"`
-	Archive       string `json:"archive"`
-	SchemaName    string `json:"schema_name,omitempty"`
-	SchemaVersion int    `json:"schema_version"`
-	SchemaHash    string `json:"schema_hash"`
-	Mode          string `json:"mode,omitempty"`
-	Source        string `json:"source,omitempty"`
-	SourceSyncAt  string `json:"source_sync_at,omitempty"`
-	SnapshotID    string `json:"snapshot_id,omitempty"`
-	SourceSHA256  string `json:"source_sha256,omitempty"`
+	App           string   `json:"app"`
+	Archive       string   `json:"archive"`
+	SchemaName    string   `json:"schema_name,omitempty"`
+	SchemaVersion int      `json:"schema_version"`
+	SchemaHash    string   `json:"schema_hash"`
+	Mode          string   `json:"mode,omitempty"`
+	Source        string   `json:"source,omitempty"`
+	SourceSyncAt  string   `json:"source_sync_at,omitempty"`
+	SnapshotID    string   `json:"snapshot_id,omitempty"`
+	SourceSHA256  string   `json:"source_sha256,omitempty"`
+	Capabilities  []string `json:"capabilities,omitempty"`
 }
 
 type IngestRequest struct {
-	Manifest IngestManifest `json:"manifest"`
-	Table    string         `json:"table"`
-	Columns  []string       `json:"columns"`
-	Rows     [][]any        `json:"rows"`
-	Cursor   string         `json:"cursor,omitempty"`
-	Final    bool           `json:"final,omitempty"`
+	Manifest      IngestManifest `json:"manifest"`
+	Table         string         `json:"table"`
+	Columns       []string       `json:"columns"`
+	Rows          [][]any        `json:"rows"`
+	Cursor        string         `json:"cursor,omitempty"`
+	MutationToken string         `json:"mutation_token,omitempty"`
+	Final         bool           `json:"final,omitempty"`
 }
 
 type IngestResult struct {
 	RunID           string `json:"run_id,omitempty"`
 	Table           string `json:"table,omitempty"`
 	SnapshotID      string `json:"snapshot_id,omitempty"`
+	MutationToken   string `json:"mutation_token,omitempty"`
 	RowsAccepted    int64  `json:"rows_accepted,omitempty"`
 	Cursor          string `json:"cursor,omitempty"`
 	Complete        bool   `json:"complete,omitempty"`
 	ResetIncomplete bool   `json:"reset_incomplete,omitempty"`
 	ResetDeleted    int64  `json:"reset_deleted,omitempty"`
+}
+
+type CutoverResult struct {
+	ArchiveID  string `json:"archive_id,omitempty"`
+	SnapshotID string `json:"snapshot_id"`
+	Status     string `json:"status,omitempty"`
+	CutoverAt  string `json:"cutover_at,omitempty"`
 }
 
 type SQLiteUploadRequest struct {
@@ -419,6 +463,14 @@ func (c *Client) Ingest(ctx context.Context, app, archive string, req IngestRequ
 	req.Manifest.Archive = strings.TrimSpace(archive)
 	var out IngestResult
 	err := c.do(ctx, http.MethodPost, archivePath(app, archive, "ingest"), req, &out, true)
+	return out, err
+}
+
+func (c *Client) Cutover(ctx context.Context, app, archive, snapshotID string) (CutoverResult, error) {
+	var out CutoverResult
+	err := c.do(ctx, http.MethodPost, archivePath(app, archive, "cutover"), struct {
+		SnapshotID string `json:"snapshot_id"`
+	}{SnapshotID: strings.TrimSpace(snapshotID)}, &out, true)
 	return out, err
 }
 

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -326,10 +326,10 @@ type IngestResult struct {
 }
 
 type CutoverResult struct {
-	ArchiveID  string `json:"archive_id,omitempty"`
-	SnapshotID string `json:"snapshot_id"`
-	Status     string `json:"status,omitempty"`
-	CutoverAt  string `json:"cutover_at,omitempty"`
+	Archive      string `json:"archive,omitempty"`
+	SnapshotID   string `json:"snapshot_id"`
+	SnapshotMode string `json:"snapshot_mode,omitempty"`
+	CutoverAt    string `json:"cutover_at,omitempty"`
 }
 
 type SQLiteUploadRequest struct {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -494,6 +494,9 @@ func (c *Client) UploadSQLiteBundlePart(ctx context.Context, app, archive string
 	if part.Body == nil {
 		return SQLiteUploadResult{}, errors.New("sqlite bundle part body is required")
 	}
+	if part.SnapshotID != "" && !validSQLiteSnapshotID(part.SnapshotID) {
+		return SQLiteUploadResult{}, errors.New("sqlite bundle snapshot id must be empty or a lowercase sha256 digest")
+	}
 	headers := http.Header{}
 	headers.Set("content-type", "application/gzip")
 	headers.Set("x-crawl-sqlite-upload", "bundle-part")
@@ -507,6 +510,9 @@ func (c *Client) UploadSQLiteBundlePart(ctx context.Context, app, archive string
 }
 
 func (c *Client) UploadSQLiteBundleFiles(ctx context.Context, app, archive string, manifest SQLiteBundleManifest, parts []SQLiteBundlePartFile) (SQLiteBundleUploadResult, error) {
+	if manifest.SnapshotID != "" && !validSQLiteSnapshotID(manifest.SnapshotID) {
+		return SQLiteBundleUploadResult{}, errors.New("sqlite bundle snapshot id must be empty or a lowercase sha256 digest")
+	}
 	for _, part := range parts {
 		file, err := os.Open(part.Path)
 		if err != nil {
@@ -529,6 +535,9 @@ func (c *Client) UploadSQLiteBundleFiles(ctx context.Context, app, archive strin
 }
 
 func (c *Client) UploadSQLiteBundleManifest(ctx context.Context, app, archive string, manifest SQLiteBundleManifest) (SQLiteBundleUploadResult, error) {
+	if manifest.SnapshotID != "" && !validSQLiteSnapshotID(manifest.SnapshotID) {
+		return SQLiteBundleUploadResult{}, errors.New("sqlite bundle snapshot id must be empty or a lowercase sha256 digest")
+	}
 	if strings.TrimSpace(manifest.App) == "" {
 		manifest.App = strings.TrimSpace(app)
 	}

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -185,30 +185,48 @@ type Identity struct {
 	Roles []string `json:"roles,omitempty"`
 }
 
+type ArchiveSnapshot struct {
+	ID           string `json:"id"`
+	SourceSHA256 string `json:"source_sha256,omitempty"`
+	SchemaHash   string `json:"schema_hash,omitempty"`
+	SourceSyncAt string `json:"source_sync_at,omitempty"`
+	PublishedAt  string `json:"published_at,omitempty"`
+}
+
+type ArchivePublish struct {
+	Status     string `json:"status"`
+	SnapshotID string `json:"snapshot_id,omitempty"`
+	StartedAt  string `json:"started_at,omitempty"`
+}
+
 type Archive struct {
-	ID            string   `json:"id"`
-	App           string   `json:"app"`
-	Slug          string   `json:"slug"`
-	SchemaName    string   `json:"schema_name,omitempty"`
-	SchemaVersion int      `json:"schema_version,omitempty"`
-	SchemaHash    string   `json:"schema_hash,omitempty"`
-	Capabilities  []string `json:"capabilities,omitempty"`
-	LastIngestAt  string   `json:"last_ingest_at,omitempty"`
-	LastSyncAt    string   `json:"last_sync_at,omitempty"`
+	ID            string           `json:"id"`
+	App           string           `json:"app"`
+	Slug          string           `json:"slug"`
+	SchemaName    string           `json:"schema_name,omitempty"`
+	SchemaVersion int              `json:"schema_version,omitempty"`
+	SchemaHash    string           `json:"schema_hash,omitempty"`
+	Capabilities  []string         `json:"capabilities,omitempty"`
+	LastIngestAt  string           `json:"last_ingest_at,omitempty"`
+	LastSyncAt    string           `json:"last_sync_at,omitempty"`
+	Snapshot      *ArchiveSnapshot `json:"snapshot,omitempty"`
+	Publish       *ArchivePublish  `json:"publish,omitempty"`
 }
 
 type Status struct {
-	App          string          `json:"app"`
-	Archive      string          `json:"archive"`
-	Mode         string          `json:"mode,omitempty"`
-	GeneratedAt  string          `json:"generated_at,omitempty"`
-	LastSyncAt   string          `json:"last_sync_at,omitempty"`
-	LastIngestAt string          `json:"last_ingest_at,omitempty"`
-	Counts       []control.Count `json:"counts,omitempty"`
-	Capabilities []string        `json:"capabilities,omitempty"`
-	SQLiteObject *SQLiteObject   `json:"sqlite_object,omitempty"`
-	SQLiteBundle *SQLiteBundle   `json:"sqlite_bundle,omitempty"`
-	Warnings     []string        `json:"warnings,omitempty"`
+	App          string           `json:"app"`
+	Archive      string           `json:"archive"`
+	Mode         string           `json:"mode,omitempty"`
+	GeneratedAt  string           `json:"generated_at,omitempty"`
+	LastSyncAt   string           `json:"last_sync_at,omitempty"`
+	LastIngestAt string           `json:"last_ingest_at,omitempty"`
+	Counts       []control.Count  `json:"counts,omitempty"`
+	Capabilities []string         `json:"capabilities,omitempty"`
+	SQLiteObject *SQLiteObject    `json:"sqlite_object,omitempty"`
+	SQLiteBundle *SQLiteBundle    `json:"sqlite_bundle,omitempty"`
+	Snapshot     *ArchiveSnapshot `json:"snapshot,omitempty"`
+	Publish      *ArchivePublish  `json:"publish,omitempty"`
+	Warnings     []string         `json:"warnings,omitempty"`
 }
 
 type QueryRequest struct {
@@ -234,6 +252,7 @@ type QueryResult struct {
 	Cursor     string           `json:"cursor,omitempty"`
 	Stats      QueryStats       `json:"stats,omitempty"`
 	SchemaHash string           `json:"schema_hash,omitempty"`
+	Snapshot   *ArchiveSnapshot `json:"snapshot,omitempty"`
 }
 
 type IngestManifest struct {
@@ -245,6 +264,8 @@ type IngestManifest struct {
 	Mode          string `json:"mode,omitempty"`
 	Source        string `json:"source,omitempty"`
 	SourceSyncAt  string `json:"source_sync_at,omitempty"`
+	SnapshotID    string `json:"snapshot_id,omitempty"`
+	SourceSHA256  string `json:"source_sha256,omitempty"`
 }
 
 type IngestRequest struct {
@@ -259,6 +280,7 @@ type IngestRequest struct {
 type IngestResult struct {
 	RunID           string `json:"run_id,omitempty"`
 	Table           string `json:"table,omitempty"`
+	SnapshotID      string `json:"snapshot_id,omitempty"`
 	RowsAccepted    int64  `json:"rows_accepted,omitempty"`
 	Cursor          string `json:"cursor,omitempty"`
 	Complete        bool   `json:"complete,omitempty"`

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -500,6 +500,7 @@ func (c *Client) UploadSQLiteBundlePart(ctx context.Context, app, archive string
 	headers.Set("x-crawl-bundle-part-index", fmt.Sprintf("%d", part.Index))
 	setHeader(headers, "x-crawl-content-sha256", part.SHA256)
 	setHeader(headers, "x-crawl-compression", part.Compression)
+	setHeader(headers, "x-crawl-snapshot-id", part.SnapshotID)
 	var out SQLiteUploadResult
 	err := c.doRaw(ctx, http.MethodPut, archivePath(app, archive, "sqlite"), part.Body, part.Size, headers, &out, true)
 	return out, err
@@ -517,6 +518,7 @@ func (c *Client) UploadSQLiteBundleFiles(ctx context.Context, app, archive strin
 			Size:        part.Size,
 			SHA256:      part.SHA256,
 			Compression: SQLiteGzipCompression,
+			SnapshotID:  manifest.SnapshotID,
 		})
 		_ = file.Close()
 		if uploadErr != nil {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -197,10 +197,10 @@ func TestClientArchiveOperations(t *testing.T) {
 				t.Fatalf("decode cutover: %v", err)
 			}
 			_ = json.NewEncoder(w).Encode(CutoverResult{
-				ArchiveID:  "gitcrawl/openclaw",
-				SnapshotID: body.SnapshotID,
-				Status:     "active",
-				CutoverAt:  "2026-07-12T08:00:00Z",
+				Archive:      "gitcrawl/openclaw",
+				SnapshotID:   body.SnapshotID,
+				SnapshotMode: "explicit",
+				CutoverAt:    "2026-07-12T08:00:00Z",
 			})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/auth/github/start":
 			var req LoginStartRequest
@@ -286,7 +286,9 @@ func TestClientArchiveOperations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cutover: %v", err)
 	}
-	if cutover.SnapshotID != manifest.SnapshotID || cutover.Status != "active" {
+	if cutover.Archive != "gitcrawl/openclaw" ||
+		cutover.SnapshotID != manifest.SnapshotID ||
+		cutover.SnapshotMode != "explicit" {
 		t.Fatalf("cutover result = %#v", cutover)
 	}
 	start, err := client.StartGitHubLogin(context.Background(), "hash")

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -374,7 +374,7 @@ func TestClientUploadSQLiteSendsRawBodyAndMetadata(t *testing.T) {
 	}
 }
 
-func TestBuildGzipSQLiteBundleSplitsAndDescribesParts(t *testing.T) {
+func TestBuildGzipSQLiteBundlePreservesCurrentKeyLayout(t *testing.T) {
 	dir := t.TempDir()
 	source := filepath.Join(dir, "archive.db")
 	payload := strings.Repeat("SQLite format 3\n", 100)
@@ -402,15 +402,14 @@ func TestBuildGzipSQLiteBundleSplitsAndDescribesParts(t *testing.T) {
 	if bundle.Manifest.Object.Size != int64(len(payload)) || bundle.Manifest.Object.SHA256 == "" {
 		t.Fatalf("object = %#v", bundle.Manifest.Object)
 	}
-	if bundle.Manifest.SnapshotID != bundle.Manifest.Object.SHA256 {
-		t.Fatalf("snapshot id = %q object sha = %q", bundle.Manifest.SnapshotID, bundle.Manifest.Object.SHA256)
+	if bundle.Manifest.SnapshotID != "" {
+		t.Fatalf("snapshot id = %q", bundle.Manifest.SnapshotID)
 	}
-	if bundle.Manifest.Object.Key != SQLiteSnapshotObjectKey(
-		"gitcrawl",
-		"gitcrawl/openclaw__openclaw",
-		bundle.Manifest.SnapshotID,
-	) {
+	if bundle.Manifest.Object.Key != SQLiteObjectKey("gitcrawl", "gitcrawl/openclaw__openclaw") {
 		t.Fatalf("object key = %q", bundle.Manifest.Object.Key)
+	}
+	if bundle.Manifest.CompressedObject.Key != SQLiteCompressedObjectKey("gitcrawl", "gitcrawl/openclaw__openclaw") {
+		t.Fatalf("compressed object key = %q", bundle.Manifest.CompressedObject.Key)
 	}
 	if bundle.Manifest.CompressedObject.Size <= 0 || bundle.Manifest.CompressedObject.SHA256 == "" {
 		t.Fatalf("compressed object = %#v", bundle.Manifest.CompressedObject)
@@ -425,11 +424,71 @@ func TestBuildGzipSQLiteBundleSplitsAndDescribesParts(t *testing.T) {
 			t.Fatalf("read part: %v", err)
 		}
 		compressed.Write(bytes)
-		if !strings.Contains(part.Key, "/sqlite/snapshots/"+bundle.Manifest.SnapshotID+"/chunks/archive.db.gz.part-") {
+		if part.Key != SQLiteBundlePartKey("gitcrawl", "gitcrawl/openclaw__openclaw", part.Index) {
 			t.Fatalf("part key = %q", part.Key)
 		}
 	}
-	reader, err := gzip.NewReader(strings.NewReader(compressed.String()))
+	assertSQLiteBundlePayload(t, compressed.String(), payload)
+}
+
+func TestBuildSnapshotGzipSQLiteBundleUsesSnapshotKeyLayout(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "archive.db")
+	payload := strings.Repeat("SQLite format 3\n", 100)
+	if err := os.WriteFile(source, []byte(payload), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	bundle, err := BuildSnapshotGzipSQLiteBundle(context.Background(), SQLiteBundleBuildOptions{
+		App:        "gitcrawl",
+		Archive:    "gitcrawl/openclaw__openclaw",
+		SourcePath: source,
+		WorkDir:    dir,
+		ChunkSize:  64,
+		Counts:     map[string]int64{"threads": 3},
+	})
+	if err != nil {
+		t.Fatalf("build snapshot bundle: %v", err)
+	}
+	defer bundle.Cleanup()
+	if bundle.Manifest.SnapshotID == "" || bundle.Manifest.SnapshotID != bundle.Manifest.Object.SHA256 {
+		t.Fatalf("snapshot id = %q object sha = %q", bundle.Manifest.SnapshotID, bundle.Manifest.Object.SHA256)
+	}
+	if bundle.Manifest.Object.Key != SQLiteSnapshotObjectKey(
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		bundle.Manifest.SnapshotID,
+	) {
+		t.Fatalf("object key = %q", bundle.Manifest.Object.Key)
+	}
+	if bundle.Manifest.CompressedObject.Key != SQLiteSnapshotCompressedObjectKey(
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		bundle.Manifest.SnapshotID,
+	) {
+		t.Fatalf("compressed object key = %q", bundle.Manifest.CompressedObject.Key)
+	}
+	var compressed strings.Builder
+	for _, part := range bundle.Parts {
+		bytes, err := os.ReadFile(part.Path)
+		if err != nil {
+			t.Fatalf("read part: %v", err)
+		}
+		compressed.Write(bytes)
+		if part.Key != SQLiteSnapshotBundlePartKey(
+			"gitcrawl",
+			"gitcrawl/openclaw__openclaw",
+			bundle.Manifest.SnapshotID,
+			part.Index,
+		) {
+			t.Fatalf("part key = %q", part.Key)
+		}
+	}
+	assertSQLiteBundlePayload(t, compressed.String(), payload)
+}
+
+func assertSQLiteBundlePayload(t *testing.T, compressed, payload string) {
+	t.Helper()
+	reader, err := gzip.NewReader(strings.NewReader(compressed))
 	if err != nil {
 		t.Fatalf("gzip reader: %v", err)
 	}
@@ -445,83 +504,167 @@ func TestBuildGzipSQLiteBundleSplitsAndDescribesParts(t *testing.T) {
 	}
 }
 
-func TestClientUploadSQLiteBundleFilesUploadsPartsThenManifest(t *testing.T) {
-	dir := t.TempDir()
-	partPath := filepath.Join(dir, "part")
-	if err := os.WriteFile(partPath, []byte("compressed"), 0o600); err != nil {
-		t.Fatalf("write part: %v", err)
+func TestSQLiteBundleKeyLayouts(t *testing.T) {
+	const (
+		app      = "git crawl"
+		archive  = "openclaw/crawlkit"
+		snapshot = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	)
+	if got, want := SQLiteObjectKey(app, archive), "v1/git%20crawl/openclaw%2Fcrawlkit/sqlite/current.db"; got != want {
+		t.Fatalf("object key = %q, want %q", got, want)
 	}
-	var uploads []string
-	var sawManifest bool
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		uploads = append(uploads, r.Header.Get("x-crawl-sqlite-upload"))
-		switch r.Header.Get("x-crawl-sqlite-upload") {
-		case "bundle-part":
-			if r.Header.Get("x-crawl-bundle-part-index") != "0" || r.Header.Get("content-type") != "application/gzip" {
-				t.Fatalf("part headers index=%q content-type=%q", r.Header.Get("x-crawl-bundle-part-index"), r.Header.Get("content-type"))
+	if got, want := SQLiteCompressedObjectKey(app, archive), "v1/git%20crawl/openclaw%2Fcrawlkit/sqlite/current.db.gz"; got != want {
+		t.Fatalf("compressed key = %q, want %q", got, want)
+	}
+	if got, want := SQLiteBundleManifestKey(app, archive), "v1/git%20crawl/openclaw%2Fcrawlkit/sqlite/current.manifest.json"; got != want {
+		t.Fatalf("manifest key = %q, want %q", got, want)
+	}
+	if got, want := SQLiteBundlePartKey(app, archive, 7), "v1/git%20crawl/openclaw%2Fcrawlkit/sqlite/chunks/current.db.gz.part-0007"; got != want {
+		t.Fatalf("part key = %q, want %q", got, want)
+	}
+	if got := SQLiteSnapshotObjectKey(app, archive, ""); got != SQLiteObjectKey(app, archive) {
+		t.Fatalf("empty snapshot object key = %q", got)
+	}
+	if got := SQLiteSnapshotCompressedObjectKey(app, archive, ""); got != SQLiteCompressedObjectKey(app, archive) {
+		t.Fatalf("empty snapshot compressed key = %q", got)
+	}
+	if got := SQLiteSnapshotBundleManifestKey(app, archive, ""); got != SQLiteBundleManifestKey(app, archive) {
+		t.Fatalf("empty snapshot manifest key = %q", got)
+	}
+	if got := SQLiteSnapshotBundlePartKey(app, archive, "", 7); got != SQLiteBundlePartKey(app, archive, 7) {
+		t.Fatalf("empty snapshot part key = %q", got)
+	}
+	if got := SQLiteSnapshotObjectKey(app, archive, "not-a-digest"); got != "" {
+		t.Fatalf("invalid snapshot object key = %q", got)
+	}
+	if got := SQLiteSnapshotBundleManifestKey(app, archive, strings.ToUpper(snapshot)); got != "" {
+		t.Fatalf("non-canonical snapshot manifest key = %q", got)
+	}
+}
+
+func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		snapshotID  string
+		manifestKey func() string
+	}{
+		{
+			name: "legacy",
+			manifestKey: func() string {
+				return SQLiteBundleManifestKey("gitcrawl", "gitcrawl/openclaw__openclaw")
+			},
+		},
+		{
+			name:       "snapshot",
+			snapshotID: strings.Repeat("c", 64),
+			manifestKey: func() string {
+				return SQLiteSnapshotBundleManifestKey("gitcrawl", "gitcrawl/openclaw__openclaw", strings.Repeat("c", 64))
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			partPath := filepath.Join(dir, "part")
+			if err := os.WriteFile(partPath, []byte("compressed"), 0o600); err != nil {
+				t.Fatalf("write part: %v", err)
 			}
-			if r.Header.Get("x-crawl-snapshot-id") != strings.Repeat("c", 64) {
-				t.Fatalf("snapshot header = %q", r.Header.Get("x-crawl-snapshot-id"))
-			}
-			body, err := io.ReadAll(r.Body)
+			var uploads []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				uploads = append(uploads, r.Header.Get("x-crawl-sqlite-upload"))
+				switch r.Header.Get("x-crawl-sqlite-upload") {
+				case "bundle-part":
+					if r.Header.Get("x-crawl-bundle-part-index") != "0" ||
+						r.Header.Get("content-type") != "application/gzip" ||
+						r.Header.Get("x-crawl-snapshot-id") != tc.snapshotID {
+						t.Fatalf(
+							"part headers index=%q content-type=%q snapshot=%q",
+							r.Header.Get("x-crawl-bundle-part-index"),
+							r.Header.Get("content-type"),
+							r.Header.Get("x-crawl-snapshot-id"),
+						)
+					}
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Fatalf("read part body: %v", err)
+					}
+					if string(body) != "compressed" {
+						t.Fatalf("part body = %q", body)
+					}
+					_ = json.NewEncoder(w).Encode(SQLiteUploadResult{Complete: true})
+				case "bundle-manifest":
+					var manifest SQLiteBundleManifest
+					if err := json.NewDecoder(r.Body).Decode(&manifest); err != nil {
+						t.Fatalf("decode manifest: %v", err)
+					}
+					if manifest.Format != SQLiteGzipChunkedBundleFormat || manifest.SnapshotID != tc.snapshotID {
+						t.Fatalf("manifest = %#v", manifest)
+					}
+					_ = json.NewEncoder(w).Encode(SQLiteBundleUploadResult{
+						App:      "gitcrawl",
+						Archive:  "gitcrawl/openclaw__openclaw",
+						Complete: true,
+						Bundle: &SQLiteBundle{
+							Key:      tc.manifestKey(),
+							Manifest: &manifest,
+						},
+					})
+				default:
+					t.Fatalf("unexpected upload kind %q", r.Header.Get("x-crawl-sqlite-upload"))
+				}
+			}))
+			defer server.Close()
+			client, err := NewClient(Options{Endpoint: server.URL, TokenProvider: StaticToken("secret"), UserAgent: "test-agent"})
 			if err != nil {
-				t.Fatalf("read part body: %v", err)
+				t.Fatalf("client: %v", err)
 			}
-			if string(body) != "compressed" {
-				t.Fatalf("part body = %q", body)
+			result, err := client.UploadSQLiteBundleFiles(context.Background(), "gitcrawl", "gitcrawl/openclaw__openclaw", SQLiteBundleManifest{
+				Format:     SQLiteGzipChunkedBundleFormat,
+				App:        "gitcrawl",
+				Archive:    "gitcrawl/openclaw__openclaw",
+				SnapshotID: tc.snapshotID,
+			}, []SQLiteBundlePartFile{{
+				SQLiteBundlePart: SQLiteBundlePart{Index: 0, Size: int64(len("compressed")), SHA256: "part-sha"},
+				Path:             partPath,
+			}})
+			if err != nil {
+				t.Fatalf("upload bundle files: %v", err)
 			}
-			_ = json.NewEncoder(w).Encode(SQLiteUploadResult{Complete: true})
-		case "bundle-manifest":
-			sawManifest = true
-			var manifest SQLiteBundleManifest
-			if err := json.NewDecoder(r.Body).Decode(&manifest); err != nil {
-				t.Fatalf("decode manifest: %v", err)
+			if len(uploads) != 2 || uploads[0] != "bundle-part" || uploads[1] != "bundle-manifest" {
+				t.Fatalf("uploads = %#v", uploads)
 			}
-			if manifest.Format != SQLiteGzipChunkedBundleFormat {
-				t.Fatalf("manifest = %#v", manifest)
+			if result.Bundle == nil || result.Bundle.Key != tc.manifestKey() {
+				t.Fatalf("result = %#v", result)
 			}
-			if manifest.SnapshotID != strings.Repeat("c", 64) {
-				t.Fatalf("snapshot id = %q", manifest.SnapshotID)
-			}
-			_ = json.NewEncoder(w).Encode(SQLiteBundleUploadResult{
-				App:      "gitcrawl",
-				Archive:  "gitcrawl/openclaw__openclaw",
-				Complete: true,
-				Bundle: &SQLiteBundle{
-					Key: SQLiteSnapshotBundleManifestKey(
-						"gitcrawl",
-						"gitcrawl/openclaw__openclaw",
-						manifest.SnapshotID,
-					),
-					Manifest: &manifest,
-				},
-			})
-		default:
-			t.Fatalf("unexpected upload kind %q", r.Header.Get("x-crawl-sqlite-upload"))
-		}
+		})
+	}
+}
+
+func TestClientRejectsInvalidSQLiteBundleSnapshotIDs(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		t.Fatalf("unexpected request")
 	}))
 	defer server.Close()
-	client, err := NewClient(Options{Endpoint: server.URL, TokenProvider: StaticToken("secret"), UserAgent: "test-agent"})
+	client, err := NewClient(Options{Endpoint: server.URL, TokenProvider: StaticToken("secret")})
 	if err != nil {
 		t.Fatalf("client: %v", err)
 	}
-	result, err := client.UploadSQLiteBundleFiles(context.Background(), "gitcrawl", "gitcrawl/openclaw__openclaw", SQLiteBundleManifest{
-		Format:     SQLiteGzipChunkedBundleFormat,
-		App:        "gitcrawl",
-		Archive:    "gitcrawl/openclaw__openclaw",
-		SnapshotID: strings.Repeat("c", 64),
-	}, []SQLiteBundlePartFile{{
-		SQLiteBundlePart: SQLiteBundlePart{Index: 0, Size: int64(len("compressed")), SHA256: "part-sha"},
-		Path:             partPath,
-	}})
-	if err != nil {
-		t.Fatalf("upload bundle files: %v", err)
+	invalid := strings.Repeat("g", 64)
+	if _, err := client.UploadSQLiteBundlePart(context.Background(), "gitcrawl", "archive", SQLiteBundlePartUpload{
+		Body:       strings.NewReader("compressed"),
+		Size:       int64(len("compressed")),
+		SnapshotID: invalid,
+	}); err == nil || !strings.Contains(err.Error(), "lowercase sha256 digest") {
+		t.Fatalf("part upload err = %v", err)
 	}
-	if !sawManifest || len(uploads) != 2 || uploads[0] != "bundle-part" || uploads[1] != "bundle-manifest" {
-		t.Fatalf("uploads = %#v sawManifest=%v", uploads, sawManifest)
+	if _, err := client.UploadSQLiteBundleManifest(context.Background(), "gitcrawl", "archive", SQLiteBundleManifest{
+		SnapshotID: invalid,
+	}); err == nil || !strings.Contains(err.Error(), "lowercase sha256 digest") {
+		t.Fatalf("manifest upload err = %v", err)
 	}
-	if result.Bundle == nil || result.Bundle.Manifest == nil {
-		t.Fatalf("result = %#v", result)
+	if requests != 0 {
+		t.Fatalf("requests = %d", requests)
 	}
 }
 

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -3,8 +3,10 @@ package remote
 import (
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -464,6 +466,7 @@ func TestBuildSnapshotGzipSQLiteBundleUsesSnapshotKeyLayout(t *testing.T) {
 		"gitcrawl",
 		"gitcrawl/openclaw__openclaw",
 		bundle.Manifest.SnapshotID,
+		bundle.Manifest.CompressedObject.SHA256,
 	) {
 		t.Fatalf("compressed object key = %q", bundle.Manifest.CompressedObject.Key)
 	}
@@ -478,15 +481,64 @@ func TestBuildSnapshotGzipSQLiteBundleUsesSnapshotKeyLayout(t *testing.T) {
 			"gitcrawl",
 			"gitcrawl/openclaw__openclaw",
 			bundle.Manifest.SnapshotID,
+			part.SHA256,
 			part.Index,
 		) {
 			t.Fatalf("part key = %q", part.Key)
 		}
 	}
-	assertSQLiteBundlePayload(t, compressed.String(), payload)
+	decompressed := assertSQLiteBundlePayload(t, compressed.String(), payload)
+	if got, want := bundle.Manifest.SnapshotID, fmt.Sprintf("%x", sha256.Sum256(decompressed)); got != want {
+		t.Fatalf("snapshot id = %q, want digest of compressed source bytes %q", got, want)
+	}
 }
 
-func assertSQLiteBundlePayload(t *testing.T, compressed, payload string) {
+func TestBuildSnapshotGzipSQLiteBundleIsolatesEncodedRepresentations(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "archive.db")
+	payload := make([]byte, 8192)
+	for i := range payload {
+		payload[i] = byte((i*31 + i/7) % 251)
+	}
+	if err := os.WriteFile(source, payload, 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	build := func(t *testing.T, level int, chunkSize int64) SQLiteBundleBuild {
+		t.Helper()
+		bundle, err := BuildSnapshotGzipSQLiteBundle(context.Background(), SQLiteBundleBuildOptions{
+			App:              "gitcrawl",
+			Archive:          "gitcrawl/openclaw__openclaw",
+			SourcePath:       source,
+			WorkDir:          dir,
+			CompressionLevel: level,
+			ChunkSize:        chunkSize,
+		})
+		if err != nil {
+			t.Fatalf("build snapshot bundle: %v", err)
+		}
+		t.Cleanup(bundle.Cleanup)
+		return bundle
+	}
+	fastSmall := build(t, gzip.BestSpeed, 64)
+	bestSmall := build(t, gzip.BestCompression, 64)
+	fastLarge := build(t, gzip.BestSpeed, 128)
+	if fastSmall.Manifest.SnapshotID != bestSmall.Manifest.SnapshotID ||
+		fastSmall.Manifest.SnapshotID != fastLarge.Manifest.SnapshotID {
+		t.Fatalf("source snapshot ids differ")
+	}
+	if fastSmall.Manifest.Object.Key != bestSmall.Manifest.Object.Key ||
+		fastSmall.Manifest.Object.Key != fastLarge.Manifest.Object.Key {
+		t.Fatalf("source object keys differ")
+	}
+	if fastSmall.Manifest.CompressedObject.Key == bestSmall.Manifest.CompressedObject.Key {
+		t.Fatalf("compression variants share key %q", fastSmall.Manifest.CompressedObject.Key)
+	}
+	if fastSmall.Manifest.Parts[0].Key == fastLarge.Manifest.Parts[0].Key {
+		t.Fatalf("chunk variants share first part key %q", fastSmall.Manifest.Parts[0].Key)
+	}
+}
+
+func assertSQLiteBundlePayload(t *testing.T, compressed, payload string) []byte {
 	t.Helper()
 	reader, err := gzip.NewReader(strings.NewReader(compressed))
 	if err != nil {
@@ -502,6 +554,7 @@ func assertSQLiteBundlePayload(t *testing.T, compressed, payload string) {
 	if string(decompressed) != payload {
 		t.Fatalf("decompressed payload mismatch")
 	}
+	return decompressed
 }
 
 func TestSQLiteBundleKeyLayouts(t *testing.T) {
@@ -525,17 +578,23 @@ func TestSQLiteBundleKeyLayouts(t *testing.T) {
 	if got := SQLiteSnapshotObjectKey(app, archive, ""); got != SQLiteObjectKey(app, archive) {
 		t.Fatalf("empty snapshot object key = %q", got)
 	}
-	if got := SQLiteSnapshotCompressedObjectKey(app, archive, ""); got != SQLiteCompressedObjectKey(app, archive) {
+	if got := SQLiteSnapshotCompressedObjectKey(app, archive, "", ""); got != SQLiteCompressedObjectKey(app, archive) {
 		t.Fatalf("empty snapshot compressed key = %q", got)
 	}
 	if got := SQLiteSnapshotBundleManifestKey(app, archive, ""); got != SQLiteBundleManifestKey(app, archive) {
 		t.Fatalf("empty snapshot manifest key = %q", got)
 	}
-	if got := SQLiteSnapshotBundlePartKey(app, archive, "", 7); got != SQLiteBundlePartKey(app, archive, 7) {
+	if got := SQLiteSnapshotBundlePartKey(app, archive, "", "", 7); got != SQLiteBundlePartKey(app, archive, 7) {
 		t.Fatalf("empty snapshot part key = %q", got)
 	}
 	if got := SQLiteSnapshotObjectKey(app, archive, "not-a-digest"); got != "" {
 		t.Fatalf("invalid snapshot object key = %q", got)
+	}
+	if got := SQLiteSnapshotCompressedObjectKey(app, archive, snapshot, "not-a-digest"); got != "" {
+		t.Fatalf("invalid compressed object key = %q", got)
+	}
+	if got := SQLiteSnapshotBundlePartKey(app, archive, snapshot, "not-a-digest", 7); got != "" {
+		t.Fatalf("invalid snapshot part key = %q", got)
 	}
 	if got := SQLiteSnapshotBundleManifestKey(app, archive, strings.ToUpper(snapshot)); got != "" {
 		t.Fatalf("non-canonical snapshot manifest key = %q", got)
@@ -575,11 +634,15 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 				case "bundle-part":
 					if r.Header.Get("x-crawl-bundle-part-index") != "0" ||
 						r.Header.Get("content-type") != "application/gzip" ||
+						r.Header.Get("x-crawl-content-sha256") != strings.Repeat("d", 64) ||
+						r.Header.Get("x-crawl-compression") != SQLiteGzipCompression ||
 						r.Header.Get("x-crawl-snapshot-id") != tc.snapshotID {
 						t.Fatalf(
-							"part headers index=%q content-type=%q snapshot=%q",
+							"part headers index=%q content-type=%q sha=%q compression=%q snapshot=%q",
 							r.Header.Get("x-crawl-bundle-part-index"),
 							r.Header.Get("content-type"),
+							r.Header.Get("x-crawl-content-sha256"),
+							r.Header.Get("x-crawl-compression"),
 							r.Header.Get("x-crawl-snapshot-id"),
 						)
 					}
@@ -623,7 +686,7 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 				Archive:    "gitcrawl/openclaw__openclaw",
 				SnapshotID: tc.snapshotID,
 			}, []SQLiteBundlePartFile{{
-				SQLiteBundlePart: SQLiteBundlePart{Index: 0, Size: int64(len("compressed")), SHA256: "part-sha"},
+				SQLiteBundlePart: SQLiteBundlePart{Index: 0, Size: int64(len("compressed")), SHA256: strings.Repeat("d", 64)},
 				Path:             partPath,
 			}})
 			if err != nil {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"bytes"
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
@@ -14,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestConfigNormalizeAndEnabled(t *testing.T) {
@@ -380,16 +382,18 @@ func TestBuildGzipSQLiteBundlePreservesCurrentKeyLayout(t *testing.T) {
 	dir := t.TempDir()
 	source := filepath.Join(dir, "archive.db")
 	payload := strings.Repeat("SQLite format 3\n", 100)
+	generatedAt := time.Date(2026, time.July, 12, 8, 0, 0, 123, time.UTC)
 	if err := os.WriteFile(source, []byte(payload), 0o600); err != nil {
 		t.Fatalf("write source: %v", err)
 	}
 	bundle, err := BuildGzipSQLiteBundle(context.Background(), SQLiteBundleBuildOptions{
-		App:        "gitcrawl",
-		Archive:    "gitcrawl/openclaw__openclaw",
-		SourcePath: source,
-		WorkDir:    dir,
-		ChunkSize:  64,
-		Counts:     map[string]int64{"threads": 3},
+		App:         "gitcrawl",
+		Archive:     "gitcrawl/openclaw__openclaw",
+		SourcePath:  source,
+		WorkDir:     dir,
+		ChunkSize:   64,
+		GeneratedAt: generatedAt,
+		Counts:      map[string]int64{"threads": 3},
 	})
 	if err != nil {
 		t.Fatalf("build bundle: %v", err)
@@ -406,6 +410,9 @@ func TestBuildGzipSQLiteBundlePreservesCurrentKeyLayout(t *testing.T) {
 	}
 	if bundle.Manifest.SnapshotID != "" {
 		t.Fatalf("snapshot id = %q", bundle.Manifest.SnapshotID)
+	}
+	if got, want := bundle.Manifest.GeneratedAt, generatedAt.Format(time.RFC3339Nano); got != want {
+		t.Fatalf("generated_at = %q, want %q", got, want)
 	}
 	if bundle.Manifest.Object.Key != SQLiteObjectKey("gitcrawl", "gitcrawl/openclaw__openclaw") {
 		t.Fatalf("object key = %q", bundle.Manifest.Object.Key)
@@ -493,7 +500,87 @@ func TestBuildSnapshotGzipSQLiteBundleUsesSnapshotKeyLayout(t *testing.T) {
 	}
 }
 
-func TestBuildSnapshotGzipSQLiteBundleIsolatesEncodedRepresentations(t *testing.T) {
+func TestBuildSnapshotGzipSQLiteBundleIsDeterministicAcrossGeneratedAt(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "archive.db")
+	payload := strings.Repeat("deterministic snapshot payload\n", 256)
+	if err := os.WriteFile(source, []byte(payload), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	build := func(t *testing.T, generatedAt time.Time) SQLiteBundleBuild {
+		t.Helper()
+		bundle, err := BuildSnapshotGzipSQLiteBundle(context.Background(), SQLiteBundleBuildOptions{
+			App:              "gitcrawl",
+			Archive:          "gitcrawl/openclaw__openclaw",
+			SourcePath:       source,
+			WorkDir:          dir,
+			CompressionLevel: gzip.BestCompression,
+			ChunkSize:        128,
+			GeneratedAt:      generatedAt,
+			ContentType:      "application/vnd.sqlite3",
+			Privacy:          map[string]any{"scrubbed": true, "policy": "public-only"},
+			Counts:           map[string]int64{"threads": 256},
+		})
+		if err != nil {
+			t.Fatalf("build snapshot bundle: %v", err)
+		}
+		t.Cleanup(bundle.Cleanup)
+		return bundle
+	}
+	first := build(t, time.Date(2026, time.July, 12, 8, 0, 0, 0, time.UTC))
+	second := build(t, time.Date(2036, time.July, 12, 8, 0, 0, 0, time.UTC))
+	if first.Manifest.GeneratedAt != "" || second.Manifest.GeneratedAt != "" {
+		t.Fatalf("snapshot generated_at must be omitted: first=%q second=%q", first.Manifest.GeneratedAt, second.Manifest.GeneratedAt)
+	}
+	firstManifest, err := json.Marshal(first.Manifest)
+	if err != nil {
+		t.Fatalf("marshal first manifest: %v", err)
+	}
+	secondManifest, err := json.Marshal(second.Manifest)
+	if err != nil {
+		t.Fatalf("marshal second manifest: %v", err)
+	}
+	if !bytes.Equal(firstManifest, secondManifest) {
+		t.Fatalf("snapshot manifests differ:\nfirst:  %s\nsecond: %s", firstManifest, secondManifest)
+	}
+	firstManifestKey := SQLiteSnapshotBundleManifestKey(first.Manifest.App, first.Manifest.Archive, first.Manifest.SnapshotID)
+	secondManifestKey := SQLiteSnapshotBundleManifestKey(second.Manifest.App, second.Manifest.Archive, second.Manifest.SnapshotID)
+	if firstManifestKey != secondManifestKey {
+		t.Fatalf("manifest keys differ: first=%q second=%q", firstManifestKey, secondManifestKey)
+	}
+	firstCompressed, err := os.ReadFile(first.CompressedPath)
+	if err != nil {
+		t.Fatalf("read first compressed object: %v", err)
+	}
+	secondCompressed, err := os.ReadFile(second.CompressedPath)
+	if err != nil {
+		t.Fatalf("read second compressed object: %v", err)
+	}
+	if !bytes.Equal(firstCompressed, secondCompressed) {
+		t.Fatal("compressed snapshot objects differ")
+	}
+	if len(first.Parts) != len(second.Parts) {
+		t.Fatalf("part counts differ: first=%d second=%d", len(first.Parts), len(second.Parts))
+	}
+	for i := range first.Parts {
+		if first.Parts[i].SQLiteBundlePart != second.Parts[i].SQLiteBundlePart {
+			t.Fatalf("part %d metadata differs: first=%#v second=%#v", i, first.Parts[i], second.Parts[i])
+		}
+		firstPart, err := os.ReadFile(first.Parts[i].Path)
+		if err != nil {
+			t.Fatalf("read first part %d: %v", i, err)
+		}
+		secondPart, err := os.ReadFile(second.Parts[i].Path)
+		if err != nil {
+			t.Fatalf("read second part %d: %v", i, err)
+		}
+		if !bytes.Equal(firstPart, secondPart) {
+			t.Fatalf("part %d bytes differ", i)
+		}
+	}
+}
+
+func TestBuildSnapshotGzipSQLiteBundleRepresentationChangesConflictAtSourceManifestKey(t *testing.T) {
 	dir := t.TempDir()
 	source := filepath.Join(dir, "archive.db")
 	payload := make([]byte, 8192)
@@ -530,11 +617,36 @@ func TestBuildSnapshotGzipSQLiteBundleIsolatesEncodedRepresentations(t *testing.
 		fastSmall.Manifest.Object.Key != fastLarge.Manifest.Object.Key {
 		t.Fatalf("source object keys differ")
 	}
+	manifestKey := func(bundle SQLiteBundleBuild) string {
+		return SQLiteSnapshotBundleManifestKey(bundle.Manifest.App, bundle.Manifest.Archive, bundle.Manifest.SnapshotID)
+	}
+	if manifestKey(fastSmall) != manifestKey(bestSmall) ||
+		manifestKey(fastSmall) != manifestKey(fastLarge) {
+		t.Fatalf("representation variants must target one immutable source manifest key")
+	}
 	if fastSmall.Manifest.CompressedObject.Key == bestSmall.Manifest.CompressedObject.Key {
 		t.Fatalf("compression variants share key %q", fastSmall.Manifest.CompressedObject.Key)
 	}
 	if fastSmall.Manifest.Parts[0].Key == fastLarge.Manifest.Parts[0].Key {
 		t.Fatalf("chunk variants share first part key %q", fastSmall.Manifest.Parts[0].Key)
+	}
+	fastSmallManifest, err := json.Marshal(fastSmall.Manifest)
+	if err != nil {
+		t.Fatalf("marshal fast-small manifest: %v", err)
+	}
+	bestSmallManifest, err := json.Marshal(bestSmall.Manifest)
+	if err != nil {
+		t.Fatalf("marshal best-small manifest: %v", err)
+	}
+	fastLargeManifest, err := json.Marshal(fastLarge.Manifest)
+	if err != nil {
+		t.Fatalf("marshal fast-large manifest: %v", err)
+	}
+	if bytes.Equal(fastSmallManifest, bestSmallManifest) {
+		t.Fatal("compression variants must produce conflicting immutable manifest bodies")
+	}
+	if bytes.Equal(fastSmallManifest, fastLargeManifest) {
+		t.Fatal("chunk variants must produce conflicting immutable manifest bodies")
 	}
 }
 
@@ -559,9 +671,11 @@ func assertSQLiteBundlePayload(t *testing.T, compressed, payload string) []byte 
 
 func TestSQLiteBundleKeyLayouts(t *testing.T) {
 	const (
-		app      = "git crawl"
-		archive  = "openclaw/crawlkit"
-		snapshot = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+		app           = "git crawl"
+		archive       = "openclaw/crawlkit"
+		snapshot      = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+		compressedSHA = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+		partSHA       = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 	)
 	if got, want := SQLiteObjectKey(app, archive), "v1/git%20crawl/openclaw%2Fcrawlkit/sqlite/current.db"; got != want {
 		t.Fatalf("object key = %q, want %q", got, want)
@@ -574,6 +688,18 @@ func TestSQLiteBundleKeyLayouts(t *testing.T) {
 	}
 	if got, want := SQLiteBundlePartKey(app, archive, 7), "v1/git%20crawl/openclaw%2Fcrawlkit/sqlite/chunks/current.db.gz.part-0007"; got != want {
 		t.Fatalf("part key = %q, want %q", got, want)
+	}
+	if got, want := SQLiteSnapshotObjectKey(app, archive, snapshot), "v1/git%20crawl/openclaw%2Fcrawlkit/sqlite/snapshots/"+snapshot+"/archive.db"; got != want {
+		t.Fatalf("snapshot object key = %q, want %q", got, want)
+	}
+	if got, want := SQLiteSnapshotCompressedObjectKey(app, archive, snapshot, compressedSHA), "v1/git%20crawl/openclaw%2Fcrawlkit/sqlite/snapshots/"+snapshot+"/objects/"+compressedSHA+"/archive.db.gz"; got != want {
+		t.Fatalf("snapshot compressed key = %q, want %q", got, want)
+	}
+	if got, want := SQLiteSnapshotBundleManifestKey(app, archive, snapshot), "v1/git%20crawl/openclaw%2Fcrawlkit/sqlite/snapshots/"+snapshot+"/manifest.json"; got != want {
+		t.Fatalf("snapshot manifest key = %q, want %q", got, want)
+	}
+	if got, want := SQLiteSnapshotBundlePartKey(app, archive, snapshot, partSHA, 7), "v1/git%20crawl/openclaw%2Fcrawlkit/sqlite/snapshots/"+snapshot+"/chunks/"+partSHA+"/archive.db.gz.part-0007"; got != want {
+		t.Fatalf("snapshot part key = %q, want %q", got, want)
 	}
 	if got := SQLiteSnapshotObjectKey(app, archive, ""); got != SQLiteObjectKey(app, archive) {
 		t.Fatalf("empty snapshot object key = %q", got)

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -405,6 +405,13 @@ func TestBuildGzipSQLiteBundleSplitsAndDescribesParts(t *testing.T) {
 	if bundle.Manifest.SnapshotID != bundle.Manifest.Object.SHA256 {
 		t.Fatalf("snapshot id = %q object sha = %q", bundle.Manifest.SnapshotID, bundle.Manifest.Object.SHA256)
 	}
+	if bundle.Manifest.Object.Key != SQLiteSnapshotObjectKey(
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		bundle.Manifest.SnapshotID,
+	) {
+		t.Fatalf("object key = %q", bundle.Manifest.Object.Key)
+	}
 	if bundle.Manifest.CompressedObject.Size <= 0 || bundle.Manifest.CompressedObject.SHA256 == "" {
 		t.Fatalf("compressed object = %#v", bundle.Manifest.CompressedObject)
 	}
@@ -418,7 +425,7 @@ func TestBuildGzipSQLiteBundleSplitsAndDescribesParts(t *testing.T) {
 			t.Fatalf("read part: %v", err)
 		}
 		compressed.Write(bytes)
-		if !strings.Contains(part.Key, "current.db.gz.part-") {
+		if !strings.Contains(part.Key, "/sqlite/snapshots/"+bundle.Manifest.SnapshotID+"/chunks/archive.db.gz.part-") {
 			t.Fatalf("part key = %q", part.Key)
 		}
 	}
@@ -453,6 +460,9 @@ func TestClientUploadSQLiteBundleFilesUploadsPartsThenManifest(t *testing.T) {
 			if r.Header.Get("x-crawl-bundle-part-index") != "0" || r.Header.Get("content-type") != "application/gzip" {
 				t.Fatalf("part headers index=%q content-type=%q", r.Header.Get("x-crawl-bundle-part-index"), r.Header.Get("content-type"))
 			}
+			if r.Header.Get("x-crawl-snapshot-id") != strings.Repeat("c", 64) {
+				t.Fatalf("snapshot header = %q", r.Header.Get("x-crawl-snapshot-id"))
+			}
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Fatalf("read part body: %v", err)
@@ -477,7 +487,14 @@ func TestClientUploadSQLiteBundleFilesUploadsPartsThenManifest(t *testing.T) {
 				App:      "gitcrawl",
 				Archive:  "gitcrawl/openclaw__openclaw",
 				Complete: true,
-				Bundle:   &SQLiteBundle{Key: SQLiteBundleManifestKey("gitcrawl", "gitcrawl/openclaw__openclaw"), Manifest: &manifest},
+				Bundle: &SQLiteBundle{
+					Key: SQLiteSnapshotBundleManifestKey(
+						"gitcrawl",
+						"gitcrawl/openclaw__openclaw",
+						manifest.SnapshotID,
+					),
+					Manifest: &manifest,
+				},
 			})
 		default:
 			t.Fatalf("unexpected upload kind %q", r.Header.Get("x-crawl-sqlite-upload"))

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -63,6 +63,11 @@ func TestClientQuerySendsBearerAndEscapedArchive(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(QueryResult{
 			Columns: []string{"number", "title"},
 			Rows:    [][]any{{float64(1), "remote"}},
+			Snapshot: &ArchiveSnapshot{
+				ID:           strings.Repeat("a", 64),
+				SourceSHA256: strings.Repeat("a", 64),
+				PublishedAt:  "2026-07-12T08:00:00Z",
+			},
 		})
 	}))
 	defer server.Close()
@@ -83,6 +88,9 @@ func TestClientQuerySendsBearerAndEscapedArchive(t *testing.T) {
 	}
 	if len(result.Rows) != 1 || result.Columns[0] != "number" {
 		t.Fatalf("result = %#v", result)
+	}
+	if result.Snapshot == nil || result.Snapshot.ID != strings.Repeat("a", 64) {
+		t.Fatalf("snapshot = %#v", result.Snapshot)
 	}
 }
 
@@ -105,9 +113,19 @@ func TestClientArchiveOperations(t *testing.T) {
 		}
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/archives":
-			_ = json.NewEncoder(w).Encode(map[string]any{"archives": []Archive{{ID: "arch-1", App: "gitcrawl"}}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"archives": []Archive{{
+				ID:       "arch-1",
+				App:      "gitcrawl",
+				Snapshot: &ArchiveSnapshot{ID: strings.Repeat("b", 64)},
+			}}})
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/status"):
-			_ = json.NewEncoder(w).Encode(Status{App: "gitcrawl", Archive: "gitcrawl/openclaw", Mode: ModeCloud})
+			_ = json.NewEncoder(w).Encode(Status{
+				App:      "gitcrawl",
+				Archive:  "gitcrawl/openclaw",
+				Mode:     ModeCloud,
+				Snapshot: &ArchiveSnapshot{ID: strings.Repeat("b", 64)},
+				Publish:  &ArchivePublish{Status: "complete"},
+			})
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/batch-read"):
 			var body struct {
 				Requests []QueryRequest `json:"requests"`
@@ -127,11 +145,20 @@ func TestClientArchiveOperations(t *testing.T) {
 			if req.Manifest.App != "gitcrawl" || req.Manifest.Archive != "gitcrawl/openclaw" {
 				t.Fatalf("ingest manifest = %#v", req.Manifest)
 			}
+			if req.Manifest.SnapshotID != strings.Repeat("b", 64) || req.Manifest.SourceSHA256 != strings.Repeat("b", 64) {
+				t.Fatalf("ingest snapshot manifest = %#v", req.Manifest)
+			}
 			if len(req.Rows) == 0 {
 				_ = json.NewEncoder(w).Encode(IngestResult{RunID: "run-1", Table: req.Table, ResetIncomplete: true, ResetDeleted: 10000})
 				return
 			}
-			_ = json.NewEncoder(w).Encode(IngestResult{RunID: "run-1", Table: req.Table, RowsAccepted: int64(len(req.Rows)), Complete: req.Final})
+			_ = json.NewEncoder(w).Encode(IngestResult{
+				RunID:        "run-1",
+				Table:        req.Table,
+				SnapshotID:   req.Manifest.SnapshotID,
+				RowsAccepted: int64(len(req.Rows)),
+				Complete:     req.Final,
+			})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/auth/github/start":
 			var req LoginStartRequest
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -164,14 +191,14 @@ func TestClientArchiveOperations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("archives: %v", err)
 	}
-	if len(archives) != 1 || archives[0].ID != "arch-1" {
+	if len(archives) != 1 || archives[0].ID != "arch-1" || archives[0].Snapshot == nil {
 		t.Fatalf("archives = %#v", archives)
 	}
 	status, err := client.Status(context.Background(), "gitcrawl", "gitcrawl/openclaw")
 	if err != nil {
 		t.Fatalf("status: %v", err)
 	}
-	if status.Mode != ModeCloud {
+	if status.Mode != ModeCloud || status.Snapshot == nil || status.Publish == nil {
 		t.Fatalf("status = %#v", status)
 	}
 	results, err := client.BatchRead(context.Background(), "gitcrawl", "gitcrawl/openclaw", []QueryRequest{{Name: "threads"}})
@@ -181,14 +208,27 @@ func TestClientArchiveOperations(t *testing.T) {
 	if len(results) != 1 || results[0].Columns[0] != "id" {
 		t.Fatalf("batch results = %#v", results)
 	}
-	ingest, err := client.Ingest(context.Background(), "gitcrawl", "gitcrawl/openclaw", IngestRequest{Table: "threads", Rows: [][]any{{"1"}}, Final: true})
+	manifest := IngestManifest{
+		SnapshotID:   strings.Repeat("b", 64),
+		SourceSHA256: strings.Repeat("b", 64),
+	}
+	ingest, err := client.Ingest(context.Background(), "gitcrawl", "gitcrawl/openclaw", IngestRequest{
+		Manifest: manifest,
+		Table:    "threads",
+		Rows:     [][]any{{"1"}},
+		Final:    true,
+	})
 	if err != nil {
 		t.Fatalf("ingest: %v", err)
 	}
-	if !ingest.Complete || ingest.RowsAccepted != 1 {
+	if !ingest.Complete || ingest.RowsAccepted != 1 || ingest.SnapshotID != manifest.SnapshotID {
 		t.Fatalf("ingest result = %#v", ingest)
 	}
-	reset, err := client.Ingest(context.Background(), "gitcrawl", "gitcrawl/openclaw", IngestRequest{Table: "threads", Rows: [][]any{}})
+	reset, err := client.Ingest(context.Background(), "gitcrawl", "gitcrawl/openclaw", IngestRequest{
+		Manifest: manifest,
+		Table:    "threads",
+		Rows:     [][]any{},
+	})
 	if err != nil {
 		t.Fatalf("reset ingest: %v", err)
 	}
@@ -306,6 +346,9 @@ func TestBuildGzipSQLiteBundleSplitsAndDescribesParts(t *testing.T) {
 	if bundle.Manifest.Object.Size != int64(len(payload)) || bundle.Manifest.Object.SHA256 == "" {
 		t.Fatalf("object = %#v", bundle.Manifest.Object)
 	}
+	if bundle.Manifest.SnapshotID != bundle.Manifest.Object.SHA256 {
+		t.Fatalf("snapshot id = %q object sha = %q", bundle.Manifest.SnapshotID, bundle.Manifest.Object.SHA256)
+	}
 	if bundle.Manifest.CompressedObject.Size <= 0 || bundle.Manifest.CompressedObject.SHA256 == "" {
 		t.Fatalf("compressed object = %#v", bundle.Manifest.CompressedObject)
 	}
@@ -371,6 +414,9 @@ func TestClientUploadSQLiteBundleFilesUploadsPartsThenManifest(t *testing.T) {
 			if manifest.Format != SQLiteGzipChunkedBundleFormat {
 				t.Fatalf("manifest = %#v", manifest)
 			}
+			if manifest.SnapshotID != strings.Repeat("c", 64) {
+				t.Fatalf("snapshot id = %q", manifest.SnapshotID)
+			}
 			_ = json.NewEncoder(w).Encode(SQLiteBundleUploadResult{
 				App:      "gitcrawl",
 				Archive:  "gitcrawl/openclaw__openclaw",
@@ -387,9 +433,10 @@ func TestClientUploadSQLiteBundleFilesUploadsPartsThenManifest(t *testing.T) {
 		t.Fatalf("client: %v", err)
 	}
 	result, err := client.UploadSQLiteBundleFiles(context.Background(), "gitcrawl", "gitcrawl/openclaw__openclaw", SQLiteBundleManifest{
-		Format:  SQLiteGzipChunkedBundleFormat,
-		App:     "gitcrawl",
-		Archive: "gitcrawl/openclaw__openclaw",
+		Format:     SQLiteGzipChunkedBundleFormat,
+		App:        "gitcrawl",
+		Archive:    "gitcrawl/openclaw__openclaw",
+		SnapshotID: strings.Repeat("c", 64),
 	}, []SQLiteBundlePartFile{{
 		SQLiteBundlePart: SQLiteBundlePart{Index: 0, Size: int64(len("compressed")), SHA256: "part-sha"},
 		Path:             partPath,

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -57,12 +57,20 @@ func TestClientQuerySendsBearerAndEscapedArchive(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		if req.App != "gitcrawl" || req.Archive != "gitcrawl/openclaw__openclaw" || req.Name != "gitcrawl.threads.search" {
+		if req.App != "gitcrawl" || req.Archive != "gitcrawl/openclaw__openclaw" ||
+			req.Name != "gitcrawl.threads.search" || req.SnapshotID != strings.Repeat("a", 64) {
 			t.Fatalf("request = %#v", req)
 		}
 		_ = json.NewEncoder(w).Encode(QueryResult{
 			Columns: []string{"number", "title"},
 			Rows:    [][]any{{float64(1), "remote"}},
+			Stats: QueryStats{
+				SnapshotID:       strings.Repeat("a", 64),
+				CoverageComplete: true,
+				SchemaVersion:    8,
+				ObservationOrder: "observation-order",
+				NextCursor:       "cursor-2",
+			},
 			Snapshot: &ArchiveSnapshot{
 				ID:           strings.Repeat("a", 64),
 				SourceSHA256: strings.Repeat("a", 64),
@@ -76,7 +84,10 @@ func TestClientQuerySendsBearerAndEscapedArchive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("client: %v", err)
 	}
-	result, err := client.Query(context.Background(), "gitcrawl", "gitcrawl/openclaw__openclaw", QueryRequest{Name: "gitcrawl.threads.search"})
+	result, err := client.Query(context.Background(), "gitcrawl", "gitcrawl/openclaw__openclaw", QueryRequest{
+		Name:       "gitcrawl.threads.search",
+		SnapshotID: strings.Repeat("a", 64),
+	})
 	if err != nil {
 		t.Fatalf("query: %v", err)
 	}
@@ -91,6 +102,9 @@ func TestClientQuerySendsBearerAndEscapedArchive(t *testing.T) {
 	}
 	if result.Snapshot == nil || result.Snapshot.ID != strings.Repeat("a", 64) {
 		t.Fatalf("snapshot = %#v", result.Snapshot)
+	}
+	if result.Stats.SnapshotID != result.Snapshot.ID || result.Stats.NextCursor != "cursor-2" {
+		t.Fatalf("stats = %#v", result.Stats)
 	}
 }
 
@@ -120,9 +134,21 @@ func TestClientArchiveOperations(t *testing.T) {
 			}}})
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/status"):
 			_ = json.NewEncoder(w).Encode(Status{
-				App:      "gitcrawl",
-				Archive:  "gitcrawl/openclaw",
-				Mode:     ModeCloud,
+				App:                "gitcrawl",
+				Archive:            "gitcrawl/openclaw",
+				Mode:               ModeCloud,
+				SchemaVersion:      8,
+				SnapshotMode:       "snapshot",
+				SnapshotCutoverAt:  "2026-07-12T08:00:00Z",
+				ActiveSnapshotID:   strings.Repeat("b", 64),
+				SourceSyncAt:       "2026-07-12T07:55:00Z",
+				DatasetGeneratedAt: "2026-07-12T07:56:00Z",
+				CoverageComplete:   true,
+				Datasets: []DatasetCoverage{{
+					Dataset:  "threads",
+					RowCount: 10,
+					Complete: true,
+				}},
 				Snapshot: &ArchiveSnapshot{ID: strings.Repeat("b", 64)},
 				Publish:  &ArchivePublish{Status: "complete"},
 			})
@@ -148,16 +174,33 @@ func TestClientArchiveOperations(t *testing.T) {
 			if req.Manifest.SnapshotID != strings.Repeat("b", 64) || req.Manifest.SourceSHA256 != strings.Repeat("b", 64) {
 				t.Fatalf("ingest snapshot manifest = %#v", req.Manifest)
 			}
+			if req.MutationToken != "generation-1" {
+				t.Fatalf("mutation token = %q", req.MutationToken)
+			}
 			if len(req.Rows) == 0 {
 				_ = json.NewEncoder(w).Encode(IngestResult{RunID: "run-1", Table: req.Table, ResetIncomplete: true, ResetDeleted: 10000})
 				return
 			}
 			_ = json.NewEncoder(w).Encode(IngestResult{
-				RunID:        "run-1",
-				Table:        req.Table,
-				SnapshotID:   req.Manifest.SnapshotID,
-				RowsAccepted: int64(len(req.Rows)),
-				Complete:     req.Final,
+				RunID:         "run-1",
+				Table:         req.Table,
+				SnapshotID:    req.Manifest.SnapshotID,
+				MutationToken: req.MutationToken,
+				RowsAccepted:  int64(len(req.Rows)),
+				Complete:      req.Final,
+			})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/cutover"):
+			var body struct {
+				SnapshotID string `json:"snapshot_id"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode cutover: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(CutoverResult{
+				ArchiveID:  "gitcrawl/openclaw",
+				SnapshotID: body.SnapshotID,
+				Status:     "active",
+				CutoverAt:  "2026-07-12T08:00:00Z",
 			})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/auth/github/start":
 			var req LoginStartRequest
@@ -198,7 +241,8 @@ func TestClientArchiveOperations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("status: %v", err)
 	}
-	if status.Mode != ModeCloud || status.Snapshot == nil || status.Publish == nil {
+	if status.Mode != ModeCloud || status.Snapshot == nil || status.Publish == nil ||
+		status.ActiveSnapshotID == "" || !status.CoverageComplete || len(status.Datasets) != 1 {
 		t.Fatalf("status = %#v", status)
 	}
 	results, err := client.BatchRead(context.Background(), "gitcrawl", "gitcrawl/openclaw", []QueryRequest{{Name: "threads"}})
@@ -213,27 +257,37 @@ func TestClientArchiveOperations(t *testing.T) {
 		SourceSHA256: strings.Repeat("b", 64),
 	}
 	ingest, err := client.Ingest(context.Background(), "gitcrawl", "gitcrawl/openclaw", IngestRequest{
-		Manifest: manifest,
-		Table:    "threads",
-		Rows:     [][]any{{"1"}},
-		Final:    true,
+		Manifest:      manifest,
+		Table:         "threads",
+		Rows:          [][]any{{"1"}},
+		MutationToken: "generation-1",
+		Final:         true,
 	})
 	if err != nil {
 		t.Fatalf("ingest: %v", err)
 	}
-	if !ingest.Complete || ingest.RowsAccepted != 1 || ingest.SnapshotID != manifest.SnapshotID {
+	if !ingest.Complete || ingest.RowsAccepted != 1 || ingest.SnapshotID != manifest.SnapshotID ||
+		ingest.MutationToken != "generation-1" {
 		t.Fatalf("ingest result = %#v", ingest)
 	}
 	reset, err := client.Ingest(context.Background(), "gitcrawl", "gitcrawl/openclaw", IngestRequest{
-		Manifest: manifest,
-		Table:    "threads",
-		Rows:     [][]any{},
+		Manifest:      manifest,
+		Table:         "threads",
+		Rows:          [][]any{},
+		MutationToken: "generation-1",
 	})
 	if err != nil {
 		t.Fatalf("reset ingest: %v", err)
 	}
 	if !reset.ResetIncomplete || reset.ResetDeleted != 10000 {
 		t.Fatalf("reset result = %#v", reset)
+	}
+	cutover, err := client.Cutover(context.Background(), "gitcrawl", "gitcrawl/openclaw", manifest.SnapshotID)
+	if err != nil {
+		t.Fatalf("cutover: %v", err)
+	}
+	if cutover.SnapshotID != manifest.SnapshotID || cutover.Status != "active" {
+		t.Fatalf("cutover result = %#v", cutover)
 	}
 	start, err := client.StartGitHubLogin(context.Background(), "hash")
 	if err != nil {
@@ -249,7 +303,7 @@ func TestClientArchiveOperations(t *testing.T) {
 	if poll.Status != "complete" || poll.Token != "session-token" {
 		t.Fatalf("poll = %#v", poll)
 	}
-	if len(requests) != 7 {
+	if len(requests) != 8 {
 		t.Fatalf("requests = %#v", requests)
 	}
 }
@@ -505,6 +559,9 @@ func TestBaseContractValidates(t *testing.T) {
 	}
 	if !hasRoute(contract, http.MethodGet, ContractPath, AuthPublic) {
 		t.Fatalf("contract route missing")
+	}
+	if !hasRoute(contract, http.MethodPost, "/v1/apps/:app/archives/:archive/cutover", AuthPublisher) {
+		t.Fatalf("contract cutover route missing")
 	}
 }
 

--- a/remote/sqlite_bundle.go
+++ b/remote/sqlite_bundle.go
@@ -89,6 +89,10 @@ func BuildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions) (
 	return buildGzipSQLiteBundle(ctx, opts, false)
 }
 
+// BuildSnapshotGzipSQLiteBundle builds an immutable, content-addressed bundle.
+// Its manifest omits GeneratedAt so identical source bytes and options produce
+// identical JSON. Callers must treat a different representation for the same
+// source snapshot as a conflict at the immutable source manifest key.
 func BuildSnapshotGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions) (SQLiteBundleBuild, error) {
 	return buildGzipSQLiteBundle(ctx, opts, true)
 }
@@ -105,9 +109,13 @@ func buildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions, s
 	if level == 0 {
 		level = gzip.DefaultCompression
 	}
-	generatedAt := opts.GeneratedAt
-	if generatedAt.IsZero() {
-		generatedAt = time.Now().UTC()
+	generatedAt := ""
+	if !snapshotScoped {
+		value := opts.GeneratedAt
+		if value.IsZero() {
+			value = time.Now().UTC()
+		}
+		generatedAt = value.Format(time.RFC3339Nano)
 	}
 	contentType := opts.ContentType
 	if contentType == "" {
@@ -158,7 +166,7 @@ func buildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions, s
 		App:         opts.App,
 		Archive:     opts.Archive,
 		SnapshotID:  snapshotID,
-		GeneratedAt: generatedAt.Format(time.RFC3339Nano),
+		GeneratedAt: generatedAt,
 		ContentType: contentType,
 		Compression: SQLiteBundleCompression{
 			Algorithm: SQLiteGzipCompression,

--- a/remote/sqlite_bundle.go
+++ b/remote/sqlite_bundle.go
@@ -82,6 +82,7 @@ type SQLiteBundlePartUpload struct {
 	Size        int64
 	SHA256      string
 	Compression string
+	SnapshotID  string
 }
 
 func BuildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions) (SQLiteBundleBuild, error) {
@@ -133,7 +134,7 @@ func BuildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions) (
 		cleanup()
 		return SQLiteBundleBuild{}, err
 	}
-	parts, err := splitBundleParts(ctx, compressedPath, tmpDir, opts.App, opts.Archive, chunkSize)
+	parts, err := splitBundleParts(ctx, compressedPath, tmpDir, opts.App, opts.Archive, sourceSHA, chunkSize)
 	if err != nil {
 		cleanup()
 		return SQLiteBundleBuild{}, err
@@ -154,16 +155,16 @@ func BuildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions) (
 		},
 		Privacy: opts.Privacy,
 		Object: SQLiteBundleObject{
-			Key:    SQLiteObjectKey(opts.App, opts.Archive),
+			Key:    SQLiteSnapshotObjectKey(opts.App, opts.Archive, sourceSHA),
 			Size:   sourceInfo.Size(),
 			SHA256: sourceSHA,
 		},
 		CompressedObject: SQLiteBundleObject{
-			Key:    SQLiteCompressedObjectKey(opts.App, opts.Archive),
+			Key:    SQLiteSnapshotCompressedObjectKey(opts.App, opts.Archive, sourceSHA),
 			Size:   compressedInfo.Size(),
 			SHA256: compressedSHA,
 		},
-		Reconstruct: "concatenate parts in index order to current.db.gz, then gzip-decompress to current.db",
+		Reconstruct: "concatenate parts in index order to archive.db.gz, then gzip-decompress to archive.db",
 		Counts:      opts.Counts,
 		Parts:       manifestParts,
 	}
@@ -191,6 +192,43 @@ func SQLiteBundlePartKey(app, archive string, index int) string {
 	return fmt.Sprintf("v1/%s/%s/sqlite/chunks/current.db.gz.part-%04d", url.PathEscape(app), url.PathEscape(archive), index)
 }
 
+func SQLiteSnapshotObjectKey(app, archive, snapshotID string) string {
+	return fmt.Sprintf(
+		"v1/%s/%s/sqlite/snapshots/%s/archive.db",
+		url.PathEscape(app),
+		url.PathEscape(archive),
+		url.PathEscape(snapshotID),
+	)
+}
+
+func SQLiteSnapshotCompressedObjectKey(app, archive, snapshotID string) string {
+	return fmt.Sprintf(
+		"v1/%s/%s/sqlite/snapshots/%s/archive.db.gz",
+		url.PathEscape(app),
+		url.PathEscape(archive),
+		url.PathEscape(snapshotID),
+	)
+}
+
+func SQLiteSnapshotBundleManifestKey(app, archive, snapshotID string) string {
+	return fmt.Sprintf(
+		"v1/%s/%s/sqlite/snapshots/%s/manifest.json",
+		url.PathEscape(app),
+		url.PathEscape(archive),
+		url.PathEscape(snapshotID),
+	)
+}
+
+func SQLiteSnapshotBundlePartKey(app, archive, snapshotID string, index int) string {
+	return fmt.Sprintf(
+		"v1/%s/%s/sqlite/snapshots/%s/chunks/archive.db.gz.part-%04d",
+		url.PathEscape(app),
+		url.PathEscape(archive),
+		url.PathEscape(snapshotID),
+		index,
+	)
+}
+
 func gzipFile(ctx context.Context, sourcePath, targetPath string, level int) error {
 	source, err := os.Open(sourcePath)
 	if err != nil {
@@ -216,7 +254,7 @@ func gzipFile(ctx context.Context, sourcePath, targetPath string, level int) err
 	return nil
 }
 
-func splitBundleParts(ctx context.Context, sourcePath, dir, app, archive string, chunkSize int64) ([]SQLiteBundlePartFile, error) {
+func splitBundleParts(ctx context.Context, sourcePath, dir, app, archive, snapshotID string, chunkSize int64) ([]SQLiteBundlePartFile, error) {
 	source, err := os.Open(sourcePath)
 	if err != nil {
 		return nil, fmt.Errorf("open compressed sqlite bundle: %w", err)
@@ -248,7 +286,7 @@ func splitBundleParts(ctx context.Context, sourcePath, dir, app, archive string,
 		parts = append(parts, SQLiteBundlePartFile{
 			SQLiteBundlePart: SQLiteBundlePart{
 				Index:  index,
-				Key:    SQLiteBundlePartKey(app, archive, index),
+				Key:    SQLiteSnapshotBundlePartKey(app, archive, snapshotID, index),
 				Size:   written,
 				SHA256: fmt.Sprintf("%x", hash.Sum(nil)),
 			},

--- a/remote/sqlite_bundle.go
+++ b/remote/sqlite_bundle.go
@@ -193,6 +193,9 @@ func SQLiteBundlePartKey(app, archive string, index int) string {
 }
 
 func SQLiteSnapshotObjectKey(app, archive, snapshotID string) string {
+	if snapshotID == "" {
+		return SQLiteObjectKey(app, archive)
+	}
 	return fmt.Sprintf(
 		"v1/%s/%s/sqlite/snapshots/%s/archive.db",
 		url.PathEscape(app),
@@ -202,6 +205,9 @@ func SQLiteSnapshotObjectKey(app, archive, snapshotID string) string {
 }
 
 func SQLiteSnapshotCompressedObjectKey(app, archive, snapshotID string) string {
+	if snapshotID == "" {
+		return SQLiteCompressedObjectKey(app, archive)
+	}
 	return fmt.Sprintf(
 		"v1/%s/%s/sqlite/snapshots/%s/archive.db.gz",
 		url.PathEscape(app),
@@ -211,6 +217,9 @@ func SQLiteSnapshotCompressedObjectKey(app, archive, snapshotID string) string {
 }
 
 func SQLiteSnapshotBundleManifestKey(app, archive, snapshotID string) string {
+	if snapshotID == "" {
+		return SQLiteBundleManifestKey(app, archive)
+	}
 	return fmt.Sprintf(
 		"v1/%s/%s/sqlite/snapshots/%s/manifest.json",
 		url.PathEscape(app),
@@ -220,6 +229,9 @@ func SQLiteSnapshotBundleManifestKey(app, archive, snapshotID string) string {
 }
 
 func SQLiteSnapshotBundlePartKey(app, archive, snapshotID string, index int) string {
+	if snapshotID == "" {
+		return SQLiteBundlePartKey(app, archive, index)
+	}
 	return fmt.Sprintf(
 		"v1/%s/%s/sqlite/snapshots/%s/chunks/archive.db.gz.part-%04d",
 		url.PathEscape(app),

--- a/remote/sqlite_bundle.go
+++ b/remote/sqlite_bundle.go
@@ -39,6 +39,7 @@ type SQLiteBundleManifest struct {
 	Format           string                  `json:"format"`
 	App              string                  `json:"app"`
 	Archive          string                  `json:"archive"`
+	SnapshotID       string                  `json:"snapshot_id,omitempty"`
 	GeneratedAt      string                  `json:"generated_at,omitempty"`
 	ContentType      string                  `json:"content_type,omitempty"`
 	Compression      SQLiteBundleCompression `json:"compression,omitempty"`
@@ -145,6 +146,7 @@ func BuildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions) (
 		Format:      SQLiteGzipChunkedBundleFormat,
 		App:         opts.App,
 		Archive:     opts.Archive,
+		SnapshotID:  sourceSHA,
 		GeneratedAt: generatedAt.Format(time.RFC3339Nano),
 		ContentType: contentType,
 		Compression: SQLiteBundleCompression{

--- a/remote/sqlite_bundle.go
+++ b/remote/sqlite_bundle.go
@@ -97,10 +97,6 @@ func buildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions, s
 	if opts.SourcePath == "" {
 		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle source path is required")
 	}
-	sourceInfo, err := os.Stat(opts.SourcePath)
-	if err != nil {
-		return SQLiteBundleBuild{}, fmt.Errorf("stat sqlite bundle source: %w", err)
-	}
 	chunkSize := opts.ChunkSize
 	if chunkSize <= 0 {
 		chunkSize = DefaultSQLiteBundleChunkSize
@@ -123,11 +119,7 @@ func buildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions, s
 	}
 	cleanup := func() { _ = os.RemoveAll(tmpDir) }
 	compressedPath := filepath.Join(tmpDir, "current.db.gz")
-	if err := gzipFile(ctx, opts.SourcePath, compressedPath, level); err != nil {
-		cleanup()
-		return SQLiteBundleBuild{}, err
-	}
-	sourceSHA, err := fileSHA256(ctx, opts.SourcePath)
+	sourceSHA, sourceSize, err := gzipFile(ctx, opts.SourcePath, compressedPath, level)
 	if err != nil {
 		cleanup()
 		return SQLiteBundleBuild{}, err
@@ -149,7 +141,7 @@ func buildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions, s
 	if snapshotScoped {
 		snapshotID = sourceSHA
 		objectKey = SQLiteSnapshotObjectKey(opts.App, opts.Archive, snapshotID)
-		compressedObjectKey = SQLiteSnapshotCompressedObjectKey(opts.App, opts.Archive, snapshotID)
+		compressedObjectKey = SQLiteSnapshotCompressedObjectKey(opts.App, opts.Archive, snapshotID, compressedSHA)
 		reconstruct = "concatenate parts in index order to archive.db.gz, then gzip-decompress to archive.db"
 	}
 	parts, err := splitBundleParts(ctx, compressedPath, tmpDir, opts.App, opts.Archive, snapshotID, chunkSize)
@@ -174,7 +166,7 @@ func buildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions, s
 		Privacy: opts.Privacy,
 		Object: SQLiteBundleObject{
 			Key:    objectKey,
-			Size:   sourceInfo.Size(),
+			Size:   sourceSize,
 			SHA256: sourceSHA,
 		},
 		CompressedObject: SQLiteBundleObject{
@@ -225,18 +217,19 @@ func SQLiteSnapshotObjectKey(app, archive, snapshotID string) string {
 	)
 }
 
-func SQLiteSnapshotCompressedObjectKey(app, archive, snapshotID string) string {
+func SQLiteSnapshotCompressedObjectKey(app, archive, snapshotID, compressedSHA string) string {
 	if snapshotID == "" {
 		return SQLiteCompressedObjectKey(app, archive)
 	}
-	if !validSQLiteSnapshotID(snapshotID) {
+	if !validSQLiteSnapshotID(snapshotID) || !validSQLiteSnapshotID(compressedSHA) {
 		return ""
 	}
 	return fmt.Sprintf(
-		"v1/%s/%s/sqlite/snapshots/%s/archive.db.gz",
+		"v1/%s/%s/sqlite/snapshots/%s/objects/%s/archive.db.gz",
 		url.PathEscape(app),
 		url.PathEscape(archive),
 		url.PathEscape(snapshotID),
+		url.PathEscape(compressedSHA),
 	)
 }
 
@@ -255,18 +248,19 @@ func SQLiteSnapshotBundleManifestKey(app, archive, snapshotID string) string {
 	)
 }
 
-func SQLiteSnapshotBundlePartKey(app, archive, snapshotID string, index int) string {
+func SQLiteSnapshotBundlePartKey(app, archive, snapshotID, partSHA string, index int) string {
 	if snapshotID == "" {
 		return SQLiteBundlePartKey(app, archive, index)
 	}
-	if !validSQLiteSnapshotID(snapshotID) {
+	if !validSQLiteSnapshotID(snapshotID) || !validSQLiteSnapshotID(partSHA) {
 		return ""
 	}
 	return fmt.Sprintf(
-		"v1/%s/%s/sqlite/snapshots/%s/chunks/archive.db.gz.part-%04d",
+		"v1/%s/%s/sqlite/snapshots/%s/chunks/%s/archive.db.gz.part-%04d",
 		url.PathEscape(app),
 		url.PathEscape(archive),
 		url.PathEscape(snapshotID),
+		url.PathEscape(partSHA),
 		index,
 	)
 }
@@ -283,29 +277,31 @@ func validSQLiteSnapshotID(snapshotID string) bool {
 	return true
 }
 
-func gzipFile(ctx context.Context, sourcePath, targetPath string, level int) error {
+func gzipFile(ctx context.Context, sourcePath, targetPath string, level int) (string, int64, error) {
 	source, err := os.Open(sourcePath)
 	if err != nil {
-		return fmt.Errorf("open sqlite bundle source: %w", err)
+		return "", 0, fmt.Errorf("open sqlite bundle source: %w", err)
 	}
 	defer func() { _ = source.Close() }()
 	target, err := os.OpenFile(targetPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
 	if err != nil {
-		return fmt.Errorf("create compressed sqlite bundle: %w", err)
+		return "", 0, fmt.Errorf("create compressed sqlite bundle: %w", err)
 	}
 	defer func() { _ = target.Close() }()
 	gzw, err := gzip.NewWriterLevel(target, level)
 	if err != nil {
-		return fmt.Errorf("create gzip writer: %w", err)
+		return "", 0, fmt.Errorf("create gzip writer: %w", err)
 	}
-	if err := copyWithContext(ctx, gzw, source); err != nil {
+	hash := sha256.New()
+	sourceSize, err := copyWithContext(ctx, io.MultiWriter(gzw, hash), source)
+	if err != nil {
 		_ = gzw.Close()
-		return fmt.Errorf("compress sqlite bundle: %w", err)
+		return "", 0, fmt.Errorf("compress sqlite bundle: %w", err)
 	}
 	if err := gzw.Close(); err != nil {
-		return fmt.Errorf("finish compressed sqlite bundle: %w", err)
+		return "", 0, fmt.Errorf("finish compressed sqlite bundle: %w", err)
 	}
-	return nil
+	return fmt.Sprintf("%x", hash.Sum(nil)), sourceSize, nil
 }
 
 func splitBundleParts(ctx context.Context, sourcePath, dir, app, archive, snapshotID string, chunkSize int64) ([]SQLiteBundlePartFile, error) {
@@ -337,12 +333,13 @@ func splitBundleParts(ctx context.Context, sourcePath, dir, app, archive, snapsh
 			_ = os.Remove(partPath)
 			break
 		}
+		partSHA := fmt.Sprintf("%x", hash.Sum(nil))
 		parts = append(parts, SQLiteBundlePartFile{
 			SQLiteBundlePart: SQLiteBundlePart{
 				Index:  index,
-				Key:    SQLiteSnapshotBundlePartKey(app, archive, snapshotID, index),
+				Key:    SQLiteSnapshotBundlePartKey(app, archive, snapshotID, partSHA, index),
 				Size:   written,
-				SHA256: fmt.Sprintf("%x", hash.Sum(nil)),
+				SHA256: partSHA,
 			},
 			Path: partPath,
 		})
@@ -363,29 +360,35 @@ func fileSHA256(ctx context.Context, path string) (string, error) {
 	}
 	defer func() { _ = file.Close() }()
 	hash := sha256.New()
-	if err := copyWithContext(ctx, hash, file); err != nil {
+	if _, err := copyWithContext(ctx, hash, file); err != nil {
 		return "", fmt.Errorf("hash file: %w", err)
 	}
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
 }
 
-func copyWithContext(ctx context.Context, dst io.Writer, src io.Reader) error {
+func copyWithContext(ctx context.Context, dst io.Writer, src io.Reader) (int64, error) {
 	buf := make([]byte, 1024*1024)
+	var written int64
 	for {
 		if err := ctx.Err(); err != nil {
-			return err
+			return written, err
 		}
 		n, readErr := src.Read(buf)
 		if n > 0 {
-			if _, err := dst.Write(buf[:n]); err != nil {
-				return err
+			count, err := dst.Write(buf[:n])
+			written += int64(count)
+			if err != nil {
+				return written, err
+			}
+			if count != n {
+				return written, io.ErrShortWrite
 			}
 		}
 		if readErr == io.EOF {
-			return nil
+			return written, nil
 		}
 		if readErr != nil {
-			return readErr
+			return written, readErr
 		}
 	}
 }

--- a/remote/sqlite_bundle.go
+++ b/remote/sqlite_bundle.go
@@ -86,6 +86,14 @@ type SQLiteBundlePartUpload struct {
 }
 
 func BuildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions) (SQLiteBundleBuild, error) {
+	return buildGzipSQLiteBundle(ctx, opts, false)
+}
+
+func BuildSnapshotGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions) (SQLiteBundleBuild, error) {
+	return buildGzipSQLiteBundle(ctx, opts, true)
+}
+
+func buildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions, snapshotScoped bool) (SQLiteBundleBuild, error) {
 	if opts.SourcePath == "" {
 		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle source path is required")
 	}
@@ -134,7 +142,17 @@ func BuildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions) (
 		cleanup()
 		return SQLiteBundleBuild{}, err
 	}
-	parts, err := splitBundleParts(ctx, compressedPath, tmpDir, opts.App, opts.Archive, sourceSHA, chunkSize)
+	snapshotID := ""
+	objectKey := SQLiteObjectKey(opts.App, opts.Archive)
+	compressedObjectKey := SQLiteCompressedObjectKey(opts.App, opts.Archive)
+	reconstruct := "concatenate parts in index order to current.db.gz, then gzip-decompress to current.db"
+	if snapshotScoped {
+		snapshotID = sourceSHA
+		objectKey = SQLiteSnapshotObjectKey(opts.App, opts.Archive, snapshotID)
+		compressedObjectKey = SQLiteSnapshotCompressedObjectKey(opts.App, opts.Archive, snapshotID)
+		reconstruct = "concatenate parts in index order to archive.db.gz, then gzip-decompress to archive.db"
+	}
+	parts, err := splitBundleParts(ctx, compressedPath, tmpDir, opts.App, opts.Archive, snapshotID, chunkSize)
 	if err != nil {
 		cleanup()
 		return SQLiteBundleBuild{}, err
@@ -147,7 +165,7 @@ func BuildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions) (
 		Format:      SQLiteGzipChunkedBundleFormat,
 		App:         opts.App,
 		Archive:     opts.Archive,
-		SnapshotID:  sourceSHA,
+		SnapshotID:  snapshotID,
 		GeneratedAt: generatedAt.Format(time.RFC3339Nano),
 		ContentType: contentType,
 		Compression: SQLiteBundleCompression{
@@ -155,16 +173,16 @@ func BuildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions) (
 		},
 		Privacy: opts.Privacy,
 		Object: SQLiteBundleObject{
-			Key:    SQLiteSnapshotObjectKey(opts.App, opts.Archive, sourceSHA),
+			Key:    objectKey,
 			Size:   sourceInfo.Size(),
 			SHA256: sourceSHA,
 		},
 		CompressedObject: SQLiteBundleObject{
-			Key:    SQLiteSnapshotCompressedObjectKey(opts.App, opts.Archive, sourceSHA),
+			Key:    compressedObjectKey,
 			Size:   compressedInfo.Size(),
 			SHA256: compressedSHA,
 		},
-		Reconstruct: "concatenate parts in index order to archive.db.gz, then gzip-decompress to archive.db",
+		Reconstruct: reconstruct,
 		Counts:      opts.Counts,
 		Parts:       manifestParts,
 	}
@@ -196,6 +214,9 @@ func SQLiteSnapshotObjectKey(app, archive, snapshotID string) string {
 	if snapshotID == "" {
 		return SQLiteObjectKey(app, archive)
 	}
+	if !validSQLiteSnapshotID(snapshotID) {
+		return ""
+	}
 	return fmt.Sprintf(
 		"v1/%s/%s/sqlite/snapshots/%s/archive.db",
 		url.PathEscape(app),
@@ -207,6 +228,9 @@ func SQLiteSnapshotObjectKey(app, archive, snapshotID string) string {
 func SQLiteSnapshotCompressedObjectKey(app, archive, snapshotID string) string {
 	if snapshotID == "" {
 		return SQLiteCompressedObjectKey(app, archive)
+	}
+	if !validSQLiteSnapshotID(snapshotID) {
+		return ""
 	}
 	return fmt.Sprintf(
 		"v1/%s/%s/sqlite/snapshots/%s/archive.db.gz",
@@ -220,6 +244,9 @@ func SQLiteSnapshotBundleManifestKey(app, archive, snapshotID string) string {
 	if snapshotID == "" {
 		return SQLiteBundleManifestKey(app, archive)
 	}
+	if !validSQLiteSnapshotID(snapshotID) {
+		return ""
+	}
 	return fmt.Sprintf(
 		"v1/%s/%s/sqlite/snapshots/%s/manifest.json",
 		url.PathEscape(app),
@@ -232,6 +259,9 @@ func SQLiteSnapshotBundlePartKey(app, archive, snapshotID string, index int) str
 	if snapshotID == "" {
 		return SQLiteBundlePartKey(app, archive, index)
 	}
+	if !validSQLiteSnapshotID(snapshotID) {
+		return ""
+	}
 	return fmt.Sprintf(
 		"v1/%s/%s/sqlite/snapshots/%s/chunks/archive.db.gz.part-%04d",
 		url.PathEscape(app),
@@ -239,6 +269,18 @@ func SQLiteSnapshotBundlePartKey(app, archive, snapshotID string, index int) str
 		url.PathEscape(snapshotID),
 		index,
 	)
+}
+
+func validSQLiteSnapshotID(snapshotID string) bool {
+	if len(snapshotID) != sha256.Size*2 {
+		return false
+	}
+	for _, char := range snapshotID {
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 func gzipFile(ctx context.Context, sourcePath, targetPath string, level int) error {


### PR DESCRIPTION
## Summary
- add archive snapshot provenance fields to status, query, ingest, and cutover APIs
- support atomic snapshot publishing with mutation-token continuation and explicit cutover
- bind SQLite bundle manifests to the exact source database digest
- keep source-keyed snapshot manifests deterministic while isolating compressed objects and parts under digest-qualified immutable keys

## Tests\n- `GOWORK=off go test ./... -count=1`\n- `GOWORK=off go test -race ./... -count=1`\n- `GOWORK=off go vet ./...`\n- Windows amd64 cross-compile, tidy, formatting, and `git diff --check`