### PR TITLE
feat(remote): release snapshot APIs in v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.13.5 - Unreleased
+## v0.13.5 - 2026-07-12
 
 - Require notarized, single-architecture `crawlctl` release binaries bound to the repository-pinned signed tag and protected remote `main` commit, restore signing-keychain state before credential-free candidate probes, roll back partial artifact promotion, and keep naturally quarantined Gatekeeper execution plus Full Disk Access continuity as separate clean-VM gates because raw binaries and ZIP submission carriers cannot carry stapled tickets and raw-CLI `spctl` assessment is not an app-launch verdict.
 - Add immutable SQLite snapshot bundle manifests with deterministic source and representation digests, digest-scoped compressed objects and chunks, and explicit snapshot publishing helpers while preserving the legacy `current.*` bundle layout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Require notarized, single-architecture `crawlctl` release binaries bound to the repository-pinned signed tag and protected remote `main` commit, restore signing-keychain state before credential-free candidate probes, roll back partial artifact promotion, and keep naturally quarantined Gatekeeper execution plus Full Disk Access continuity as separate clean-VM gates because raw binaries and ZIP submission carriers cannot carry stapled tickets and raw-CLI `spctl` assessment is not an app-launch verdict.
 - Add immutable SQLite snapshot bundle manifests with deterministic source and representation digests, digest-scoped compressed objects and chunks, and explicit snapshot publishing helpers while preserving the legacy `current.*` bundle layout.
+- Expose immutable snapshot capabilities separately from the currently served archive capabilities so publishers can safely resume staged profiles before cutover.
 
 ## v0.13.4 - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.13.5 - 2026-07-12
+## v0.14.0 - 2026-07-12
 
 - Require notarized, single-architecture `crawlctl` release binaries bound to the repository-pinned signed tag and protected remote `main` commit, restore signing-keychain state before credential-free candidate probes, roll back partial artifact promotion, and keep naturally quarantined Gatekeeper execution plus Full Disk Access continuity as separate clean-VM gates because raw binaries and ZIP submission carriers cannot carry stapled tickets and raw-CLI `spctl` assessment is not an app-launch verdict.
 - Add immutable SQLite snapshot bundle manifests with deterministic source and representation digests, digest-scoped compressed objects and chunks, and explicit snapshot publishing helpers while preserving the legacy `current.*` bundle layout.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ requirement across in-place updates; the separate clean-VM release gate must
 prove that a later same-path build does not trigger a second protected-data
 alert. This contract does not suppress the first-install consent.
 
-Starting with v0.13.5, release binaries also require an Apple online
+Starting with v0.14.0, release binaries also require an Apple online
 notarization ticket before packaging and installation. The raw executable and
 ephemeral ZIP submitted to Apple do not support ticket stapling, so verification
 requires network access. Release verification also binds each thin binary's Go

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -24,9 +24,9 @@ GOWORK=off go test -count=1 ./...
 6. Tag the next semver release from `main`:
 
 ```bash
-git tag -s v0.13.5
+git tag -s v0.14.0
 git push origin main
-git push origin v0.13.5
+git push origin v0.14.0
 ```
 
 7. From the clean checkout whose `HEAD` exactly matches the signed release tag,
@@ -39,11 +39,11 @@ or renamed tag is not releasable. It then uses the shared secret-safe release
 keychain helper and fails closed if any provenance or signing check differs:
 
 ```bash
-make release-artifacts VERSION=v0.13.5
-release_commit=$(scripts/verify-crawlctl-release-provenance.sh v0.13.5)
-scripts/verify-crawlctl-release.sh v0.13.5 "$release_commit" \
-  dist/crawlctl-v0.13.5-macos-arm64.tar.gz \
-  dist/crawlctl-v0.13.5-macos-x86_64.tar.gz
+make release-artifacts VERSION=v0.14.0
+release_commit=$(scripts/verify-crawlctl-release-provenance.sh v0.14.0)
+scripts/verify-crawlctl-release.sh v0.14.0 "$release_commit" \
+  dist/crawlctl-v0.14.0-macos-arm64.tar.gz \
+  dist/crawlctl-v0.14.0-macos-x86_64.tar.gz
 ```
 
 The fixed code identifier is `org.openclaw.crawlctl`. The required signing
@@ -110,14 +110,14 @@ separately:
 9. Prime and verify module proxy visibility:
 
 ```bash
-GOPROXY=https://proxy.golang.org GONOSUMDB= go list -m github.com/openclaw/crawlkit@v0.13.5
-GOPROXY=https://proxy.golang.org go list -m github.com/openclaw/crawlkit@v0.13.5
+GOPROXY=https://proxy.golang.org GONOSUMDB= go list -m github.com/openclaw/crawlkit@v0.14.0
+GOPROXY=https://proxy.golang.org go list -m github.com/openclaw/crawlkit@v0.14.0
 ```
 
 10. Bump downstream apps to the new tag and commit their `go.mod`/`go.sum` updates:
 
 ```bash
-go get github.com/openclaw/crawlkit@v0.13.5
+go get github.com/openclaw/crawlkit@v0.14.0
 GOWORK=off go mod tidy
 ```
 

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -186,16 +186,17 @@ type Identity struct {
 }
 
 type ArchiveSnapshot struct {
-	ID                 string `json:"id"`
-	SourceSHA256       string `json:"source_sha256,omitempty"`
-	SchemaName         string `json:"schema_name,omitempty"`
-	SchemaVersion      int    `json:"schema_version,omitempty"`
-	SchemaHash         string `json:"schema_hash,omitempty"`
-	SourceSyncAt       string `json:"source_sync_at,omitempty"`
-	DatasetGeneratedAt string `json:"dataset_generated_at,omitempty"`
-	CoverageComplete   bool   `json:"coverage_complete,omitempty"`
-	PublishedAt        string `json:"published_at,omitempty"`
-	CutoverAt          string `json:"cutover_at,omitempty"`
+	ID                 string   `json:"id"`
+	SourceSHA256       string   `json:"source_sha256,omitempty"`
+	SchemaName         string   `json:"schema_name,omitempty"`
+	SchemaVersion      int      `json:"schema_version,omitempty"`
+	SchemaHash         string   `json:"schema_hash,omitempty"`
+	Capabilities       []string `json:"capabilities,omitempty"`
+	SourceSyncAt       string   `json:"source_sync_at,omitempty"`
+	DatasetGeneratedAt string   `json:"dataset_generated_at,omitempty"`
+	CoverageComplete   bool     `json:"coverage_complete,omitempty"`
+	PublishedAt        string   `json:"published_at,omitempty"`
+	CutoverAt          string   `json:"cutover_at,omitempty"`
 }
 
 type ArchivePublish struct {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -132,9 +133,12 @@ func TestClientArchiveOperations(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/archives":
 			_ = json.NewEncoder(w).Encode(map[string]any{"archives": []Archive{{
-				ID:       "arch-1",
-				App:      "gitcrawl",
-				Snapshot: &ArchiveSnapshot{ID: strings.Repeat("b", 64)},
+				ID:  "arch-1",
+				App: "gitcrawl",
+				Snapshot: &ArchiveSnapshot{
+					ID:           strings.Repeat("b", 64),
+					Capabilities: []string{"gitcrawl.observation-order.v1"},
+				},
 			}}})
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/status"):
 			_ = json.NewEncoder(w).Encode(Status{
@@ -153,8 +157,11 @@ func TestClientArchiveOperations(t *testing.T) {
 					RowCount: 10,
 					Complete: true,
 				}},
-				Snapshot: &ArchiveSnapshot{ID: strings.Repeat("b", 64)},
-				Publish:  &ArchivePublish{Status: "complete"},
+				Snapshot: &ArchiveSnapshot{
+					ID:           strings.Repeat("b", 64),
+					Capabilities: []string{"gitcrawl.observation-order.v1"},
+				},
+				Publish: &ArchivePublish{Status: "complete"},
 			})
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/batch-read"):
 			var body struct {
@@ -238,7 +245,8 @@ func TestClientArchiveOperations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("archives: %v", err)
 	}
-	if len(archives) != 1 || archives[0].ID != "arch-1" || archives[0].Snapshot == nil {
+	if len(archives) != 1 || archives[0].ID != "arch-1" || archives[0].Snapshot == nil ||
+		!slices.Contains(archives[0].Snapshot.Capabilities, "gitcrawl.observation-order.v1") {
 		t.Fatalf("archives = %#v", archives)
 	}
 	status, err := client.Status(context.Background(), "gitcrawl", "gitcrawl/openclaw")
@@ -246,7 +254,8 @@ func TestClientArchiveOperations(t *testing.T) {
 		t.Fatalf("status: %v", err)
 	}
 	if status.Mode != ModeCloud || status.Snapshot == nil || status.Publish == nil ||
-		status.ActiveSnapshotID == "" || !status.CoverageComplete || len(status.Datasets) != 1 {
+		status.ActiveSnapshotID == "" || !status.CoverageComplete || len(status.Datasets) != 1 ||
+		!slices.Contains(status.Snapshot.Capabilities, "gitcrawl.observation-order.v1") {
 		t.Fatalf("status = %#v", status)
 	}
 	results, err := client.BatchRead(context.Background(), "gitcrawl", "gitcrawl/openclaw", []QueryRequest{{Name: "threads"}})

--- a/scripts/test-crawlctl-release.sh
+++ b/scripts/test-crawlctl-release.sh
@@ -433,7 +433,7 @@ if CRAWLCTL_EXPECTED_COMMIT="$MOCK_COMMIT" CODESIGN_IDENTITY="$EXPECTED_AUTHORIT
 fi
 [[ ! -e "$WORK_DIR/missing-ticket" ]] || fail "missing ticket mutated the artifact destination"
 
-for version in v0.13.4 v0.13.5; do
+for version in v0.13.4 v0.14.0; do
   GH_TOKEN=caller-token GITHUB_TOKEN=caller-token \
     bash "$ROOT/scripts/package-crawlctl-release.sh" "$version" "$WORK_DIR/$version" >/dev/null
   for arch in arm64 x86_64; do
@@ -452,7 +452,7 @@ awk '
 grep -F 'candidate' "$MOCK_RELEASE_EVENT_LOG" >/dev/null || fail "candidate probe was not instrumented"
 
 if MOCK_BUILDINFO_REVISION="$MOCK_SIDE_COMMIT" \
-  bash "$ROOT/scripts/package-crawlctl-release.sh" v0.13.5 "$WORK_DIR/wrong-build-revision" \
+  bash "$ROOT/scripts/package-crawlctl-release.sh" v0.14.0 "$WORK_DIR/wrong-build-revision" \
     >/dev/null 2>&1; then
   fail "package accepted a binary built from the wrong revision"
 fi
@@ -460,7 +460,7 @@ fi
   fail "wrong build revision mutated the artifact destination"
 
 if MOCK_BUILDINFO_MODIFIED=true \
-  bash "$ROOT/scripts/package-crawlctl-release.sh" v0.13.5 "$WORK_DIR/modified-build" \
+  bash "$ROOT/scripts/package-crawlctl-release.sh" v0.14.0 "$WORK_DIR/modified-build" \
     >/dev/null 2>&1; then
   fail "package accepted a binary with vcs.modified=true"
 fi
@@ -468,7 +468,7 @@ fi
   fail "modified build mutated the artifact destination"
 
 if MOCK_BUILDINFO_PATH=github.com/openclaw/crawlkit/cmd/other \
-  bash "$ROOT/scripts/package-crawlctl-release.sh" v0.13.5 "$WORK_DIR/wrong-package-path" \
+  bash "$ROOT/scripts/package-crawlctl-release.sh" v0.14.0 "$WORK_DIR/wrong-package-path" \
     >/dev/null 2>&1; then
   fail "package accepted another main package built from the release commit"
 fi
@@ -478,12 +478,12 @@ fi
 promotion_failure="$(cd "$WORK_DIR" && pwd)/promotion-failure"
 promotion_counter="$WORK_DIR/promotion-counter"
 if MOCK_FAIL_PROMOTION_DIR="$promotion_failure" MOCK_PROMOTION_COUNTER="$promotion_counter" \
-  bash "$ROOT/scripts/package-crawlctl-release.sh" v0.13.5 "$promotion_failure" \
+  bash "$ROOT/scripts/package-crawlctl-release.sh" v0.14.0 "$promotion_failure" \
     >/dev/null 2>&1; then
   fail "injected failure after the first artifact promotion was accepted"
 fi
 [[ ! -e "$promotion_failure" ]] || fail "failed promotion left partial official artifacts"
-bash "$ROOT/scripts/package-crawlctl-release.sh" v0.13.5 "$promotion_failure" >/dev/null
+bash "$ROOT/scripts/package-crawlctl-release.sh" v0.14.0 "$promotion_failure" >/dev/null
 [[ "$(find "$promotion_failure" -maxdepth 1 -type f | wc -l | tr -d ' ')" == 4 ]] ||
   fail "release packaging was not rerunnable after promotion rollback"
 
@@ -568,7 +568,7 @@ if MOCK_BUILDINFO_PATH=github.com/openclaw/crawlkit/cmd/other \
   fail "verifier accepted another main package built from the release commit"
 fi
 INSTALL_DIR="$WORK_DIR/install"
-for version in v0.13.4 v0.13.5; do
+for version in v0.13.4 v0.14.0; do
   GH_TOKEN=caller-token GITHUB_TOKEN=caller-token MOCK_ASSET_DIR="$WORK_DIR/$version" \
     CRAWLCTL_DOWNLOAD_BASE_URL=https://example.invalid/releases/download/"$version" \
     bash "$ROOT/scripts/install-crawlctl.sh" "$version" "$INSTALL_DIR" >/dev/null
@@ -581,35 +581,35 @@ second_hash=$(shasum -a 256 "$INSTALL_DIR/crawlctl" | awk '{print $1}')
 [[ "$first_hash" != "$second_hash" ]] || fail "update did not replace the executable"
 
 installed_hash=$second_hash
-if MOCK_NOTARY_TICKET=missing MOCK_ASSET_DIR="$WORK_DIR/v0.13.5" \
-  CRAWLCTL_DOWNLOAD_BASE_URL=https://example.invalid/releases/download/v0.13.5 \
-  bash "$ROOT/scripts/install-crawlctl.sh" v0.13.5 "$INSTALL_DIR" >/dev/null 2>&1; then
+if MOCK_NOTARY_TICKET=missing MOCK_ASSET_DIR="$WORK_DIR/v0.14.0" \
+  CRAWLCTL_DOWNLOAD_BASE_URL=https://example.invalid/releases/download/v0.14.0 \
+  bash "$ROOT/scripts/install-crawlctl.sh" v0.14.0 "$INSTALL_DIR" >/dev/null 2>&1; then
   fail "installer accepted a missing notarization ticket"
 fi
 [[ "$(shasum -a 256 "$INSTALL_DIR/crawlctl" | awk '{print $1}')" == "$installed_hash" ]] ||
   fail "missing-ticket install changed the destination"
 
 if MOCK_DESIGNATED_REQUIREMENT="$WRONG_REQUIREMENT" \
-  MOCK_ASSET_DIR="$WORK_DIR/v0.13.5" \
-  CRAWLCTL_DOWNLOAD_BASE_URL=https://example.invalid/releases/download/v0.13.5 \
-  bash "$ROOT/scripts/install-crawlctl.sh" v0.13.5 "$INSTALL_DIR" >/dev/null 2>&1; then
+  MOCK_ASSET_DIR="$WORK_DIR/v0.14.0" \
+  CRAWLCTL_DOWNLOAD_BASE_URL=https://example.invalid/releases/download/v0.14.0 \
+  bash "$ROOT/scripts/install-crawlctl.sh" v0.14.0 "$INSTALL_DIR" >/dev/null 2>&1; then
   fail "installer accepted a mismatched embedded designated requirement"
 fi
 [[ "$(shasum -a 256 "$INSTALL_DIR/crawlctl" | awk '{print $1}')" == "$installed_hash" ]] ||
   fail "wrong-designated-requirement install changed the destination"
 
-if MOCK_LIPO_ARCHS='arm64 x86_64' MOCK_ASSET_DIR="$WORK_DIR/v0.13.5" \
-  CRAWLCTL_DOWNLOAD_BASE_URL=https://example.invalid/releases/download/v0.13.5 \
-  bash "$ROOT/scripts/install-crawlctl.sh" v0.13.5 "$INSTALL_DIR" >/dev/null 2>&1; then
+if MOCK_LIPO_ARCHS='arm64 x86_64' MOCK_ASSET_DIR="$WORK_DIR/v0.14.0" \
+  CRAWLCTL_DOWNLOAD_BASE_URL=https://example.invalid/releases/download/v0.14.0 \
+  bash "$ROOT/scripts/install-crawlctl.sh" v0.14.0 "$INSTALL_DIR" >/dev/null 2>&1; then
   fail "installer accepted a universal binary in an architecture-specific asset"
 fi
 [[ "$(shasum -a 256 "$INSTALL_DIR/crawlctl" | awk '{print $1}')" == "$installed_hash" ]] ||
   fail "universal-binary install changed the destination"
 
 if MOCK_CODESIGN_AUTHORITY='Developer ID Application: Peter Steinberger (Y5PE65HELJ)' \
-  MOCK_ASSET_DIR="$WORK_DIR/v0.13.5" \
-  CRAWLCTL_DOWNLOAD_BASE_URL=https://example.invalid/releases/download/v0.13.5 \
-  bash "$ROOT/scripts/install-crawlctl.sh" v0.13.5 "$INSTALL_DIR" >/dev/null 2>&1; then
+  MOCK_ASSET_DIR="$WORK_DIR/v0.14.0" \
+  CRAWLCTL_DOWNLOAD_BASE_URL=https://example.invalid/releases/download/v0.14.0 \
+  bash "$ROOT/scripts/install-crawlctl.sh" v0.14.0 "$INSTALL_DIR" >/dev/null 2>&1; then
   fail "installer accepted the wrong signing identity"
 fi
 [[ "$(shasum -a 256 "$INSTALL_DIR/crawlctl" | awk '{print $1}')" == "$installed_hash" ]] ||
@@ -620,19 +620,19 @@ BAD_STAGE="$WORK_DIR/bad-stage"
 mkdir -p "$BAD_ASSETS" "$BAD_STAGE"
 cp "$INSTALL_DIR/crawlctl" "$BAD_STAGE/crawlctl"
 echo unexpected > "$BAD_STAGE/unexpected"
-bad_asset=crawlctl-v0.13.6-macos-arm64.tar.gz
+bad_asset=crawlctl-v0.14.1-macos-arm64.tar.gz
 tar -czf "$BAD_ASSETS/$bad_asset" -C "$BAD_STAGE" crawlctl unexpected
 (
   cd "$BAD_ASSETS"
   shasum -a 256 "$bad_asset" > "$bad_asset.sha256"
 )
 if MOCK_ASSET_DIR="$BAD_ASSETS" \
-  CRAWLCTL_DOWNLOAD_BASE_URL=https://example.invalid/releases/download/v0.13.6 \
-  bash "$ROOT/scripts/install-crawlctl.sh" v0.13.6 "$INSTALL_DIR" >/dev/null 2>&1; then
+  CRAWLCTL_DOWNLOAD_BASE_URL=https://example.invalid/releases/download/v0.14.1 \
+  bash "$ROOT/scripts/install-crawlctl.sh" v0.14.1 "$INSTALL_DIR" >/dev/null 2>&1; then
   fail "archive with extra entries was accepted"
 fi
-[[ "$("$INSTALL_DIR/crawlctl" --version)" == 0.13.5 ]] || fail "failed update changed the installed executable"
-if bash "$ROOT/scripts/verify-crawlctl-release.sh" v0.13.6 "$MOCK_COMMIT" \
+[[ "$("$INSTALL_DIR/crawlctl" --version)" == 0.14.0 ]] || fail "failed update changed the installed executable"
+if bash "$ROOT/scripts/verify-crawlctl-release.sh" v0.14.1 "$MOCK_COMMIT" \
   "$BAD_ASSETS/$bad_asset" >/dev/null 2>&1; then
   fail "verifier accepted an archive with extra entries"
 fi


### PR DESCRIPTION
## Summary

- expose immutable snapshot capabilities separately from currently served archive capabilities
- classify the accumulated public snapshot publishing infrastructure as the v0.14.0 minor release
- update release examples and release-script fixtures for the next signed module tag consumed by Gitcrawl

## Validation

- `GOWORK=off go mod tidy`
- `git diff --exit-code -- go.mod go.sum`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test -count=1 ./...`
- `bash scripts/test-crawlctl-release.sh`