### PR TITLE
feat(remote): expose publisher status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add a publisher-authenticated archive status route and client helper so
+  interrupted snapshot publication can resume without reader credentials.
+
 ## v0.14.0 - 2026-07-12
 
 - Require notarized, single-architecture `crawlctl` release binaries bound to the repository-pinned signed tag and protected remote `main` commit, restore signing-keychain state before credential-free candidate probes, roll back partial artifact promotion, and keep naturally quarantined Gatekeeper execution plus Full Disk Access continuity as separate clean-VM gates because raw binaries and ZIP submission carriers cannot carry stapled tickets and raw-CLI `spctl` assessment is not an app-launch verdict.

--- a/docs/cloudflare-remote-archives.md
+++ b/docs/cloudflare-remote-archives.md
@@ -429,6 +429,7 @@ GET  /v1/whoami
 
 GET  /v1/archives
 GET  /v1/apps/:app/archives/:archive/status
+GET  /v1/apps/:app/archives/:archive/publish-status
 POST /v1/apps/:app/archives/:archive/query
 POST /v1/apps/:app/archives/:archive/batch-read
 POST /v1/apps/:app/archives/:archive/ingest

--- a/docs/cloudflare-remote-archives.md
+++ b/docs/cloudflare-remote-archives.md
@@ -37,6 +37,8 @@ Worker APIs and receive rows/pages, not `.db`, WAL, SHM, or Git snapshot files.
   browser-login plus bearer-session pattern.
 - Let publishers update remote archives without forcing readers to have
   GitHub, Discord, Cloudflare, or bot credentials.
+- Let publisher-only credentials inspect the minimal publication state needed
+  to resume an interrupted snapshot without granting reader access.
 - Preserve `discrawl` privacy boundaries: local wiretap DMs and `@me` data stay
   out of shared remote archives by default.
 - Leave room for later Worker-native sync, R2-backed content-addressed shards,

--- a/remote/contract.go
+++ b/remote/contract.go
@@ -72,6 +72,7 @@ func BaseContract() Contract {
 			{Method: http.MethodGet, Path: "/v1/whoami", Auth: AuthReader},
 			{Method: http.MethodGet, Path: "/v1/archives", Auth: AuthReader},
 			{Method: http.MethodGet, Path: "/v1/apps/:app/archives/:archive/status", Auth: AuthReader},
+			{Method: http.MethodGet, Path: "/v1/apps/:app/archives/:archive/publish-status", Auth: AuthPublisher},
 			{Method: http.MethodPost, Path: "/v1/apps/:app/archives/:archive/query", Auth: AuthReader},
 			{Method: http.MethodPost, Path: "/v1/apps/:app/archives/:archive/batch-read", Auth: AuthReader},
 			{Method: http.MethodPost, Path: "/v1/apps/:app/archives/:archive/ingest", Auth: AuthPublisher},

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -245,6 +245,14 @@ type Status struct {
 	Warnings           []string          `json:"warnings,omitempty"`
 }
 
+type PublisherStatus struct {
+	App              string           `json:"app"`
+	Archive          string           `json:"archive"`
+	ActiveSnapshotID string           `json:"active_snapshot_id,omitempty"`
+	CoverageComplete bool             `json:"coverage_complete,omitempty"`
+	Snapshot         *ArchiveSnapshot `json:"snapshot,omitempty"`
+}
+
 type DatasetCoverage struct {
 	Dataset            string `json:"dataset"`
 	RowCount           int64  `json:"row_count,omitempty"`
@@ -436,8 +444,8 @@ func (c *Client) Status(ctx context.Context, app, archive string) (Status, error
 	return out, err
 }
 
-func (c *Client) PublishStatus(ctx context.Context, app, archive string) (Status, error) {
-	var out Status
+func (c *Client) PublishStatus(ctx context.Context, app, archive string) (PublisherStatus, error) {
+	var out PublisherStatus
 	err := c.do(ctx, http.MethodGet, archivePath(app, archive, "publish-status"), nil, &out, true)
 	return out, err
 }

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -436,6 +436,12 @@ func (c *Client) Status(ctx context.Context, app, archive string) (Status, error
 	return out, err
 }
 
+func (c *Client) PublishStatus(ctx context.Context, app, archive string) (Status, error) {
+	var out Status
+	err := c.do(ctx, http.MethodGet, archivePath(app, archive, "publish-status"), nil, &out, true)
+	return out, err
+}
+
 func (c *Client) Query(ctx context.Context, app, archive string, req QueryRequest) (QueryResult, error) {
 	req.App = strings.TrimSpace(app)
 	req.Archive = strings.TrimSpace(archive)

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -140,8 +140,18 @@ func TestClientArchiveOperations(t *testing.T) {
 					Capabilities: []string{"gitcrawl.observation-order.v1"},
 				},
 			}}})
-		case r.Method == http.MethodGet && (strings.HasSuffix(r.URL.Path, "/status") ||
-			strings.HasSuffix(r.URL.Path, "/publish-status")):
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/publish-status"):
+			_ = json.NewEncoder(w).Encode(PublisherStatus{
+				App:              "gitcrawl",
+				Archive:          "gitcrawl/openclaw",
+				ActiveSnapshotID: strings.Repeat("b", 64),
+				CoverageComplete: true,
+				Snapshot: &ArchiveSnapshot{
+					ID:           strings.Repeat("b", 64),
+					Capabilities: []string{"gitcrawl.observation-order.v1"},
+				},
+			})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/status"):
 			_ = json.NewEncoder(w).Encode(Status{
 				App:                "gitcrawl",
 				Archive:            "gitcrawl/openclaw",
@@ -149,7 +159,7 @@ func TestClientArchiveOperations(t *testing.T) {
 				SchemaVersion:      8,
 				SnapshotMode:       "snapshot",
 				SnapshotCutoverAt:  "2026-07-12T08:00:00Z",
-				ActiveSnapshotID:   strings.Repeat("b", 64),
+				ActiveSnapshotID:   strings.Repeat("a", 64),
 				SourceSyncAt:       "2026-07-12T07:55:00Z",
 				DatasetGeneratedAt: "2026-07-12T07:56:00Z",
 				CoverageComplete:   true,
@@ -159,7 +169,7 @@ func TestClientArchiveOperations(t *testing.T) {
 					Complete: true,
 				}},
 				Snapshot: &ArchiveSnapshot{
-					ID:           strings.Repeat("b", 64),
+					ID:           strings.Repeat("a", 64),
 					Capabilities: []string{"gitcrawl.observation-order.v1"},
 				},
 				Publish: &ArchivePublish{Status: "complete"},
@@ -263,10 +273,11 @@ func TestClientArchiveOperations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("publish status: %v", err)
 	}
-	if publishStatus.ActiveSnapshotID != status.ActiveSnapshotID ||
+	if publishStatus.ActiveSnapshotID == status.ActiveSnapshotID ||
 		publishStatus.Snapshot == nil ||
-		publishStatus.Snapshot.ID != status.Snapshot.ID {
-		t.Fatalf("publish status = %#v, want snapshot %#v", publishStatus, status.Snapshot)
+		publishStatus.Snapshot.ID != strings.Repeat("b", 64) ||
+		publishStatus.CoverageComplete != true {
+		t.Fatalf("publish status = %#v, reader status = %#v", publishStatus, status)
 	}
 	results, err := client.BatchRead(context.Background(), "gitcrawl", "gitcrawl/openclaw", []QueryRequest{{Name: "threads"}})
 	if err != nil {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -140,7 +140,8 @@ func TestClientArchiveOperations(t *testing.T) {
 					Capabilities: []string{"gitcrawl.observation-order.v1"},
 				},
 			}}})
-		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/status"):
+		case r.Method == http.MethodGet && (strings.HasSuffix(r.URL.Path, "/status") ||
+			strings.HasSuffix(r.URL.Path, "/publish-status")):
 			_ = json.NewEncoder(w).Encode(Status{
 				App:                "gitcrawl",
 				Archive:            "gitcrawl/openclaw",
@@ -258,6 +259,15 @@ func TestClientArchiveOperations(t *testing.T) {
 		!slices.Contains(status.Snapshot.Capabilities, "gitcrawl.observation-order.v1") {
 		t.Fatalf("status = %#v", status)
 	}
+	publishStatus, err := client.PublishStatus(context.Background(), "gitcrawl", "gitcrawl/openclaw")
+	if err != nil {
+		t.Fatalf("publish status: %v", err)
+	}
+	if publishStatus.ActiveSnapshotID != status.ActiveSnapshotID ||
+		publishStatus.Snapshot == nil ||
+		publishStatus.Snapshot.ID != status.Snapshot.ID {
+		t.Fatalf("publish status = %#v, want snapshot %#v", publishStatus, status.Snapshot)
+	}
 	results, err := client.BatchRead(context.Background(), "gitcrawl", "gitcrawl/openclaw", []QueryRequest{{Name: "threads"}})
 	if err != nil {
 		t.Fatalf("batch read: %v", err)
@@ -318,8 +328,14 @@ func TestClientArchiveOperations(t *testing.T) {
 	if poll.Status != "complete" || poll.Token != "session-token" {
 		t.Fatalf("poll = %#v", poll)
 	}
-	if len(requests) != 8 {
+	if len(requests) != 9 {
 		t.Fatalf("requests = %#v", requests)
+	}
+	if !slices.Contains(
+		requests,
+		"GET /v1/apps/gitcrawl/archives/gitcrawl%2Fopenclaw/publish-status",
+	) {
+		t.Fatalf("publisher status request missing: %#v", requests)
 	}
 }
 
@@ -922,6 +938,9 @@ func TestBaseContractValidates(t *testing.T) {
 	}
 	if !hasRoute(contract, http.MethodPost, "/v1/apps/:app/archives/:archive/cutover", AuthPublisher) {
 		t.Fatalf("contract cutover route missing")
+	}
+	if !hasRoute(contract, http.MethodGet, "/v1/apps/:app/archives/:archive/publish-status", AuthPublisher) {
+		t.Fatalf("contract publisher status route missing")
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a publisher-authenticated archive publication status route to the provider-neutral contract
- expose `Client.PublishStatus` without changing the reader-authenticated `Status` API
- document publisher-only interrupted snapshot resume and add exact route coverage

## Validation

- `GOWORK=off go mod tidy`
- `git diff --exit-code -- go.mod go.sum`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test -count=1 ./...`

## Follow-up

- crawl-remote will implement the advertised route
- gitcrawl will consume the released patch tag for staged snapshot resume

## Local Worker Conformance

Against crawl-remote exact head `c7a75f3cc58427e063c1c52e9f16afcb750d425d` with isolated local Wrangler D1/R2 state and migrations `0001` through `0007`:

- publisher-only `GET .../publish-status`: HTTP 200
- response keys: `active_snapshot_id`, `app`, `archive`, `coverage_complete`
- reader-only `GET .../publish-status`: HTTP 403 `forbidden`
- reader-only `GET .../status`: HTTP 200 with reader counts preserved
- no production endpoint, credential, or deployment was used