### PR TITLE
fix(remote): bound default SQLite bundle chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Add a 64 MiB mutable SQLite bundle default and preserve exact request content
   lengths for bounded remote uploads. The shipped
   `DefaultSQLiteBundleChunkSize` constant and immutable snapshot default remain
-  256 MiB for caller and retry compatibility.
+  256 MiB for caller and retry compatibility. Bundle uploads now reject part,
+  count, and total-size violations before writing any remote parts.
 
 ## v0.14.0 - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Add a 64 MiB mutable SQLite bundle default and preserve exact request content
   lengths for bounded remote uploads. The shipped
   `DefaultSQLiteBundleChunkSize` constant and immutable snapshot default remain
-  256 MiB for caller and retry compatibility. Bundle construction now caps
+  256 MiB for caller and retry compatibility, including explicitly configured
+  legacy mutable bundles. Bundle construction now rejects empty sources, caps
   compressed output at 512 MiB and eight parts, removes partial temp artifacts
   on failure, and uploads reject invalid or oversized 64 KiB manifests before
   writing any remote parts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Add a snapshot-scoped publisher status client helper so resumable publishers
   verify the exact immutable candidate instead of trusting an unrelated
   completed candidate from the unscoped status route, and reject successful
-  responses that omit or return a different snapshot.
+  responses that omit the snapshot or return a different snapshot, app, or
+  archive.
 - Add a 64 MiB mutable SQLite bundle default and preserve exact request content
   lengths for bounded remote uploads. The shipped
   `DefaultSQLiteBundleChunkSize` constant and immutable snapshot default remain
@@ -19,10 +20,15 @@
   sources, removes partial temp artifacts on failure, and rejects source
   identity/content drift. Immutable uploads use private validated part
   snapshots and verify compressed and decompressed digests before any remote
-  write. Mutable uploads retain bounded sequential file handling, verify exact
-  streamed bytes, and avoid duplicate temporary staging. Snapshot manifests are
-  capped at 64 KiB while legacy mutable manifests retain the service-compatible
-  1 MiB ceiling.
+  write. Every file-backed read is capped at its declared size plus one byte so
+  concurrent same-inode growth is detected without consuming an unbounded tail.
+  Mutable uploads retain bounded sequential file handling, `Size: -1`
+  unknown-length transport, minimal legacy manifests, index-keyed part
+  matching, and no duplicate temporary staging; tiny chunk sizes also avoid
+  caller-sized part-slice preallocation. Manifests use crawl-remote's
+  deterministic two-space persisted JSON representation and are size-preflighted
+  before full encoding: snapshots are capped at 64 KiB while legacy mutable
+  manifests retain the service-compatible 1 MiB ceiling.
 
 ## v0.14.0 - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@
   256 MiB for caller and retry compatibility, including explicitly configured
   legacy mutable bundles. Bundle construction now rejects empty sources, caps
   compressed output at 512 MiB and eight parts, removes partial temp artifacts
-  on failure, and uploads reject invalid or oversized 64 KiB manifests before
-  writing any remote parts.
+  on failure, rejects source identity/content drift, and uploads hash and retain
+  validated part handles while rejecting invalid or oversized 64 KiB manifests
+  before writing any remote parts.
 
 ## v0.14.0 - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,19 @@
   interrupted snapshot publication can resume without reader credentials.
 - Add a snapshot-scoped publisher status client helper so resumable publishers
   verify the exact immutable candidate instead of trusting an unrelated
-  completed candidate from the unscoped status route.
+  completed candidate from the unscoped status route, and reject successful
+  responses that omit or return a different snapshot.
 - Add a 64 MiB mutable SQLite bundle default and preserve exact request content
   lengths for bounded remote uploads. The shipped
   `DefaultSQLiteBundleChunkSize` constant and immutable snapshot default remain
   256 MiB for caller and retry compatibility, including explicitly configured
-  legacy mutable bundles. Bundle construction now rejects empty sources, caps
-  compressed output at 512 MiB and eight parts, removes partial temp artifacts
-  on failure, rejects source identity/content drift, and uploads hash and retain
-  validated part handles while rejecting invalid or oversized 64 KiB manifests
+  legacy mutable bundles. Mutable bundles retain their legacy part-count and
+  aggregate-size compatibility, while immutable snapshots enforce the
+  negotiated 512 MiB and eight-part bounds. Bundle construction now rejects
+  empty sources, removes partial temp artifacts on failure, and rejects source
+  identity/content drift. Uploads use private validated part snapshots and
+  verify immutable snapshot compressed and decompressed digests before any
+  remote write, while invalid or oversized 64 KiB manifests are also rejected
   before writing any remote parts.
 
 ## v0.14.0 - 2026-07-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add a publisher-authenticated archive status route and client helper so
   interrupted snapshot publication can resume without reader credentials.
+- Reduce the default SQLite bundle part size from 256 MiB to 64 MiB and preserve
+  exact request content lengths for bounded remote uploads.
 
 ## v0.14.0 - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,12 @@
   snapshots and verify compressed and decompressed digests before any remote
   write. Every file-backed read is capped at its declared size plus one byte so
   concurrent same-inode growth is detected without consuming an unbounded tail.
-  Mutable uploads retain bounded sequential file handling, `Size: -1`
-  unknown-length transport, minimal legacy manifests, index-keyed part
-  matching, and no duplicate temporary staging; tiny chunk sizes also avoid
-  caller-sized part-slice preallocation. Manifests use crawl-remote's
+  Mutable uploads retain bounded sequential file handling: `Size: -1` uses the
+  statted file size for local verification while preserving unknown-length
+  transport, and part digests remain optional but are verified when supplied.
+  Minimal legacy manifests, index-keyed part matching, and no duplicate
+  temporary staging are also preserved; tiny chunk sizes avoid caller-sized
+  part-slice preallocation. Manifests use crawl-remote's
   deterministic two-space persisted JSON representation and are size-preflighted
   before full encoding: snapshots are capped at 64 KiB while legacy mutable
   manifests retain the service-compatible 1 MiB ceiling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
 - Add a 64 MiB mutable SQLite bundle default and preserve exact request content
   lengths for bounded remote uploads. The shipped
   `DefaultSQLiteBundleChunkSize` constant and immutable snapshot default remain
-  256 MiB for caller and retry compatibility. Bundle uploads now reject part,
-  count, and total-size violations before writing any remote parts.
+  256 MiB for caller and retry compatibility. Bundle construction now caps
+  compressed output at 512 MiB and eight parts, removes partial temp artifacts
+  on failure, and uploads reject invalid or oversized 64 KiB manifests before
+  writing any remote parts.
 
 ## v0.14.0 - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Add a publisher-authenticated archive status route and client helper so
   interrupted snapshot publication can resume without reader credentials.
+- Add a snapshot-scoped publisher status client helper so resumable publishers
+  verify the exact immutable candidate instead of trusting an unrelated
+  completed candidate from the unscoped status route.
 - Add a 64 MiB mutable SQLite bundle default and preserve exact request content
   lengths for bounded remote uploads. The shipped
   `DefaultSQLiteBundleChunkSize` constant and immutable snapshot default remain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 - Add a publisher-authenticated archive status route and client helper so
   interrupted snapshot publication can resume without reader credentials.
-- Reduce the default SQLite bundle part size from 256 MiB to 64 MiB and preserve
-  exact request content lengths for bounded remote uploads.
+- Reduce the default mutable SQLite bundle part size from 256 MiB to 64 MiB and
+  preserve exact request content lengths for bounded remote uploads. Immutable
+  snapshot builds retain their released implicit 256 MiB representation for
+  retry compatibility and must opt into a smaller explicit chunk size.
 
 ## v0.14.0 - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,16 @@
   `DefaultSQLiteBundleChunkSize` constant and immutable snapshot default remain
   256 MiB for caller and retry compatibility, including explicitly configured
   legacy mutable bundles. Mutable bundles retain their legacy part-count and
-  aggregate-size compatibility, while immutable snapshots enforce the
-  negotiated 512 MiB and eight-part bounds. Bundle construction now rejects
-  empty sources, removes partial temp artifacts on failure, and rejects source
-  identity/content drift. Uploads use private validated part snapshots and
-  verify immutable snapshot compressed and decompressed digests before any
-  remote write, while invalid or oversized 64 KiB manifests are also rejected
-  before writing any remote parts.
+  aggregate-size, chunk-size, and object-size compatibility, while immutable
+  snapshots enforce the negotiated 256 MiB part, 4 GiB object, 512 MiB
+  compressed, and eight-part bounds. Bundle construction now rejects empty
+  sources, removes partial temp artifacts on failure, and rejects source
+  identity/content drift. Immutable uploads use private validated part
+  snapshots and verify compressed and decompressed digests before any remote
+  write. Mutable uploads retain bounded sequential file handling, verify exact
+  streamed bytes, and avoid duplicate temporary staging. Snapshot manifests are
+  capped at 64 KiB while legacy mutable manifests retain the service-compatible
+  1 MiB ceiling.
 
 ## v0.14.0 - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 - Add a publisher-authenticated archive status route and client helper so
   interrupted snapshot publication can resume without reader credentials.
-- Reduce the default mutable SQLite bundle part size from 256 MiB to 64 MiB and
-  preserve exact request content lengths for bounded remote uploads. Immutable
-  snapshot builds retain their released implicit 256 MiB representation for
-  retry compatibility and must opt into a smaller explicit chunk size.
+- Add a 64 MiB mutable SQLite bundle default and preserve exact request content
+  lengths for bounded remote uploads. The shipped
+  `DefaultSQLiteBundleChunkSize` constant and immutable snapshot default remain
+  256 MiB for caller and retry compatibility.
 
 ## v0.14.0 - 2026-07-12
 

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -476,6 +476,13 @@ func (c *Client) publishStatus(ctx context.Context, app, archive, snapshotID str
 		return out, err
 	}
 	err = c.doRequest(ctx, req, false, &out, true)
+	if err == nil && snapshotID != "" && out.Snapshot != nil && out.Snapshot.ID != snapshotID {
+		return PublisherStatus{}, fmt.Errorf(
+			"publish status returned snapshot %q, want %q",
+			out.Snapshot.ID,
+			snapshotID,
+		)
+	}
 	return out, err
 }
 
@@ -561,23 +568,20 @@ func (c *Client) UploadSQLiteBundleFiles(ctx context.Context, app, archive strin
 	if err != nil {
 		return SQLiteBundleUploadResult{}, err
 	}
-	if err := validateSQLiteBundleFiles(preparedManifest, parts); err != nil {
+	validatedParts, err := openValidatedSQLiteBundleFiles(ctx, preparedManifest, parts)
+	if err != nil {
 		return SQLiteBundleUploadResult{}, err
 	}
-	for _, part := range parts {
-		file, err := os.Open(part.Path)
-		if err != nil {
-			return SQLiteBundleUploadResult{}, fmt.Errorf("open sqlite bundle part %d: %w", part.Index, err)
-		}
+	defer closeValidatedSQLiteBundleFiles(validatedParts)
+	for _, part := range validatedParts {
 		_, uploadErr := c.UploadSQLiteBundlePart(ctx, app, archive, SQLiteBundlePartUpload{
-			Index:       part.Index,
-			Body:        file,
-			Size:        part.Size,
-			SHA256:      part.SHA256,
+			Index:       part.part.Index,
+			Body:        part.file,
+			Size:        part.part.Size,
+			SHA256:      part.part.SHA256,
 			Compression: SQLiteGzipCompression,
 			SnapshotID:  preparedManifest.SnapshotID,
 		})
-		_ = file.Close()
 		if uploadErr != nil {
 			return SQLiteBundleUploadResult{}, uploadErr
 		}
@@ -650,6 +654,9 @@ func validateSQLiteBundleManifest(manifest SQLiteBundleManifest, app, archive st
 	}
 	if manifest.ContentType != "" && manifest.ContentType != "application/vnd.sqlite3" {
 		return errors.New("sqlite bundle content type must be application/vnd.sqlite3 when set")
+	}
+	if snapshotScoped && manifest.GeneratedAt != "" {
+		return errors.New("snapshot sqlite bundle generated_at must be omitted")
 	}
 	if manifest.GeneratedAt != "" {
 		if err := validateSQLiteBundleMetadata(manifest.GeneratedAt, "sqlite bundle generated_at"); err != nil {
@@ -808,27 +815,75 @@ func validateSQLiteBundleManifestLimits(manifest SQLiteBundleManifest) error {
 	return nil
 }
 
-func validateSQLiteBundleFiles(manifest SQLiteBundleManifest, parts []SQLiteBundlePartFile) error {
+type validatedSQLiteBundlePartFile struct {
+	part SQLiteBundlePart
+	file *os.File
+}
+
+func openValidatedSQLiteBundleFiles(
+	ctx context.Context,
+	manifest SQLiteBundleManifest,
+	parts []SQLiteBundlePartFile,
+) (_ []validatedSQLiteBundlePartFile, err error) {
 	if err := validateSQLiteBundleManifest(manifest, manifest.App, manifest.Archive); err != nil {
-		return err
+		return nil, err
 	}
 	if len(parts) != len(manifest.Parts) {
-		return fmt.Errorf("sqlite bundle has %d part files, want %d", len(parts), len(manifest.Parts))
+		return nil, fmt.Errorf("sqlite bundle has %d part files, want %d", len(parts), len(manifest.Parts))
 	}
+	validated := make([]validatedSQLiteBundlePartFile, 0, len(parts))
+	defer func() {
+		if err != nil {
+			closeValidatedSQLiteBundleFiles(validated)
+		}
+	}()
 	for index, part := range parts {
 		expected := manifest.Parts[index]
 		if part.SQLiteBundlePart != expected {
-			return fmt.Errorf("sqlite bundle part file %d does not match the manifest", index)
+			return nil, fmt.Errorf("sqlite bundle part file %d does not match the manifest", index)
 		}
-		info, err := os.Stat(part.Path)
+		file, err := os.Open(part.Path)
 		if err != nil {
-			return fmt.Errorf("stat sqlite bundle part %d: %w", index, err)
+			return nil, fmt.Errorf("open sqlite bundle part %d: %w", index, err)
 		}
-		if !info.Mode().IsRegular() || info.Size() != part.Size {
-			return fmt.Errorf("sqlite bundle part file %d must be a %d-byte regular file", index, part.Size)
+		validated = append(validated, validatedSQLiteBundlePartFile{
+			part: expected,
+			file: file,
+		})
+		infoBefore, err := file.Stat()
+		if err != nil {
+			return nil, fmt.Errorf("stat sqlite bundle part %d: %w", index, err)
+		}
+		if !infoBefore.Mode().IsRegular() || infoBefore.Size() != part.Size {
+			return nil, fmt.Errorf("sqlite bundle part file %d must be a %d-byte regular file", index, part.Size)
+		}
+		hash := sha256.New()
+		size, err := copyWithContext(ctx, hash, file)
+		if err != nil {
+			return nil, fmt.Errorf("hash sqlite bundle part %d: %w", index, err)
+		}
+		infoAfter, err := file.Stat()
+		if err != nil {
+			return nil, fmt.Errorf("restat sqlite bundle part %d: %w", index, err)
+		}
+		if !os.SameFile(infoBefore, infoAfter) || infoAfter.Size() != part.Size || size != part.Size {
+			return nil, fmt.Errorf("sqlite bundle part file %d changed during validation", index)
+		}
+		actualSHA256 := fmt.Sprintf("%x", hash.Sum(nil))
+		if !strings.EqualFold(actualSHA256, part.SHA256) {
+			return nil, fmt.Errorf("sqlite bundle part file %d sha256 does not match the manifest", index)
+		}
+		if _, err := file.Seek(0, io.SeekStart); err != nil {
+			return nil, fmt.Errorf("rewind sqlite bundle part %d: %w", index, err)
 		}
 	}
-	return nil
+	return validated, nil
+}
+
+func closeValidatedSQLiteBundleFiles(parts []validatedSQLiteBundlePartFile) {
+	for _, part := range parts {
+		_ = part.file.Close()
+	}
 }
 
 func (c *Client) StartGitHubLogin(ctx context.Context, pollSecretHash string) (LoginStartResult, error) {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -6,16 +6,20 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -463,6 +467,8 @@ func (c *Client) PublishStatusForSnapshot(ctx context.Context, app, archive, sna
 }
 
 func (c *Client) publishStatus(ctx context.Context, app, archive, snapshotID string) (PublisherStatus, error) {
+	app = strings.TrimSpace(app)
+	archive = strings.TrimSpace(archive)
 	var out PublisherStatus
 	endpoint, err := url.Parse(c.url(archivePath(app, archive, "publish-status")))
 	if err != nil {
@@ -479,6 +485,15 @@ func (c *Client) publishStatus(ctx context.Context, app, archive, snapshotID str
 	}
 	err = c.doRequest(ctx, req, false, &out, true)
 	if err == nil && snapshotID != "" {
+		if out.App != app || out.Archive != archive {
+			return PublisherStatus{}, fmt.Errorf(
+				"publish status returned route %q/%q, want %q/%q",
+				out.App,
+				out.Archive,
+				app,
+				archive,
+			)
+		}
 		if out.Snapshot == nil {
 			return PublisherStatus{}, fmt.Errorf(
 				"publish status did not return requested snapshot %q",
@@ -558,8 +573,17 @@ func (c *Client) UploadSQLiteBundlePart(ctx context.Context, app, archive string
 	if part.SnapshotID != "" && !validSQLiteSnapshotID(part.SnapshotID) {
 		return SQLiteUploadResult{}, errors.New("sqlite bundle snapshot id must be empty or a lowercase sha256 digest")
 	}
-	if err := validateSQLiteBundlePartLimit(part.Index, part.Size, part.SnapshotID != ""); err != nil {
+	snapshotScoped := part.SnapshotID != ""
+	if err := validateSQLiteBundlePartLimit(part.Index, part.Size, snapshotScoped); err != nil {
 		return SQLiteUploadResult{}, err
+	}
+	body := part.Body
+	if snapshotScoped {
+		bounded, err := sqliteBundleDeclaredSizeReader(body, part.Size)
+		if err != nil {
+			return SQLiteUploadResult{}, err
+		}
+		body = bounded
 	}
 	headers := http.Header{}
 	headers.Set("content-type", "application/gzip")
@@ -569,7 +593,7 @@ func (c *Client) UploadSQLiteBundlePart(ctx context.Context, app, archive string
 	setHeader(headers, "x-crawl-compression", part.Compression)
 	setHeader(headers, "x-crawl-snapshot-id", part.SnapshotID)
 	var out SQLiteUploadResult
-	err := c.doRaw(ctx, http.MethodPut, archivePath(app, archive, "sqlite"), part.Body, part.Size, headers, &out, true)
+	err := c.doRaw(ctx, http.MethodPut, archivePath(app, archive, "sqlite"), body, part.Size, headers, &out, true)
 	return out, err
 }
 
@@ -579,10 +603,19 @@ func (c *Client) UploadSQLiteBundleFiles(ctx context.Context, app, archive strin
 		return SQLiteBundleUploadResult{}, err
 	}
 	if preparedManifest.SnapshotID == "" {
-		if err := validateMutableSQLiteBundleFiles(ctx, preparedManifest, parts); err != nil {
+		expectedParts, err := validateMutableSQLiteBundleFiles(ctx, preparedManifest, parts)
+		if err != nil {
 			return SQLiteBundleUploadResult{}, err
 		}
-		return c.uploadMutableSQLiteBundleFiles(ctx, app, archive, preparedManifest, manifestBody, parts)
+		return c.uploadMutableSQLiteBundleFiles(
+			ctx,
+			app,
+			archive,
+			preparedManifest,
+			manifestBody,
+			parts,
+			expectedParts,
+		)
 	}
 	validatedParts, err := openValidatedSnapshotSQLiteBundleFiles(ctx, preparedManifest, parts)
 	if err != nil {
@@ -602,7 +635,13 @@ func (c *Client) UploadSQLiteBundleFiles(ctx context.Context, app, archive strin
 			return SQLiteBundleUploadResult{}, uploadErr
 		}
 	}
-	return c.uploadSQLiteBundleManifest(ctx, app, archive, manifestBody)
+	return c.uploadSQLiteBundleManifest(
+		ctx,
+		app,
+		archive,
+		preparedManifest.SnapshotID,
+		manifestBody,
+	)
 }
 
 func (c *Client) uploadMutableSQLiteBundleFiles(
@@ -611,38 +650,68 @@ func (c *Client) uploadMutableSQLiteBundleFiles(
 	manifest SQLiteBundleManifest,
 	manifestBody []byte,
 	parts []SQLiteBundlePartFile,
+	expectedParts map[int]SQLiteBundlePart,
 ) (SQLiteBundleUploadResult, error) {
-	for index, part := range parts {
-		expected := manifest.Parts[index]
+	for _, part := range parts {
+		expected := expectedParts[part.Index]
 		file, err := os.Open(part.Path)
 		if err != nil {
-			return SQLiteBundleUploadResult{}, fmt.Errorf("open sqlite bundle part %d: %w", index, err)
+			return SQLiteBundleUploadResult{}, fmt.Errorf("open sqlite bundle part %d: %w", part.Index, err)
+		}
+		infoBefore, err := file.Stat()
+		if err != nil {
+			_ = file.Close()
+			return SQLiteBundleUploadResult{}, fmt.Errorf("stat sqlite bundle part %d: %w", part.Index, err)
+		}
+		bounded, err := sqliteBundleDeclaredSizeReader(file, expected.Size)
+		if err != nil {
+			_ = file.Close()
+			return SQLiteBundleUploadResult{}, err
 		}
 		hash := sha256.New()
 		var streamed byteCounter
+		body := io.TeeReader(bounded, io.MultiWriter(hash, &streamed))
 		_, uploadErr := c.UploadSQLiteBundlePart(ctx, app, archive, SQLiteBundlePartUpload{
 			Index:       expected.Index,
-			Body:        io.TeeReader(file, io.MultiWriter(hash, &streamed)),
+			Body:        body,
 			Size:        expected.Size,
 			SHA256:      expected.SHA256,
 			Compression: SQLiteGzipCompression,
 		})
+		var drainErr error
+		if uploadErr == nil {
+			_, drainErr = copyWithContext(ctx, io.Discard, body)
+		}
+		infoAfter, statErr := file.Stat()
 		closeErr := file.Close()
 		if uploadErr != nil {
 			return SQLiteBundleUploadResult{}, uploadErr
 		}
-		if closeErr != nil {
-			return SQLiteBundleUploadResult{}, fmt.Errorf("close sqlite bundle part %d: %w", index, closeErr)
+		if drainErr != nil {
+			return SQLiteBundleUploadResult{}, fmt.Errorf(
+				"verify sqlite bundle part %d upload: %w",
+				part.Index,
+				drainErr,
+			)
 		}
-		if int64(streamed) != expected.Size ||
+		if statErr != nil {
+			return SQLiteBundleUploadResult{}, fmt.Errorf("restat sqlite bundle part %d: %w", part.Index, statErr)
+		}
+		if closeErr != nil {
+			return SQLiteBundleUploadResult{}, fmt.Errorf("close sqlite bundle part %d: %w", part.Index, closeErr)
+		}
+		if !os.SameFile(infoBefore, infoAfter) ||
+			infoBefore.Size() != expected.Size ||
+			infoAfter.Size() != expected.Size ||
+			int64(streamed) != expected.Size ||
 			!strings.EqualFold(fmt.Sprintf("%x", hash.Sum(nil)), expected.SHA256) {
 			return SQLiteBundleUploadResult{}, fmt.Errorf(
 				"sqlite bundle part file %d changed during upload",
-				index,
+				part.Index,
 			)
 		}
 	}
-	return c.uploadSQLiteBundleManifest(ctx, app, archive, manifestBody)
+	return c.uploadSQLiteBundleManifest(ctx, app, archive, manifest.SnapshotID, manifestBody)
 }
 
 type byteCounter int64
@@ -657,13 +726,18 @@ func (c *Client) UploadSQLiteBundleManifest(ctx context.Context, app, archive st
 	if err != nil {
 		return SQLiteBundleUploadResult{}, err
 	}
-	return c.uploadSQLiteBundleManifest(ctx, app, archive, manifestBody)
+	return c.uploadSQLiteBundleManifest(ctx, app, archive, manifest.SnapshotID, manifestBody)
 }
 
-func (c *Client) uploadSQLiteBundleManifest(ctx context.Context, app, archive string, manifestBody []byte) (SQLiteBundleUploadResult, error) {
+func (c *Client) uploadSQLiteBundleManifest(
+	ctx context.Context,
+	app, archive, snapshotID string,
+	manifestBody []byte,
+) (SQLiteBundleUploadResult, error) {
 	headers := http.Header{}
 	headers.Set("content-type", "application/json")
 	headers.Set("x-crawl-sqlite-upload", "bundle-manifest")
+	setHeader(headers, "x-crawl-snapshot-id", snapshotID)
 	var out SQLiteBundleUploadResult
 	err := c.doRaw(
 		ctx,
@@ -687,18 +761,35 @@ func prepareSQLiteBundleManifest(app, archive string, manifest SQLiteBundleManif
 	if strings.TrimSpace(manifest.Archive) == "" {
 		manifest.Archive = archive
 	}
-	if err := validateSQLiteBundleManifest(manifest, app, archive); err != nil {
+	snapshotScoped := manifest.SnapshotID != ""
+	if snapshotScoped {
+		if err := validateSQLiteBundleManifest(manifest, app, archive); err != nil {
+			return SQLiteBundleManifest{}, nil, err
+		}
+	}
+	maxBodySize := sqliteBundleManifestSizeLimit(snapshotScoped)
+	encodedSize, err := preflightSQLiteBundleManifestEncoding(manifest, maxBodySize)
+	if err != nil {
 		return SQLiteBundleManifest{}, nil, err
 	}
 	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(manifest); err != nil {
+	buf.Grow(int(encodedSize) + 1)
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(manifest); err != nil {
 		return SQLiteBundleManifest{}, nil, fmt.Errorf("encode sqlite bundle manifest: %w", err)
 	}
 	body := buf.Bytes()
-	if err := validateSQLiteBundleManifestSize(
-		int64(len(body)),
-		manifest.SnapshotID != "",
-	); err != nil {
+	if len(body) > 0 && body[len(body)-1] == '\n' {
+		body = body[:len(body)-1]
+	}
+	if int64(len(body)) != encodedSize {
+		return SQLiteBundleManifest{}, nil, errors.New(
+			"sqlite bundle manifest encoding size changed after preflight",
+		)
+	}
+	if err := validateSQLiteBundleManifestSize(int64(len(body)), snapshotScoped); err != nil {
 		return SQLiteBundleManifest{}, nil, err
 	}
 	return manifest, body, nil
@@ -717,6 +808,423 @@ func validateSQLiteBundleManifestSize(size int64, snapshotScoped bool) error {
 		return fmt.Errorf("sqlite bundle manifest must not exceed %d bytes", maxBodySize)
 	}
 	return nil
+}
+
+const maxSQLiteBundleManifestJSONDepth = 1000
+
+var (
+	jsonMarshalerType    = reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+	textMarshalerType    = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
+	jsonNumberType       = reflect.TypeOf(json.Number(""))
+	errManifestSizeLimit = errors.New("sqlite bundle manifest size limit exceeded")
+)
+
+type sqliteBundleJSONVisit struct {
+	kind reflect.Kind
+	typ  reflect.Type
+	ptr  uintptr
+}
+
+type sqliteBundleJSONSizeCounter struct {
+	size  int64
+	limit int64
+	seen  map[sqliteBundleJSONVisit]struct{}
+}
+
+func preflightSQLiteBundleManifestEncoding(
+	manifest SQLiteBundleManifest,
+	limit int64,
+) (int64, error) {
+	counter := sqliteBundleJSONSizeCounter{
+		limit: limit,
+		seen:  make(map[sqliteBundleJSONVisit]struct{}),
+	}
+	if err := counter.addValue(reflect.ValueOf(manifest), 0); err != nil {
+		if errors.Is(err, errManifestSizeLimit) {
+			return 0, fmt.Errorf("sqlite bundle manifest must not exceed %d bytes", limit)
+		}
+		return 0, fmt.Errorf("encode sqlite bundle manifest: %w", err)
+	}
+	return counter.size, nil
+}
+
+func (c *sqliteBundleJSONSizeCounter) add(size int64) error {
+	if size < 0 || size > c.limit-c.size {
+		return errManifestSizeLimit
+	}
+	c.size += size
+	return nil
+}
+
+func (c *sqliteBundleJSONSizeCounter) addIndent(depth int) error {
+	return c.add(int64(depth * 2))
+}
+
+func (c *sqliteBundleJSONSizeCounter) addString(value string) error {
+	if err := c.add(2); err != nil {
+		return err
+	}
+	for len(value) > 0 {
+		char, width := utf8.DecodeRuneInString(value)
+		value = value[width:]
+		size := int64(width)
+		switch {
+		case char == utf8.RuneError && width == 1:
+			size = 6
+		case char == '\\' || char == '"':
+			size = 2
+		case char == '\b' || char == '\f' || char == '\n' || char == '\r' || char == '\t':
+			size = 2
+		case char < 0x20 || char == '\u2028' || char == '\u2029':
+			size = 6
+		}
+		if err := c.add(size); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *sqliteBundleJSONSizeCounter) addValue(value reflect.Value, depth int) error {
+	if depth > maxSQLiteBundleManifestJSONDepth {
+		return &json.UnsupportedValueError{
+			Value: value,
+			Str:   "exceeded maximum sqlite bundle manifest nesting depth",
+		}
+	}
+	if !value.IsValid() {
+		return c.add(4)
+	}
+	for value.Kind() == reflect.Interface {
+		if value.IsNil() {
+			return c.add(4)
+		}
+		value = value.Elem()
+	}
+	if value.Kind() == reflect.Pointer && value.IsNil() {
+		return c.add(4)
+	}
+	if value.Type() == jsonNumberType {
+		number := value.String()
+		if !validJSONNumber(number) {
+			return fmt.Errorf("json: invalid number literal %q", number)
+		}
+		return c.add(int64(len(number)))
+	}
+	if value.Type().Implements(jsonMarshalerType) ||
+		value.Type().Implements(textMarshalerType) ||
+		(value.Kind() != reflect.Pointer &&
+			(reflect.PointerTo(value.Type()).Implements(jsonMarshalerType) ||
+				reflect.PointerTo(value.Type()).Implements(textMarshalerType))) {
+		return &json.UnsupportedTypeError{Type: value.Type()}
+	}
+
+	switch value.Kind() {
+	case reflect.Pointer:
+		if err := c.enter(value); err != nil {
+			return err
+		}
+		defer c.leave(value)
+		return c.addValue(value.Elem(), depth)
+	case reflect.Bool:
+		if value.Bool() {
+			return c.add(4)
+		}
+		return c.add(5)
+	case reflect.String:
+		return c.addString(value.String())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return c.add(int64(len(strconv.FormatInt(value.Int(), 10))))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return c.add(int64(len(strconv.FormatUint(value.Uint(), 10))))
+	case reflect.Float32, reflect.Float64:
+		number, err := sqliteBundleJSONFloat(value.Float(), value.Type().Bits())
+		if err != nil {
+			return err
+		}
+		return c.add(int64(len(number)))
+	case reflect.Slice:
+		if value.IsNil() {
+			return c.add(4)
+		}
+		if value.Type().Elem().Kind() == reflect.Uint8 {
+			length := value.Len()
+			if int64(length) > c.limit-c.size {
+				return errManifestSizeLimit
+			}
+			return c.add(int64(base64.StdEncoding.EncodedLen(length) + 2))
+		}
+		if err := c.enter(value); err != nil {
+			return err
+		}
+		defer c.leave(value)
+		return c.addArray(value, depth)
+	case reflect.Array:
+		return c.addArray(value, depth)
+	case reflect.Map:
+		if value.IsNil() {
+			return c.add(4)
+		}
+		if value.Type().Key().Kind() != reflect.String ||
+			value.Type().Key().Implements(textMarshalerType) {
+			return &json.UnsupportedTypeError{Type: value.Type()}
+		}
+		if err := c.enter(value); err != nil {
+			return err
+		}
+		defer c.leave(value)
+		return c.addMap(value, depth)
+	case reflect.Struct:
+		return c.addStruct(value, depth)
+	default:
+		return &json.UnsupportedTypeError{Type: value.Type()}
+	}
+}
+
+func (c *sqliteBundleJSONSizeCounter) addArray(value reflect.Value, depth int) error {
+	if value.Len() == 0 {
+		return c.add(2)
+	}
+	if err := c.add(1); err != nil {
+		return err
+	}
+	for index := 0; index < value.Len(); index++ {
+		if index == 0 {
+			if err := c.add(1); err != nil {
+				return err
+			}
+		} else if err := c.add(2); err != nil {
+			return err
+		}
+		if err := c.addIndent(depth + 1); err != nil {
+			return err
+		}
+		if err := c.addValue(value.Index(index), depth+1); err != nil {
+			return err
+		}
+	}
+	if err := c.add(1); err != nil {
+		return err
+	}
+	if err := c.addIndent(depth); err != nil {
+		return err
+	}
+	return c.add(1)
+}
+
+func (c *sqliteBundleJSONSizeCounter) addMap(value reflect.Value, depth int) error {
+	if value.Len() == 0 {
+		return c.add(2)
+	}
+	if err := c.add(1); err != nil {
+		return err
+	}
+	iterator := value.MapRange()
+	first := true
+	for iterator.Next() {
+		if first {
+			first = false
+			if err := c.add(1); err != nil {
+				return err
+			}
+		} else if err := c.add(2); err != nil {
+			return err
+		}
+		if err := c.addIndent(depth + 1); err != nil {
+			return err
+		}
+		if err := c.addString(iterator.Key().String()); err != nil {
+			return err
+		}
+		if err := c.add(2); err != nil {
+			return err
+		}
+		if err := c.addValue(iterator.Value(), depth+1); err != nil {
+			return err
+		}
+	}
+	if err := c.add(1); err != nil {
+		return err
+	}
+	if err := c.addIndent(depth); err != nil {
+		return err
+	}
+	return c.add(1)
+}
+
+func (c *sqliteBundleJSONSizeCounter) addStruct(value reflect.Value, depth int) error {
+	if err := c.add(1); err != nil {
+		return err
+	}
+	first := true
+	typ := value.Type()
+	for index := 0; index < value.NumField(); index++ {
+		field := typ.Field(index)
+		if field.PkgPath != "" {
+			continue
+		}
+		if field.Anonymous {
+			return &json.UnsupportedTypeError{Type: typ}
+		}
+		name, options, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if name == "-" {
+			continue
+		}
+		for _, option := range strings.Split(options, ",") {
+			if option != "" && option != "omitempty" {
+				return &json.UnsupportedTypeError{Type: typ}
+			}
+		}
+		if name == "" {
+			name = field.Name
+		}
+		fieldValue := value.Field(index)
+		if strings.Contains(","+options+",", ",omitempty,") && isEmptyJSONValue(fieldValue) {
+			continue
+		}
+		if first {
+			first = false
+			if err := c.add(1); err != nil {
+				return err
+			}
+		} else if err := c.add(2); err != nil {
+			return err
+		}
+		if err := c.addIndent(depth + 1); err != nil {
+			return err
+		}
+		if err := c.addString(name); err != nil {
+			return err
+		}
+		if err := c.add(2); err != nil {
+			return err
+		}
+		if err := c.addValue(fieldValue, depth+1); err != nil {
+			return err
+		}
+	}
+	if first {
+		return c.add(1)
+	}
+	if err := c.add(1); err != nil {
+		return err
+	}
+	if err := c.addIndent(depth); err != nil {
+		return err
+	}
+	return c.add(1)
+}
+
+func (c *sqliteBundleJSONSizeCounter) enter(value reflect.Value) error {
+	visit := sqliteBundleJSONVisit{
+		kind: value.Kind(),
+		typ:  value.Type(),
+		ptr:  value.Pointer(),
+	}
+	if _, exists := c.seen[visit]; exists {
+		return &json.UnsupportedValueError{
+			Value: value,
+			Str:   "encountered a cycle in sqlite bundle manifest",
+		}
+	}
+	c.seen[visit] = struct{}{}
+	return nil
+}
+
+func (c *sqliteBundleJSONSizeCounter) leave(value reflect.Value) {
+	delete(c.seen, sqliteBundleJSONVisit{
+		kind: value.Kind(),
+		typ:  value.Type(),
+		ptr:  value.Pointer(),
+	})
+}
+
+func isEmptyJSONValue(value reflect.Value) bool {
+	switch value.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return value.Len() == 0
+	case reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64,
+		reflect.Interface, reflect.Pointer:
+		return value.IsZero()
+	default:
+		return false
+	}
+}
+
+func sqliteBundleJSONFloat(value float64, bits int) (string, error) {
+	if math.IsInf(value, 0) || math.IsNaN(value) {
+		return "", &json.UnsupportedValueError{
+			Value: reflect.ValueOf(value),
+			Str:   strconv.FormatFloat(value, 'g', -1, bits),
+		}
+	}
+	format := byte('f')
+	absolute := math.Abs(value)
+	if absolute != 0 && (absolute < 1e-6 || absolute >= 1e21) {
+		format = 'e'
+	}
+	encoded := strconv.AppendFloat(nil, value, format, -1, bits)
+	if format == 'e' {
+		for index := 0; index+3 < len(encoded); index++ {
+			if encoded[index] == 'e' &&
+				(encoded[index+1] == '-' || encoded[index+1] == '+') &&
+				encoded[index+2] == '0' {
+				encoded = append(encoded[:index+2], encoded[index+3:]...)
+				break
+			}
+		}
+	}
+	return string(encoded), nil
+}
+
+func validJSONNumber(value string) bool {
+	if value == "" {
+		return false
+	}
+	index := 0
+	if value[index] == '-' {
+		index++
+		if index == len(value) {
+			return false
+		}
+	}
+	if value[index] == '0' {
+		index++
+	} else {
+		if value[index] < '1' || value[index] > '9' {
+			return false
+		}
+		for index < len(value) && value[index] >= '0' && value[index] <= '9' {
+			index++
+		}
+	}
+	if index < len(value) && value[index] == '.' {
+		index++
+		start := index
+		for index < len(value) && value[index] >= '0' && value[index] <= '9' {
+			index++
+		}
+		if index == start {
+			return false
+		}
+	}
+	if index < len(value) && (value[index] == 'e' || value[index] == 'E') {
+		index++
+		if index < len(value) && (value[index] == '+' || value[index] == '-') {
+			index++
+		}
+		start := index
+		for index < len(value) && value[index] >= '0' && value[index] <= '9' {
+			index++
+		}
+		if index == start {
+			return false
+		}
+	}
+	return index == len(value)
 }
 
 func validateSQLiteBundleManifest(manifest SQLiteBundleManifest, app, archive string) error {
@@ -856,12 +1364,15 @@ func validateSQLiteBundlePartLimit(index int, size int64, snapshotScoped bool) e
 	if snapshotScoped && index >= maxSQLiteBundleParts {
 		return fmt.Errorf("sqlite bundle part index must be between 0 and %d", maxSQLiteBundleParts-1)
 	}
-	if size <= 0 {
-		return fmt.Errorf("sqlite bundle part %d size must be positive", index)
+	if snapshotScoped && size < 0 {
+		return fmt.Errorf("sqlite bundle part %d size must be non-negative", index)
+	}
+	if !snapshotScoped && size < -1 {
+		return fmt.Errorf("sqlite bundle part %d size must be -1 or non-negative", index)
 	}
 	if snapshotScoped && size > DefaultSQLiteBundleChunkSize {
 		return fmt.Errorf(
-			"sqlite bundle part %d size must be between 1 and %d bytes",
+			"sqlite bundle part %d size must be between 0 and %d bytes",
 			index,
 			DefaultSQLiteBundleChunkSize,
 		)
@@ -893,6 +1404,9 @@ func validateSQLiteBundleManifestLimits(manifest SQLiteBundleManifest) error {
 	for index, part := range manifest.Parts {
 		if part.Index != index {
 			return fmt.Errorf("sqlite bundle manifest part %d has index %d", index, part.Index)
+		}
+		if part.Size <= 0 {
+			return fmt.Errorf("sqlite bundle part %d size must be positive", part.Index)
 		}
 		if err := validateSQLiteBundlePartLimit(part.Index, part.Size, snapshotScoped); err != nil {
 			return err
@@ -972,20 +1486,43 @@ func validateMutableSQLiteBundleFiles(
 	ctx context.Context,
 	manifest SQLiteBundleManifest,
 	parts []SQLiteBundlePartFile,
-) error {
-	if len(parts) != len(manifest.Parts) {
-		return fmt.Errorf("sqlite bundle has %d part files, want %d", len(parts), len(manifest.Parts))
+) (map[int]SQLiteBundlePart, error) {
+	if len(manifest.Parts) > 0 && len(parts) != len(manifest.Parts) {
+		return nil, fmt.Errorf(
+			"sqlite bundle has %d part files, want %d",
+			len(parts),
+			len(manifest.Parts),
+		)
 	}
-	for index, part := range parts {
-		expected := manifest.Parts[index]
-		if part.SQLiteBundlePart != expected {
-			return fmt.Errorf("sqlite bundle part file %d does not match the manifest", index)
+	manifestParts := make(map[int]SQLiteBundlePart, len(manifest.Parts))
+	for _, part := range manifest.Parts {
+		if _, duplicate := manifestParts[part.Index]; duplicate {
+			return nil, fmt.Errorf("sqlite bundle manifest repeats part index %d", part.Index)
 		}
-		if err := copyValidatedSQLiteBundlePart(ctx, index, part, io.Discard); err != nil {
-			return err
-		}
+		manifestParts[part.Index] = part
 	}
-	return nil
+	expectedParts := make(map[int]SQLiteBundlePart, len(parts))
+	for _, part := range parts {
+		if _, duplicate := expectedParts[part.Index]; duplicate {
+			return nil, fmt.Errorf("sqlite bundle part files repeat index %d", part.Index)
+		}
+		expected := part.SQLiteBundlePart
+		if len(manifestParts) > 0 {
+			var ok bool
+			expected, ok = manifestParts[part.Index]
+			if !ok || part.SQLiteBundlePart != expected {
+				return nil, fmt.Errorf(
+					"sqlite bundle part file %d does not match the manifest",
+					part.Index,
+				)
+			}
+		}
+		if err := copyValidatedSQLiteBundlePart(ctx, part.Index, part, io.Discard); err != nil {
+			return nil, err
+		}
+		expectedParts[part.Index] = expected
+	}
+	return expectedParts, nil
 }
 
 func snapshotSQLiteBundlePart(
@@ -1039,7 +1576,12 @@ func copyValidatedSQLiteBundlePart(
 		return fmt.Errorf("sqlite bundle part file %d must be a %d-byte regular file", index, part.Size)
 	}
 	hash := sha256.New()
-	size, err := copyWithContext(ctx, io.MultiWriter(dst, hash), source)
+	size, err := copySQLiteBundleDeclaredSize(
+		ctx,
+		io.MultiWriter(dst, hash),
+		source,
+		part.Size,
+	)
 	if err != nil {
 		return fmt.Errorf("validate sqlite bundle part %d: %w", index, err)
 	}
@@ -1065,9 +1607,17 @@ func validateSnapshotSQLiteBundleContent(
 	compressedHash := sha256.New()
 	var compressedSize int64
 	for index, part := range parts {
-		size, err := copyWithContext(ctx, compressedHash, part.file)
+		size, err := copySQLiteBundleDeclaredSize(
+			ctx,
+			compressedHash,
+			part.file,
+			part.part.Size,
+		)
 		if err != nil {
 			return fmt.Errorf("hash sqlite bundle compressed part %d: %w", index, err)
+		}
+		if size != part.part.Size {
+			return fmt.Errorf("sqlite bundle compressed object does not match the manifest")
 		}
 		compressedSize += size
 	}
@@ -1080,7 +1630,14 @@ func validateSnapshotSQLiteBundleContent(
 	}
 	readers := make([]io.Reader, len(parts))
 	for index := range parts {
-		readers[index] = parts[index].file
+		reader, err := sqliteBundleDeclaredSizeReader(
+			parts[index].file,
+			parts[index].part.Size,
+		)
+		if err != nil {
+			return err
+		}
+		readers[index] = reader
 	}
 	decompressor, err := gzip.NewReader(io.MultiReader(readers...))
 	if err != nil {
@@ -1187,6 +1744,8 @@ func (c *Client) doRaw(ctx context.Context, method, route string, body io.Reader
 	}
 	if size >= 0 {
 		req.ContentLength = size
+	} else {
+		req.ContentLength = -1
 	}
 	for name, values := range headers {
 		for _, value := range values {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
@@ -14,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -476,12 +478,20 @@ func (c *Client) publishStatus(ctx context.Context, app, archive, snapshotID str
 		return out, err
 	}
 	err = c.doRequest(ctx, req, false, &out, true)
-	if err == nil && snapshotID != "" && out.Snapshot != nil && out.Snapshot.ID != snapshotID {
-		return PublisherStatus{}, fmt.Errorf(
-			"publish status returned snapshot %q, want %q",
-			out.Snapshot.ID,
-			snapshotID,
-		)
+	if err == nil && snapshotID != "" {
+		if out.Snapshot == nil {
+			return PublisherStatus{}, fmt.Errorf(
+				"publish status did not return requested snapshot %q",
+				snapshotID,
+			)
+		}
+		if out.Snapshot.ID != snapshotID {
+			return PublisherStatus{}, fmt.Errorf(
+				"publish status returned snapshot %q, want %q",
+				out.Snapshot.ID,
+				snapshotID,
+			)
+		}
 	}
 	return out, err
 }
@@ -830,8 +840,9 @@ func validateSQLiteBundleManifestLimits(manifest SQLiteBundleManifest) error {
 }
 
 type validatedSQLiteBundlePartFile struct {
-	part SQLiteBundlePart
-	file *os.File
+	part    SQLiteBundlePart
+	file    *os.File
+	tempDir string
 }
 
 func openValidatedSQLiteBundleFiles(
@@ -845,10 +856,15 @@ func openValidatedSQLiteBundleFiles(
 	if len(parts) != len(manifest.Parts) {
 		return nil, fmt.Errorf("sqlite bundle has %d part files, want %d", len(parts), len(manifest.Parts))
 	}
+	tempDir, err := os.MkdirTemp("", "crawl-sqlite-upload-*")
+	if err != nil {
+		return nil, fmt.Errorf("create sqlite bundle upload snapshot: %w", err)
+	}
 	validated := make([]validatedSQLiteBundlePartFile, 0, len(parts))
 	defer func() {
 		if err != nil {
 			closeValidatedSQLiteBundleFiles(validated)
+			_ = os.RemoveAll(tempDir)
 		}
 	}()
 	for index, part := range parts {
@@ -856,47 +872,149 @@ func openValidatedSQLiteBundleFiles(
 		if part.SQLiteBundlePart != expected {
 			return nil, fmt.Errorf("sqlite bundle part file %d does not match the manifest", index)
 		}
-		file, err := os.Open(part.Path)
+		snapshot, err := snapshotSQLiteBundlePart(ctx, tempDir, index, part)
 		if err != nil {
-			return nil, fmt.Errorf("open sqlite bundle part %d: %w", index, err)
+			return nil, err
 		}
 		validated = append(validated, validatedSQLiteBundlePartFile{
-			part: expected,
-			file: file,
+			part:    expected,
+			file:    snapshot,
+			tempDir: tempDir,
 		})
-		infoBefore, err := file.Stat()
-		if err != nil {
-			return nil, fmt.Errorf("stat sqlite bundle part %d: %w", index, err)
-		}
-		if !infoBefore.Mode().IsRegular() || infoBefore.Size() != part.Size {
-			return nil, fmt.Errorf("sqlite bundle part file %d must be a %d-byte regular file", index, part.Size)
-		}
-		hash := sha256.New()
-		size, err := copyWithContext(ctx, hash, file)
-		if err != nil {
-			return nil, fmt.Errorf("hash sqlite bundle part %d: %w", index, err)
-		}
-		infoAfter, err := file.Stat()
-		if err != nil {
-			return nil, fmt.Errorf("restat sqlite bundle part %d: %w", index, err)
-		}
-		if !os.SameFile(infoBefore, infoAfter) || infoAfter.Size() != part.Size || size != part.Size {
-			return nil, fmt.Errorf("sqlite bundle part file %d changed during validation", index)
-		}
-		actualSHA256 := fmt.Sprintf("%x", hash.Sum(nil))
-		if !strings.EqualFold(actualSHA256, part.SHA256) {
-			return nil, fmt.Errorf("sqlite bundle part file %d sha256 does not match the manifest", index)
-		}
-		if _, err := file.Seek(0, io.SeekStart); err != nil {
-			return nil, fmt.Errorf("rewind sqlite bundle part %d: %w", index, err)
+	}
+	if manifest.SnapshotID != "" {
+		if err := validateSnapshotSQLiteBundleContent(ctx, manifest, validated); err != nil {
+			return nil, err
 		}
 	}
 	return validated, nil
 }
 
+func snapshotSQLiteBundlePart(
+	ctx context.Context,
+	tempDir string,
+	index int,
+	part SQLiteBundlePartFile,
+) (_ *os.File, err error) {
+	source, err := os.Open(part.Path)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite bundle part %d: %w", index, err)
+	}
+	defer func() { _ = source.Close() }()
+	infoBefore, err := source.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat sqlite bundle part %d: %w", index, err)
+	}
+	if !infoBefore.Mode().IsRegular() || infoBefore.Size() != part.Size {
+		return nil, fmt.Errorf("sqlite bundle part file %d must be a %d-byte regular file", index, part.Size)
+	}
+	snapshotPath := filepath.Join(tempDir, fmt.Sprintf("part-%04d", index))
+	snapshot, err := os.OpenFile(snapshotPath, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("create sqlite bundle part snapshot %d: %w", index, err)
+	}
+	defer func() {
+		if err != nil {
+			_ = snapshot.Close()
+		}
+	}()
+	hash := sha256.New()
+	size, err := copyWithContext(ctx, io.MultiWriter(snapshot, hash), source)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot sqlite bundle part %d: %w", index, err)
+	}
+	infoAfter, err := source.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("restat sqlite bundle part %d: %w", index, err)
+	}
+	if !os.SameFile(infoBefore, infoAfter) || infoAfter.Size() != part.Size || size != part.Size {
+		return nil, fmt.Errorf("sqlite bundle part file %d changed during validation", index)
+	}
+	actualSHA256 := fmt.Sprintf("%x", hash.Sum(nil))
+	if !strings.EqualFold(actualSHA256, part.SHA256) {
+		return nil, fmt.Errorf("sqlite bundle part file %d sha256 does not match the manifest", index)
+	}
+	if err := snapshot.Sync(); err != nil {
+		return nil, fmt.Errorf("sync sqlite bundle part snapshot %d: %w", index, err)
+	}
+	if err := snapshot.Close(); err != nil {
+		return nil, fmt.Errorf("close sqlite bundle part snapshot %d: %w", index, err)
+	}
+	snapshot, err = os.Open(snapshotPath)
+	if err != nil {
+		return nil, fmt.Errorf("reopen sqlite bundle part snapshot %d: %w", index, err)
+	}
+	return snapshot, nil
+}
+
+func validateSnapshotSQLiteBundleContent(
+	ctx context.Context,
+	manifest SQLiteBundleManifest,
+	parts []validatedSQLiteBundlePartFile,
+) error {
+	compressedHash := sha256.New()
+	var compressedSize int64
+	for index, part := range parts {
+		size, err := copyWithContext(ctx, compressedHash, part.file)
+		if err != nil {
+			return fmt.Errorf("hash sqlite bundle compressed part %d: %w", index, err)
+		}
+		compressedSize += size
+	}
+	if compressedSize != manifest.CompressedObject.Size ||
+		fmt.Sprintf("%x", compressedHash.Sum(nil)) != manifest.CompressedObject.SHA256 {
+		return fmt.Errorf("sqlite bundle compressed object does not match the manifest")
+	}
+	if err := rewindValidatedSQLiteBundleFiles(parts); err != nil {
+		return err
+	}
+	readers := make([]io.Reader, len(parts))
+	for index := range parts {
+		readers[index] = parts[index].file
+	}
+	decompressor, err := gzip.NewReader(io.MultiReader(readers...))
+	if err != nil {
+		return fmt.Errorf("decompress sqlite bundle snapshot: %w", err)
+	}
+	objectHash := sha256.New()
+	objectSize, copyErr := copyWithContext(
+		ctx,
+		objectHash,
+		io.LimitReader(decompressor, manifest.Object.Size+1),
+	)
+	closeErr := decompressor.Close()
+	if copyErr != nil {
+		return fmt.Errorf("decompress sqlite bundle snapshot: %w", copyErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close sqlite bundle decompressor: %w", closeErr)
+	}
+	if objectSize != manifest.Object.Size ||
+		fmt.Sprintf("%x", objectHash.Sum(nil)) != manifest.Object.SHA256 {
+		return fmt.Errorf("sqlite bundle decompressed object does not match the manifest")
+	}
+	return rewindValidatedSQLiteBundleFiles(parts)
+}
+
+func rewindValidatedSQLiteBundleFiles(parts []validatedSQLiteBundlePartFile) error {
+	for index, part := range parts {
+		if _, err := part.file.Seek(0, io.SeekStart); err != nil {
+			return fmt.Errorf("rewind sqlite bundle part %d: %w", index, err)
+		}
+	}
+	return nil
+}
+
 func closeValidatedSQLiteBundleFiles(parts []validatedSQLiteBundlePartFile) {
+	tempDirs := map[string]struct{}{}
 	for _, part := range parts {
 		_ = part.file.Close()
+		if part.tempDir != "" {
+			tempDirs[part.tempDir] = struct{}{}
+		}
+	}
+	for tempDir := range tempDirs {
+		_ = os.RemoveAll(tempDir)
 	}
 }
 

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -528,10 +528,11 @@ func (c *Client) UploadSQLiteBundlePart(ctx context.Context, app, archive string
 }
 
 func (c *Client) UploadSQLiteBundleFiles(ctx context.Context, app, archive string, manifest SQLiteBundleManifest, parts []SQLiteBundlePartFile) (SQLiteBundleUploadResult, error) {
-	if manifest.SnapshotID != "" && !validSQLiteSnapshotID(manifest.SnapshotID) {
-		return SQLiteBundleUploadResult{}, errors.New("sqlite bundle snapshot id must be empty or a lowercase sha256 digest")
+	preparedManifest, manifestBody, err := prepareSQLiteBundleManifest(app, archive, manifest)
+	if err != nil {
+		return SQLiteBundleUploadResult{}, err
 	}
-	if err := validateSQLiteBundleFiles(manifest, parts); err != nil {
+	if err := validateSQLiteBundleFiles(preparedManifest, parts); err != nil {
 		return SQLiteBundleUploadResult{}, err
 	}
 	for _, part := range parts {
@@ -545,39 +546,150 @@ func (c *Client) UploadSQLiteBundleFiles(ctx context.Context, app, archive strin
 			Size:        part.Size,
 			SHA256:      part.SHA256,
 			Compression: SQLiteGzipCompression,
-			SnapshotID:  manifest.SnapshotID,
+			SnapshotID:  preparedManifest.SnapshotID,
 		})
 		_ = file.Close()
 		if uploadErr != nil {
 			return SQLiteBundleUploadResult{}, uploadErr
 		}
 	}
-	return c.UploadSQLiteBundleManifest(ctx, app, archive, manifest)
+	return c.uploadSQLiteBundleManifest(ctx, app, archive, manifestBody)
 }
 
 func (c *Client) UploadSQLiteBundleManifest(ctx context.Context, app, archive string, manifest SQLiteBundleManifest) (SQLiteBundleUploadResult, error) {
-	if manifest.SnapshotID != "" && !validSQLiteSnapshotID(manifest.SnapshotID) {
-		return SQLiteBundleUploadResult{}, errors.New("sqlite bundle snapshot id must be empty or a lowercase sha256 digest")
-	}
-	if err := validateSQLiteBundleManifestLimits(manifest); err != nil {
+	_, manifestBody, err := prepareSQLiteBundleManifest(app, archive, manifest)
+	if err != nil {
 		return SQLiteBundleUploadResult{}, err
 	}
-	if strings.TrimSpace(manifest.App) == "" {
-		manifest.App = strings.TrimSpace(app)
-	}
-	if strings.TrimSpace(manifest.Archive) == "" {
-		manifest.Archive = strings.TrimSpace(archive)
-	}
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(manifest); err != nil {
-		return SQLiteBundleUploadResult{}, fmt.Errorf("encode sqlite bundle manifest: %w", err)
-	}
+	return c.uploadSQLiteBundleManifest(ctx, app, archive, manifestBody)
+}
+
+func (c *Client) uploadSQLiteBundleManifest(ctx context.Context, app, archive string, manifestBody []byte) (SQLiteBundleUploadResult, error) {
 	headers := http.Header{}
 	headers.Set("content-type", "application/json")
 	headers.Set("x-crawl-sqlite-upload", "bundle-manifest")
 	var out SQLiteBundleUploadResult
-	err := c.doRaw(ctx, http.MethodPut, archivePath(app, archive, "sqlite"), &buf, int64(buf.Len()), headers, &out, true)
+	err := c.doRaw(
+		ctx,
+		http.MethodPut,
+		archivePath(app, archive, "sqlite"),
+		bytes.NewReader(manifestBody),
+		int64(len(manifestBody)),
+		headers,
+		&out,
+		true,
+	)
 	return out, err
+}
+
+func prepareSQLiteBundleManifest(app, archive string, manifest SQLiteBundleManifest) (SQLiteBundleManifest, []byte, error) {
+	app = strings.TrimSpace(app)
+	archive = strings.TrimSpace(archive)
+	if strings.TrimSpace(manifest.App) == "" {
+		manifest.App = app
+	}
+	if strings.TrimSpace(manifest.Archive) == "" {
+		manifest.Archive = archive
+	}
+	if err := validateSQLiteBundleManifest(manifest, app, archive); err != nil {
+		return SQLiteBundleManifest{}, nil, err
+	}
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(manifest); err != nil {
+		return SQLiteBundleManifest{}, nil, fmt.Errorf("encode sqlite bundle manifest: %w", err)
+	}
+	body := buf.Bytes()
+	if int64(len(body)) > maxSQLiteBundleManifestBytes {
+		return SQLiteBundleManifest{}, nil, fmt.Errorf(
+			"sqlite bundle manifest must not exceed %d bytes",
+			maxSQLiteBundleManifestBytes,
+		)
+	}
+	return manifest, body, nil
+}
+
+func validateSQLiteBundleManifest(manifest SQLiteBundleManifest, app, archive string) error {
+	snapshotScoped := manifest.SnapshotID != ""
+	if snapshotScoped && !validSQLiteSnapshotID(manifest.SnapshotID) {
+		return errors.New("sqlite bundle snapshot id must be empty or a lowercase sha256 digest")
+	}
+	if manifest.Format != SQLiteGzipChunkedBundleFormat {
+		return fmt.Errorf("sqlite bundle format must be %q", SQLiteGzipChunkedBundleFormat)
+	}
+	if app == "" || archive == "" || manifest.App != app || manifest.Archive != archive {
+		return errors.New("sqlite bundle manifest app and archive must match the upload route")
+	}
+	if manifest.ContentType != "" && manifest.ContentType != "application/vnd.sqlite3" {
+		return errors.New("sqlite bundle content type must be application/vnd.sqlite3 when set")
+	}
+	if manifest.Compression.Algorithm != SQLiteGzipCompression {
+		return fmt.Errorf("sqlite bundle compression must be %q", SQLiteGzipCompression)
+	}
+	if err := validateSQLiteBundleManifestLimits(manifest); err != nil {
+		return err
+	}
+	if manifest.Object.Key != SQLiteSnapshotObjectKey(app, archive, manifest.SnapshotID) {
+		return errors.New("sqlite bundle object key must match the upload route")
+	}
+	if !validSQLiteBundleSHA256(manifest.Object.SHA256, snapshotScoped) {
+		return errors.New("sqlite bundle object sha256 must be a valid digest")
+	}
+	if snapshotScoped && manifest.Object.SHA256 != manifest.SnapshotID {
+		return errors.New("sqlite bundle snapshot id must equal the object sha256")
+	}
+	if manifest.CompressedObject.Key != SQLiteSnapshotCompressedObjectKey(
+		app,
+		archive,
+		manifest.SnapshotID,
+		manifest.CompressedObject.SHA256,
+	) {
+		return errors.New("sqlite bundle compressed object key must match the upload route")
+	}
+	if !validSQLiteBundleSHA256(manifest.CompressedObject.SHA256, snapshotScoped) {
+		return errors.New("sqlite bundle compressed object sha256 must be a valid digest")
+	}
+	for index, part := range manifest.Parts {
+		if !validSQLiteBundleSHA256(part.SHA256, snapshotScoped) {
+			return fmt.Errorf("sqlite bundle part %d sha256 must be a valid digest", index)
+		}
+		if part.Key != SQLiteSnapshotBundlePartKey(
+			app,
+			archive,
+			manifest.SnapshotID,
+			part.SHA256,
+			index,
+		) {
+			return fmt.Errorf("sqlite bundle part %d key must match the upload route", index)
+		}
+	}
+	for name, count := range manifest.Counts {
+		if strings.TrimSpace(name) == "" {
+			return errors.New("sqlite bundle count names must not be empty")
+		}
+		if count < 0 {
+			return fmt.Errorf("sqlite bundle count %q must not be negative", name)
+		}
+	}
+	return nil
+}
+
+func validSQLiteBundleSHA256(value string, canonical bool) bool {
+	if len(value) != sha256.Size*2 {
+		return false
+	}
+	for _, char := range value {
+		if char >= '0' && char <= '9' {
+			continue
+		}
+		if char >= 'a' && char <= 'f' {
+			continue
+		}
+		if !canonical && char >= 'A' && char <= 'F' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func validateSQLiteBundlePartLimit(index int, size int64, snapshotScoped bool) error {
@@ -628,7 +740,7 @@ func validateSQLiteBundleManifestLimits(manifest SQLiteBundleManifest) error {
 }
 
 func validateSQLiteBundleFiles(manifest SQLiteBundleManifest, parts []SQLiteBundlePartFile) error {
-	if err := validateSQLiteBundleManifestLimits(manifest); err != nil {
+	if err := validateSQLiteBundleManifest(manifest, manifest.App, manifest.Archive); err != nil {
 		return err
 	}
 	if len(parts) != len(manifest.Parts) {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -650,10 +650,11 @@ func (c *Client) uploadMutableSQLiteBundleFiles(
 	manifest SQLiteBundleManifest,
 	manifestBody []byte,
 	parts []SQLiteBundlePartFile,
-	expectedParts map[int]SQLiteBundlePart,
+	expectedParts map[int]validatedMutableSQLiteBundlePartFile,
 ) (SQLiteBundleUploadResult, error) {
 	for _, part := range parts {
-		expected := expectedParts[part.Index]
+		validated := expectedParts[part.Index]
+		expected := validated.part
 		file, err := os.Open(part.Path)
 		if err != nil {
 			return SQLiteBundleUploadResult{}, fmt.Errorf("open sqlite bundle part %d: %w", part.Index, err)
@@ -663,7 +664,15 @@ func (c *Client) uploadMutableSQLiteBundleFiles(
 			_ = file.Close()
 			return SQLiteBundleUploadResult{}, fmt.Errorf("stat sqlite bundle part %d: %w", part.Index, err)
 		}
-		bounded, err := sqliteBundleDeclaredSizeReader(file, expected.Size)
+		if !infoBefore.Mode().IsRegular() || infoBefore.Size() != validated.localSize {
+			_ = file.Close()
+			return SQLiteBundleUploadResult{}, fmt.Errorf(
+				"sqlite bundle part file %d must be a %d-byte regular file",
+				part.Index,
+				validated.localSize,
+			)
+		}
+		bounded, err := sqliteBundleDeclaredSizeReader(file, validated.localSize)
 		if err != nil {
 			_ = file.Close()
 			return SQLiteBundleUploadResult{}, err
@@ -700,11 +709,14 @@ func (c *Client) uploadMutableSQLiteBundleFiles(
 		if closeErr != nil {
 			return SQLiteBundleUploadResult{}, fmt.Errorf("close sqlite bundle part %d: %w", part.Index, closeErr)
 		}
+		expectedSHA256 := strings.TrimSpace(expected.SHA256)
+		digestChanged := expectedSHA256 != "" &&
+			!strings.EqualFold(fmt.Sprintf("%x", hash.Sum(nil)), expectedSHA256)
 		if !os.SameFile(infoBefore, infoAfter) ||
-			infoBefore.Size() != expected.Size ||
-			infoAfter.Size() != expected.Size ||
-			int64(streamed) != expected.Size ||
-			!strings.EqualFold(fmt.Sprintf("%x", hash.Sum(nil)), expected.SHA256) {
+			infoBefore.Size() != validated.localSize ||
+			infoAfter.Size() != validated.localSize ||
+			int64(streamed) != validated.localSize ||
+			digestChanged {
 			return SQLiteBundleUploadResult{}, fmt.Errorf(
 				"sqlite bundle part file %d changed during upload",
 				part.Index,
@@ -712,6 +724,11 @@ func (c *Client) uploadMutableSQLiteBundleFiles(
 		}
 	}
 	return c.uploadSQLiteBundleManifest(ctx, app, archive, manifest.SnapshotID, manifestBody)
+}
+
+type validatedMutableSQLiteBundlePartFile struct {
+	part      SQLiteBundlePart
+	localSize int64
 }
 
 type byteCounter int64
@@ -1486,7 +1503,7 @@ func validateMutableSQLiteBundleFiles(
 	ctx context.Context,
 	manifest SQLiteBundleManifest,
 	parts []SQLiteBundlePartFile,
-) (map[int]SQLiteBundlePart, error) {
+) (map[int]validatedMutableSQLiteBundlePartFile, error) {
 	if len(manifest.Parts) > 0 && len(parts) != len(manifest.Parts) {
 		return nil, fmt.Errorf(
 			"sqlite bundle has %d part files, want %d",
@@ -1501,7 +1518,7 @@ func validateMutableSQLiteBundleFiles(
 		}
 		manifestParts[part.Index] = part
 	}
-	expectedParts := make(map[int]SQLiteBundlePart, len(parts))
+	expectedParts := make(map[int]validatedMutableSQLiteBundlePartFile, len(parts))
 	for _, part := range parts {
 		if _, duplicate := expectedParts[part.Index]; duplicate {
 			return nil, fmt.Errorf("sqlite bundle part files repeat index %d", part.Index)
@@ -1517,12 +1534,64 @@ func validateMutableSQLiteBundleFiles(
 				)
 			}
 		}
-		if err := copyValidatedSQLiteBundlePart(ctx, part.Index, part, io.Discard); err != nil {
+		size, err := validateMutableSQLiteBundlePartFile(ctx, part.Index, part)
+		if err != nil {
 			return nil, err
 		}
-		expectedParts[part.Index] = expected
+		expectedParts[part.Index] = validatedMutableSQLiteBundlePartFile{
+			part:      expected,
+			localSize: size,
+		}
 	}
 	return expectedParts, nil
+}
+
+func validateMutableSQLiteBundlePartFile(
+	ctx context.Context,
+	index int,
+	part SQLiteBundlePartFile,
+) (int64, error) {
+	if err := validateSQLiteBundlePartLimit(part.Index, part.Size, false); err != nil {
+		return 0, err
+	}
+	source, err := os.Open(part.Path)
+	if err != nil {
+		return 0, fmt.Errorf("open sqlite bundle part %d: %w", index, err)
+	}
+	defer func() { _ = source.Close() }()
+	infoBefore, err := source.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("stat sqlite bundle part %d: %w", index, err)
+	}
+	expectedSize := part.Size
+	if expectedSize == -1 {
+		expectedSize = infoBefore.Size()
+	}
+	if !infoBefore.Mode().IsRegular() || infoBefore.Size() != expectedSize {
+		return 0, fmt.Errorf(
+			"sqlite bundle part file %d must be a %d-byte regular file",
+			index,
+			expectedSize,
+		)
+	}
+	hash := sha256.New()
+	size, err := copySQLiteBundleDeclaredSize(ctx, hash, source, expectedSize)
+	if err != nil {
+		return 0, fmt.Errorf("validate sqlite bundle part %d: %w", index, err)
+	}
+	infoAfter, err := source.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("restat sqlite bundle part %d: %w", index, err)
+	}
+	if !os.SameFile(infoBefore, infoAfter) || infoAfter.Size() != expectedSize || size != expectedSize {
+		return 0, fmt.Errorf("sqlite bundle part file %d changed during validation", index)
+	}
+	expectedSHA256 := strings.TrimSpace(part.SHA256)
+	if expectedSHA256 != "" &&
+		!strings.EqualFold(fmt.Sprintf("%x", hash.Sum(nil)), expectedSHA256) {
+		return 0, fmt.Errorf("sqlite bundle part file %d sha256 does not match the manifest", index)
+	}
+	return expectedSize, nil
 }
 
 func snapshotSQLiteBundlePart(

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -512,6 +512,9 @@ func (c *Client) UploadSQLiteBundlePart(ctx context.Context, app, archive string
 	if part.SnapshotID != "" && !validSQLiteSnapshotID(part.SnapshotID) {
 		return SQLiteUploadResult{}, errors.New("sqlite bundle snapshot id must be empty or a lowercase sha256 digest")
 	}
+	if err := validateSQLiteBundlePartLimit(part.Index, part.Size, part.SnapshotID != ""); err != nil {
+		return SQLiteUploadResult{}, err
+	}
 	headers := http.Header{}
 	headers.Set("content-type", "application/gzip")
 	headers.Set("x-crawl-sqlite-upload", "bundle-part")
@@ -527,6 +530,9 @@ func (c *Client) UploadSQLiteBundlePart(ctx context.Context, app, archive string
 func (c *Client) UploadSQLiteBundleFiles(ctx context.Context, app, archive string, manifest SQLiteBundleManifest, parts []SQLiteBundlePartFile) (SQLiteBundleUploadResult, error) {
 	if manifest.SnapshotID != "" && !validSQLiteSnapshotID(manifest.SnapshotID) {
 		return SQLiteBundleUploadResult{}, errors.New("sqlite bundle snapshot id must be empty or a lowercase sha256 digest")
+	}
+	if err := validateSQLiteBundleFiles(manifest, parts); err != nil {
+		return SQLiteBundleUploadResult{}, err
 	}
 	for _, part := range parts {
 		file, err := os.Open(part.Path)
@@ -553,6 +559,9 @@ func (c *Client) UploadSQLiteBundleManifest(ctx context.Context, app, archive st
 	if manifest.SnapshotID != "" && !validSQLiteSnapshotID(manifest.SnapshotID) {
 		return SQLiteBundleUploadResult{}, errors.New("sqlite bundle snapshot id must be empty or a lowercase sha256 digest")
 	}
+	if err := validateSQLiteBundleManifestLimits(manifest); err != nil {
+		return SQLiteBundleUploadResult{}, err
+	}
 	if strings.TrimSpace(manifest.App) == "" {
 		manifest.App = strings.TrimSpace(app)
 	}
@@ -569,6 +578,76 @@ func (c *Client) UploadSQLiteBundleManifest(ctx context.Context, app, archive st
 	var out SQLiteBundleUploadResult
 	err := c.doRaw(ctx, http.MethodPut, archivePath(app, archive, "sqlite"), &buf, int64(buf.Len()), headers, &out, true)
 	return out, err
+}
+
+func validateSQLiteBundlePartLimit(index int, size int64, snapshotScoped bool) error {
+	if index < 0 || index >= maxSQLiteBundleParts {
+		return fmt.Errorf("sqlite bundle part index must be between 0 and %d", maxSQLiteBundleParts-1)
+	}
+	maxSize := DefaultMutableSQLiteBundleChunkSize
+	if snapshotScoped {
+		maxSize = DefaultSQLiteBundleChunkSize
+	}
+	if size <= 0 || size > maxSize {
+		return fmt.Errorf("sqlite bundle part %d size must be between 1 and %d bytes", index, maxSize)
+	}
+	return nil
+}
+
+func validateSQLiteBundleManifestLimits(manifest SQLiteBundleManifest) error {
+	if len(manifest.Parts) == 0 || len(manifest.Parts) > maxSQLiteBundleParts {
+		return fmt.Errorf("sqlite bundle manifest must contain between 1 and %d parts", maxSQLiteBundleParts)
+	}
+	if manifest.Object.Size <= 0 || manifest.Object.Size > maxSQLiteBundleObjectSize {
+		return fmt.Errorf("sqlite bundle object size must be between 1 and %d bytes", maxSQLiteBundleObjectSize)
+	}
+	if manifest.CompressedObject.Size <= 0 || manifest.CompressedObject.Size > maxSQLiteBundleCompressedSize {
+		return fmt.Errorf("sqlite bundle compressed size must be between 1 and %d bytes", maxSQLiteBundleCompressedSize)
+	}
+	var total int64
+	for index, part := range manifest.Parts {
+		if part.Index != index {
+			return fmt.Errorf("sqlite bundle manifest part %d has index %d", index, part.Index)
+		}
+		if err := validateSQLiteBundlePartLimit(part.Index, part.Size, manifest.SnapshotID != ""); err != nil {
+			return err
+		}
+		if total > maxSQLiteBundleCompressedSize-part.Size {
+			return fmt.Errorf("sqlite bundle parts exceed %d compressed bytes", maxSQLiteBundleCompressedSize)
+		}
+		total += part.Size
+	}
+	if total != manifest.CompressedObject.Size {
+		return fmt.Errorf(
+			"sqlite bundle part sizes total %d bytes, want compressed size %d",
+			total,
+			manifest.CompressedObject.Size,
+		)
+	}
+	return nil
+}
+
+func validateSQLiteBundleFiles(manifest SQLiteBundleManifest, parts []SQLiteBundlePartFile) error {
+	if err := validateSQLiteBundleManifestLimits(manifest); err != nil {
+		return err
+	}
+	if len(parts) != len(manifest.Parts) {
+		return fmt.Errorf("sqlite bundle has %d part files, want %d", len(parts), len(manifest.Parts))
+	}
+	for index, part := range parts {
+		expected := manifest.Parts[index]
+		if part.SQLiteBundlePart != expected {
+			return fmt.Errorf("sqlite bundle part file %d does not match the manifest", index)
+		}
+		info, err := os.Stat(part.Path)
+		if err != nil {
+			return fmt.Errorf("stat sqlite bundle part %d: %w", index, err)
+		}
+		if !info.Mode().IsRegular() || info.Size() != part.Size {
+			return fmt.Errorf("sqlite bundle part file %d must be a %d-byte regular file", index, part.Size)
+		}
+	}
+	return nil
 }
 
 func (c *Client) StartGitHubLogin(ctx context.Context, pollSecretHash string) (LoginStartResult, error) {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -578,11 +578,17 @@ func (c *Client) UploadSQLiteBundleFiles(ctx context.Context, app, archive strin
 	if err != nil {
 		return SQLiteBundleUploadResult{}, err
 	}
-	validatedParts, err := openValidatedSQLiteBundleFiles(ctx, preparedManifest, parts)
+	if preparedManifest.SnapshotID == "" {
+		if err := validateMutableSQLiteBundleFiles(ctx, preparedManifest, parts); err != nil {
+			return SQLiteBundleUploadResult{}, err
+		}
+		return c.uploadMutableSQLiteBundleFiles(ctx, app, archive, preparedManifest, manifestBody, parts)
+	}
+	validatedParts, err := openValidatedSnapshotSQLiteBundleFiles(ctx, preparedManifest, parts)
 	if err != nil {
 		return SQLiteBundleUploadResult{}, err
 	}
-	defer closeValidatedSQLiteBundleFiles(validatedParts)
+	defer closeValidatedSnapshotSQLiteBundleFiles(validatedParts)
 	for _, part := range validatedParts {
 		_, uploadErr := c.UploadSQLiteBundlePart(ctx, app, archive, SQLiteBundlePartUpload{
 			Index:       part.part.Index,
@@ -597,6 +603,53 @@ func (c *Client) UploadSQLiteBundleFiles(ctx context.Context, app, archive strin
 		}
 	}
 	return c.uploadSQLiteBundleManifest(ctx, app, archive, manifestBody)
+}
+
+func (c *Client) uploadMutableSQLiteBundleFiles(
+	ctx context.Context,
+	app, archive string,
+	manifest SQLiteBundleManifest,
+	manifestBody []byte,
+	parts []SQLiteBundlePartFile,
+) (SQLiteBundleUploadResult, error) {
+	for index, part := range parts {
+		expected := manifest.Parts[index]
+		file, err := os.Open(part.Path)
+		if err != nil {
+			return SQLiteBundleUploadResult{}, fmt.Errorf("open sqlite bundle part %d: %w", index, err)
+		}
+		hash := sha256.New()
+		var streamed byteCounter
+		_, uploadErr := c.UploadSQLiteBundlePart(ctx, app, archive, SQLiteBundlePartUpload{
+			Index:       expected.Index,
+			Body:        io.TeeReader(file, io.MultiWriter(hash, &streamed)),
+			Size:        expected.Size,
+			SHA256:      expected.SHA256,
+			Compression: SQLiteGzipCompression,
+		})
+		closeErr := file.Close()
+		if uploadErr != nil {
+			return SQLiteBundleUploadResult{}, uploadErr
+		}
+		if closeErr != nil {
+			return SQLiteBundleUploadResult{}, fmt.Errorf("close sqlite bundle part %d: %w", index, closeErr)
+		}
+		if int64(streamed) != expected.Size ||
+			!strings.EqualFold(fmt.Sprintf("%x", hash.Sum(nil)), expected.SHA256) {
+			return SQLiteBundleUploadResult{}, fmt.Errorf(
+				"sqlite bundle part file %d changed during upload",
+				index,
+			)
+		}
+	}
+	return c.uploadSQLiteBundleManifest(ctx, app, archive, manifestBody)
+}
+
+type byteCounter int64
+
+func (counter *byteCounter) Write(p []byte) (int, error) {
+	*counter += byteCounter(len(p))
+	return len(p), nil
 }
 
 func (c *Client) UploadSQLiteBundleManifest(ctx context.Context, app, archive string, manifest SQLiteBundleManifest) (SQLiteBundleUploadResult, error) {
@@ -642,13 +695,28 @@ func prepareSQLiteBundleManifest(app, archive string, manifest SQLiteBundleManif
 		return SQLiteBundleManifest{}, nil, fmt.Errorf("encode sqlite bundle manifest: %w", err)
 	}
 	body := buf.Bytes()
-	if int64(len(body)) > maxSQLiteBundleManifestBytes {
-		return SQLiteBundleManifest{}, nil, fmt.Errorf(
-			"sqlite bundle manifest must not exceed %d bytes",
-			maxSQLiteBundleManifestBytes,
-		)
+	if err := validateSQLiteBundleManifestSize(
+		int64(len(body)),
+		manifest.SnapshotID != "",
+	); err != nil {
+		return SQLiteBundleManifest{}, nil, err
 	}
 	return manifest, body, nil
+}
+
+func sqliteBundleManifestSizeLimit(snapshotScoped bool) int64 {
+	if snapshotScoped {
+		return maxSQLiteSnapshotBundleManifestBytes
+	}
+	return maxSQLiteMutableBundleManifestBytes
+}
+
+func validateSQLiteBundleManifestSize(size int64, snapshotScoped bool) error {
+	maxBodySize := sqliteBundleManifestSizeLimit(snapshotScoped)
+	if size > maxBodySize {
+		return fmt.Errorf("sqlite bundle manifest must not exceed %d bytes", maxBodySize)
+	}
+	return nil
 }
 
 func validateSQLiteBundleManifest(manifest SQLiteBundleManifest, app, archive string) error {
@@ -788,9 +856,15 @@ func validateSQLiteBundlePartLimit(index int, size int64, snapshotScoped bool) e
 	if snapshotScoped && index >= maxSQLiteBundleParts {
 		return fmt.Errorf("sqlite bundle part index must be between 0 and %d", maxSQLiteBundleParts-1)
 	}
-	maxSize := DefaultSQLiteBundleChunkSize
-	if size <= 0 || size > maxSize {
-		return fmt.Errorf("sqlite bundle part %d size must be between 1 and %d bytes", index, maxSize)
+	if size <= 0 {
+		return fmt.Errorf("sqlite bundle part %d size must be positive", index)
+	}
+	if snapshotScoped && size > DefaultSQLiteBundleChunkSize {
+		return fmt.Errorf(
+			"sqlite bundle part %d size must be between 1 and %d bytes",
+			index,
+			DefaultSQLiteBundleChunkSize,
+		)
 	}
 	return nil
 }
@@ -803,7 +877,10 @@ func validateSQLiteBundleManifestLimits(manifest SQLiteBundleManifest) error {
 	if snapshotScoped && len(manifest.Parts) > maxSQLiteBundleParts {
 		return fmt.Errorf("sqlite bundle manifest must contain between 1 and %d parts", maxSQLiteBundleParts)
 	}
-	if manifest.Object.Size <= 0 || manifest.Object.Size > maxSQLiteBundleObjectSize {
+	if manifest.Object.Size <= 0 {
+		return fmt.Errorf("sqlite bundle object size must be positive")
+	}
+	if snapshotScoped && manifest.Object.Size > maxSQLiteBundleObjectSize {
 		return fmt.Errorf("sqlite bundle object size must be between 1 and %d bytes", maxSQLiteBundleObjectSize)
 	}
 	if manifest.CompressedObject.Size <= 0 {
@@ -839,19 +916,22 @@ func validateSQLiteBundleManifestLimits(manifest SQLiteBundleManifest) error {
 	return nil
 }
 
-type validatedSQLiteBundlePartFile struct {
+type validatedSnapshotSQLiteBundlePartFile struct {
 	part    SQLiteBundlePart
 	file    *os.File
 	tempDir string
 }
 
-func openValidatedSQLiteBundleFiles(
+func openValidatedSnapshotSQLiteBundleFiles(
 	ctx context.Context,
 	manifest SQLiteBundleManifest,
 	parts []SQLiteBundlePartFile,
-) (_ []validatedSQLiteBundlePartFile, err error) {
+) (_ []validatedSnapshotSQLiteBundlePartFile, err error) {
 	if err := validateSQLiteBundleManifest(manifest, manifest.App, manifest.Archive); err != nil {
 		return nil, err
+	}
+	if manifest.SnapshotID == "" {
+		return nil, fmt.Errorf("sqlite bundle snapshot id is required for immutable upload staging")
 	}
 	if len(parts) != len(manifest.Parts) {
 		return nil, fmt.Errorf("sqlite bundle has %d part files, want %d", len(parts), len(manifest.Parts))
@@ -860,10 +940,10 @@ func openValidatedSQLiteBundleFiles(
 	if err != nil {
 		return nil, fmt.Errorf("create sqlite bundle upload snapshot: %w", err)
 	}
-	validated := make([]validatedSQLiteBundlePartFile, 0, len(parts))
+	validated := make([]validatedSnapshotSQLiteBundlePartFile, 0, len(parts))
 	defer func() {
 		if err != nil {
-			closeValidatedSQLiteBundleFiles(validated)
+			closeValidatedSnapshotSQLiteBundleFiles(validated)
 			_ = os.RemoveAll(tempDir)
 		}
 	}()
@@ -876,18 +956,36 @@ func openValidatedSQLiteBundleFiles(
 		if err != nil {
 			return nil, err
 		}
-		validated = append(validated, validatedSQLiteBundlePartFile{
+		validated = append(validated, validatedSnapshotSQLiteBundlePartFile{
 			part:    expected,
 			file:    snapshot,
 			tempDir: tempDir,
 		})
 	}
-	if manifest.SnapshotID != "" {
-		if err := validateSnapshotSQLiteBundleContent(ctx, manifest, validated); err != nil {
-			return nil, err
-		}
+	if err := validateSnapshotSQLiteBundleContent(ctx, manifest, validated); err != nil {
+		return nil, err
 	}
 	return validated, nil
+}
+
+func validateMutableSQLiteBundleFiles(
+	ctx context.Context,
+	manifest SQLiteBundleManifest,
+	parts []SQLiteBundlePartFile,
+) error {
+	if len(parts) != len(manifest.Parts) {
+		return fmt.Errorf("sqlite bundle has %d part files, want %d", len(parts), len(manifest.Parts))
+	}
+	for index, part := range parts {
+		expected := manifest.Parts[index]
+		if part.SQLiteBundlePart != expected {
+			return fmt.Errorf("sqlite bundle part file %d does not match the manifest", index)
+		}
+		if err := copyValidatedSQLiteBundlePart(ctx, index, part, io.Discard); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func snapshotSQLiteBundlePart(
@@ -896,18 +994,6 @@ func snapshotSQLiteBundlePart(
 	index int,
 	part SQLiteBundlePartFile,
 ) (_ *os.File, err error) {
-	source, err := os.Open(part.Path)
-	if err != nil {
-		return nil, fmt.Errorf("open sqlite bundle part %d: %w", index, err)
-	}
-	defer func() { _ = source.Close() }()
-	infoBefore, err := source.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("stat sqlite bundle part %d: %w", index, err)
-	}
-	if !infoBefore.Mode().IsRegular() || infoBefore.Size() != part.Size {
-		return nil, fmt.Errorf("sqlite bundle part file %d must be a %d-byte regular file", index, part.Size)
-	}
 	snapshotPath := filepath.Join(tempDir, fmt.Sprintf("part-%04d", index))
 	snapshot, err := os.OpenFile(snapshotPath, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
 	if err != nil {
@@ -918,21 +1004,8 @@ func snapshotSQLiteBundlePart(
 			_ = snapshot.Close()
 		}
 	}()
-	hash := sha256.New()
-	size, err := copyWithContext(ctx, io.MultiWriter(snapshot, hash), source)
-	if err != nil {
-		return nil, fmt.Errorf("snapshot sqlite bundle part %d: %w", index, err)
-	}
-	infoAfter, err := source.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("restat sqlite bundle part %d: %w", index, err)
-	}
-	if !os.SameFile(infoBefore, infoAfter) || infoAfter.Size() != part.Size || size != part.Size {
-		return nil, fmt.Errorf("sqlite bundle part file %d changed during validation", index)
-	}
-	actualSHA256 := fmt.Sprintf("%x", hash.Sum(nil))
-	if !strings.EqualFold(actualSHA256, part.SHA256) {
-		return nil, fmt.Errorf("sqlite bundle part file %d sha256 does not match the manifest", index)
+	if err := copyValidatedSQLiteBundlePart(ctx, index, part, snapshot); err != nil {
+		return nil, err
 	}
 	if err := snapshot.Sync(); err != nil {
 		return nil, fmt.Errorf("sync sqlite bundle part snapshot %d: %w", index, err)
@@ -947,10 +1020,47 @@ func snapshotSQLiteBundlePart(
 	return snapshot, nil
 }
 
+func copyValidatedSQLiteBundlePart(
+	ctx context.Context,
+	index int,
+	part SQLiteBundlePartFile,
+	dst io.Writer,
+) error {
+	source, err := os.Open(part.Path)
+	if err != nil {
+		return fmt.Errorf("open sqlite bundle part %d: %w", index, err)
+	}
+	defer func() { _ = source.Close() }()
+	infoBefore, err := source.Stat()
+	if err != nil {
+		return fmt.Errorf("stat sqlite bundle part %d: %w", index, err)
+	}
+	if !infoBefore.Mode().IsRegular() || infoBefore.Size() != part.Size {
+		return fmt.Errorf("sqlite bundle part file %d must be a %d-byte regular file", index, part.Size)
+	}
+	hash := sha256.New()
+	size, err := copyWithContext(ctx, io.MultiWriter(dst, hash), source)
+	if err != nil {
+		return fmt.Errorf("validate sqlite bundle part %d: %w", index, err)
+	}
+	infoAfter, err := source.Stat()
+	if err != nil {
+		return fmt.Errorf("restat sqlite bundle part %d: %w", index, err)
+	}
+	if !os.SameFile(infoBefore, infoAfter) || infoAfter.Size() != part.Size || size != part.Size {
+		return fmt.Errorf("sqlite bundle part file %d changed during validation", index)
+	}
+	actualSHA256 := fmt.Sprintf("%x", hash.Sum(nil))
+	if !strings.EqualFold(actualSHA256, part.SHA256) {
+		return fmt.Errorf("sqlite bundle part file %d sha256 does not match the manifest", index)
+	}
+	return nil
+}
+
 func validateSnapshotSQLiteBundleContent(
 	ctx context.Context,
 	manifest SQLiteBundleManifest,
-	parts []validatedSQLiteBundlePartFile,
+	parts []validatedSnapshotSQLiteBundlePartFile,
 ) error {
 	compressedHash := sha256.New()
 	var compressedSize int64
@@ -996,7 +1106,7 @@ func validateSnapshotSQLiteBundleContent(
 	return rewindValidatedSQLiteBundleFiles(parts)
 }
 
-func rewindValidatedSQLiteBundleFiles(parts []validatedSQLiteBundlePartFile) error {
+func rewindValidatedSQLiteBundleFiles(parts []validatedSnapshotSQLiteBundlePartFile) error {
 	for index, part := range parts {
 		if _, err := part.file.Seek(0, io.SeekStart); err != nil {
 			return fmt.Errorf("rewind sqlite bundle part %d: %w", index, err)
@@ -1005,7 +1115,7 @@ func rewindValidatedSQLiteBundleFiles(parts []validatedSQLiteBundlePartFile) err
 	return nil
 }
 
-func closeValidatedSQLiteBundleFiles(parts []validatedSQLiteBundlePartFile) {
+func closeValidatedSnapshotSQLiteBundleFiles(parts []validatedSnapshotSQLiteBundlePartFile) {
 	tempDirs := map[string]struct{}{}
 	for _, part := range parts {
 		_ = part.file.Close()

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -512,7 +512,7 @@ func (c *Client) UploadSQLiteBundlePart(ctx context.Context, app, archive string
 	if part.SnapshotID != "" && !validSQLiteSnapshotID(part.SnapshotID) {
 		return SQLiteUploadResult{}, errors.New("sqlite bundle snapshot id must be empty or a lowercase sha256 digest")
 	}
-	if err := validateSQLiteBundlePartLimit(part.Index, part.Size, part.SnapshotID != ""); err != nil {
+	if err := validateSQLiteBundlePartLimit(part.Index, part.Size); err != nil {
 		return SQLiteUploadResult{}, err
 	}
 	headers := http.Header{}
@@ -692,14 +692,11 @@ func validSQLiteBundleSHA256(value string, canonical bool) bool {
 	return true
 }
 
-func validateSQLiteBundlePartLimit(index int, size int64, snapshotScoped bool) error {
+func validateSQLiteBundlePartLimit(index int, size int64) error {
 	if index < 0 || index >= maxSQLiteBundleParts {
 		return fmt.Errorf("sqlite bundle part index must be between 0 and %d", maxSQLiteBundleParts-1)
 	}
-	maxSize := DefaultMutableSQLiteBundleChunkSize
-	if snapshotScoped {
-		maxSize = DefaultSQLiteBundleChunkSize
-	}
+	maxSize := DefaultSQLiteBundleChunkSize
 	if size <= 0 || size > maxSize {
 		return fmt.Errorf("sqlite bundle part %d size must be between 1 and %d bytes", index, maxSize)
 	}
@@ -721,7 +718,7 @@ func validateSQLiteBundleManifestLimits(manifest SQLiteBundleManifest) error {
 		if part.Index != index {
 			return fmt.Errorf("sqlite bundle manifest part %d has index %d", index, part.Index)
 		}
-		if err := validateSQLiteBundlePartLimit(part.Index, part.Size, manifest.SnapshotID != ""); err != nil {
+		if err := validateSQLiteBundlePartLimit(part.Index, part.Size); err != nil {
 			return err
 		}
 		if total > maxSQLiteBundleCompressedSize-part.Size {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -16,6 +16,7 @@ import (
 	"path"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/openclaw/crawlkit/control"
 )
@@ -27,7 +28,10 @@ const (
 	ModeHybrid    = "hybrid"
 	ModePublisher = "publisher"
 
-	DefaultTokenEnv = "CRAWL_REMOTE_TOKEN"
+	DefaultTokenEnv                = "CRAWL_REMOTE_TOKEN"
+	maxSQLiteBundleMetadataBytes   = 1024
+	maxSQLiteBundleSafeInteger     = int64(1<<53 - 1)
+	snapshotSQLiteReconstructSteps = "concatenate parts in index order to archive.db.gz, then gzip-decompress to archive.db"
 )
 
 type Config struct {
@@ -445,8 +449,33 @@ func (c *Client) Status(ctx context.Context, app, archive string) (Status, error
 }
 
 func (c *Client) PublishStatus(ctx context.Context, app, archive string) (PublisherStatus, error) {
+	return c.publishStatus(ctx, app, archive, "")
+}
+
+func (c *Client) PublishStatusForSnapshot(ctx context.Context, app, archive, snapshotID string) (PublisherStatus, error) {
+	snapshotID = strings.TrimSpace(snapshotID)
+	if snapshotID == "" {
+		return PublisherStatus{}, errors.New("publish status snapshot id is required")
+	}
+	return c.publishStatus(ctx, app, archive, snapshotID)
+}
+
+func (c *Client) publishStatus(ctx context.Context, app, archive, snapshotID string) (PublisherStatus, error) {
 	var out PublisherStatus
-	err := c.do(ctx, http.MethodGet, archivePath(app, archive, "publish-status"), nil, &out, true)
+	endpoint, err := url.Parse(c.url(archivePath(app, archive, "publish-status")))
+	if err != nil {
+		return out, fmt.Errorf("build publish status URL: %w", err)
+	}
+	if snapshotID != "" {
+		query := endpoint.Query()
+		query.Set("snapshot_id", snapshotID)
+		endpoint.RawQuery = query.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return out, err
+	}
+	err = c.doRequest(ctx, req, false, &out, true)
 	return out, err
 }
 
@@ -622,8 +651,23 @@ func validateSQLiteBundleManifest(manifest SQLiteBundleManifest, app, archive st
 	if manifest.ContentType != "" && manifest.ContentType != "application/vnd.sqlite3" {
 		return errors.New("sqlite bundle content type must be application/vnd.sqlite3 when set")
 	}
+	if manifest.GeneratedAt != "" {
+		if err := validateSQLiteBundleMetadata(manifest.GeneratedAt, "sqlite bundle generated_at"); err != nil {
+			return err
+		}
+	}
 	if manifest.Compression.Algorithm != SQLiteGzipCompression {
 		return fmt.Errorf("sqlite bundle compression must be %q", SQLiteGzipCompression)
+	}
+	if snapshotScoped {
+		if manifest.Reconstruct != "" && manifest.Reconstruct != snapshotSQLiteReconstructSteps {
+			return fmt.Errorf("sqlite bundle reconstruct must be %q", snapshotSQLiteReconstructSteps)
+		}
+		for name := range manifest.Privacy {
+			if err := validateSQLiteBundleMapKey(name, "sqlite bundle privacy key"); err != nil {
+				return err
+			}
+		}
 	}
 	if err := validateSQLiteBundleManifestLimits(manifest); err != nil {
 		return err
@@ -663,12 +707,40 @@ func validateSQLiteBundleManifest(manifest SQLiteBundleManifest, app, archive st
 		}
 	}
 	for name, count := range manifest.Counts {
-		if strings.TrimSpace(name) == "" {
+		if name == "" {
 			return errors.New("sqlite bundle count names must not be empty")
 		}
 		if count < 0 {
 			return fmt.Errorf("sqlite bundle count %q must not be negative", name)
 		}
+		if snapshotScoped {
+			if err := validateSQLiteBundleMapKey(name, "sqlite bundle count name"); err != nil {
+				return err
+			}
+			if count > maxSQLiteBundleSafeInteger {
+				return fmt.Errorf(
+					"sqlite bundle count %q must be a non-negative safe integer",
+					name,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+func validateSQLiteBundleMapKey(value, label string) error {
+	if value == "" {
+		return fmt.Errorf("%s must not be empty", label)
+	}
+	return validateSQLiteBundleMetadata(value, label)
+}
+
+func validateSQLiteBundleMetadata(value, label string) error {
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("%s must be valid UTF-8", label)
+	}
+	if len(value) > maxSQLiteBundleMetadataBytes {
+		return fmt.Errorf("%s must not exceed %d UTF-8 bytes", label, maxSQLiteBundleMetadataBytes)
 	}
 	return nil
 }

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -548,7 +548,7 @@ func (c *Client) UploadSQLiteBundlePart(ctx context.Context, app, archive string
 	if part.SnapshotID != "" && !validSQLiteSnapshotID(part.SnapshotID) {
 		return SQLiteUploadResult{}, errors.New("sqlite bundle snapshot id must be empty or a lowercase sha256 digest")
 	}
-	if err := validateSQLiteBundlePartLimit(part.Index, part.Size); err != nil {
+	if err := validateSQLiteBundlePartLimit(part.Index, part.Size, part.SnapshotID != ""); err != nil {
 		return SQLiteUploadResult{}, err
 	}
 	headers := http.Header{}
@@ -771,8 +771,11 @@ func validSQLiteBundleSHA256(value string, canonical bool) bool {
 	return true
 }
 
-func validateSQLiteBundlePartLimit(index int, size int64) error {
-	if index < 0 || index >= maxSQLiteBundleParts {
+func validateSQLiteBundlePartLimit(index int, size int64, snapshotScoped bool) error {
+	if index < 0 {
+		return fmt.Errorf("sqlite bundle part index must not be negative")
+	}
+	if snapshotScoped && index >= maxSQLiteBundleParts {
 		return fmt.Errorf("sqlite bundle part index must be between 0 and %d", maxSQLiteBundleParts-1)
 	}
 	maxSize := DefaultSQLiteBundleChunkSize
@@ -783,13 +786,20 @@ func validateSQLiteBundlePartLimit(index int, size int64) error {
 }
 
 func validateSQLiteBundleManifestLimits(manifest SQLiteBundleManifest) error {
-	if len(manifest.Parts) == 0 || len(manifest.Parts) > maxSQLiteBundleParts {
+	snapshotScoped := manifest.SnapshotID != ""
+	if len(manifest.Parts) == 0 {
+		return fmt.Errorf("sqlite bundle manifest must contain at least one part")
+	}
+	if snapshotScoped && len(manifest.Parts) > maxSQLiteBundleParts {
 		return fmt.Errorf("sqlite bundle manifest must contain between 1 and %d parts", maxSQLiteBundleParts)
 	}
 	if manifest.Object.Size <= 0 || manifest.Object.Size > maxSQLiteBundleObjectSize {
 		return fmt.Errorf("sqlite bundle object size must be between 1 and %d bytes", maxSQLiteBundleObjectSize)
 	}
-	if manifest.CompressedObject.Size <= 0 || manifest.CompressedObject.Size > maxSQLiteBundleCompressedSize {
+	if manifest.CompressedObject.Size <= 0 {
+		return fmt.Errorf("sqlite bundle compressed size must be positive")
+	}
+	if snapshotScoped && manifest.CompressedObject.Size > maxSQLiteBundleCompressedSize {
 		return fmt.Errorf("sqlite bundle compressed size must be between 1 and %d bytes", maxSQLiteBundleCompressedSize)
 	}
 	var total int64
@@ -797,11 +807,15 @@ func validateSQLiteBundleManifestLimits(manifest SQLiteBundleManifest) error {
 		if part.Index != index {
 			return fmt.Errorf("sqlite bundle manifest part %d has index %d", index, part.Index)
 		}
-		if err := validateSQLiteBundlePartLimit(part.Index, part.Size); err != nil {
+		if err := validateSQLiteBundlePartLimit(part.Index, part.Size, snapshotScoped); err != nil {
 			return err
 		}
-		if total > maxSQLiteBundleCompressedSize-part.Size {
+		if snapshotScoped && total > maxSQLiteBundleCompressedSize-part.Size {
 			return fmt.Errorf("sqlite bundle parts exceed %d compressed bytes", maxSQLiteBundleCompressedSize)
+		}
+		if total > manifest.CompressedObject.Size ||
+			part.Size > manifest.CompressedObject.Size-total {
+			return fmt.Errorf("sqlite bundle part sizes exceed the declared compressed size")
 		}
 		total += part.Size
 	}

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -677,9 +677,13 @@ func (c *Client) uploadMutableSQLiteBundleFiles(
 			_ = file.Close()
 			return SQLiteBundleUploadResult{}, err
 		}
+		uploadBody := &io.LimitedReader{
+			R: bounded,
+			N: validated.localSize,
+		}
 		hash := sha256.New()
 		var streamed byteCounter
-		body := io.TeeReader(bounded, io.MultiWriter(hash, &streamed))
+		body := io.TeeReader(uploadBody, io.MultiWriter(hash, &streamed))
 		_, uploadErr := c.UploadSQLiteBundlePart(ctx, app, archive, SQLiteBundlePartUpload{
 			Index:       expected.Index,
 			Body:        body,
@@ -688,8 +692,12 @@ func (c *Client) uploadMutableSQLiteBundleFiles(
 			Compression: SQLiteGzipCompression,
 		})
 		var drainErr error
+		var growthProbeSize int64
 		if uploadErr == nil {
 			_, drainErr = copyWithContext(ctx, io.Discard, body)
+			if drainErr == nil {
+				growthProbeSize, drainErr = copyWithContext(ctx, io.Discard, bounded)
+			}
 		}
 		infoAfter, statErr := file.Stat()
 		closeErr := file.Close()
@@ -716,6 +724,7 @@ func (c *Client) uploadMutableSQLiteBundleFiles(
 			infoBefore.Size() != validated.localSize ||
 			infoAfter.Size() != validated.localSize ||
 			int64(streamed) != validated.localSize ||
+			growthProbeSize != 0 ||
 			digestChanged {
 			return SQLiteBundleUploadResult{}, fmt.Errorf(
 				"sqlite bundle part file %d changed during upload",

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -535,6 +535,19 @@ func TestBuildSQLiteBundlesRejectEmptySources(t *testing.T) {
 	}
 }
 
+func TestValidateSQLiteBundleSourceSizeBounds(t *testing.T) {
+	for _, size := range []int64{-1, 0, maxSQLiteBundleObjectSize + 1} {
+		if err := validateSQLiteBundleSourceSize(size); err == nil {
+			t.Fatalf("validate size %d succeeded", size)
+		}
+	}
+	for _, size := range []int64{1, maxSQLiteBundleObjectSize} {
+		if err := validateSQLiteBundleSourceSize(size); err != nil {
+			t.Fatalf("validate size %d: %v", size, err)
+		}
+	}
+}
+
 func TestBuildGzipSQLiteBundleRejectsBoundedOutputAndCleansPartialArtifacts(t *testing.T) {
 	sourceDir := t.TempDir()
 	source := filepath.Join(sourceDir, "archive.db")

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -219,6 +219,35 @@ func TestClientPublishStatusForSnapshotReturnsRemoteError(t *testing.T) {
 	}
 }
 
+func TestClientPublishStatusForSnapshotRejectsIgnoredScope(t *testing.T) {
+	requestedSnapshotID := strings.Repeat("a", 64)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("snapshot_id"); got != requestedSnapshotID {
+			t.Fatalf("snapshot id = %q, want %q", got, requestedSnapshotID)
+		}
+		_ = json.NewEncoder(w).Encode(PublisherStatus{
+			App:      "gitcrawl",
+			Archive:  "gitcrawl/openclaw",
+			Snapshot: &ArchiveSnapshot{ID: strings.Repeat("b", 64)},
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Options{Endpoint: server.URL, TokenProvider: StaticToken("secret")})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	_, err = client.PublishStatusForSnapshot(
+		context.Background(),
+		"gitcrawl",
+		"gitcrawl/openclaw",
+		requestedSnapshotID,
+	)
+	if err == nil || !strings.Contains(err.Error(), "publish status returned snapshot") {
+		t.Fatalf("publish status error = %v", err)
+	}
+}
+
 func TestClientArchiveOperations(t *testing.T) {
 	var requests []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1264,7 +1293,10 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
 			partPath := filepath.Join(dir, "part")
-			if err := os.WriteFile(partPath, []byte("compressed"), 0o600); err != nil {
+			partContent := []byte("compressed")
+			partDigest := sha256.Sum256(partContent)
+			expectedPartSHA := fmt.Sprintf("%x", partDigest)
+			if err := os.WriteFile(partPath, partContent, 0o600); err != nil {
 				t.Fatalf("write part: %v", err)
 			}
 			var uploads []string
@@ -1275,7 +1307,7 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 					if r.Header.Get("x-crawl-bundle-part-index") != "0" ||
 						r.Header.Get("content-type") != "application/gzip" ||
 						r.ContentLength != int64(len("compressed")) ||
-						r.Header.Get("x-crawl-content-sha256") != strings.Repeat("d", 64) ||
+						r.Header.Get("x-crawl-content-sha256") != expectedPartSHA ||
 						r.Header.Get("x-crawl-compression") != SQLiteGzipCompression ||
 						r.Header.Get("x-crawl-snapshot-id") != tc.snapshotID {
 						t.Fatalf(
@@ -1338,6 +1370,10 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 				tc.snapshotID,
 				int64(len("compressed")),
 			)
+			partSHA := setTestSQLiteBundlePartContent(&manifest, 0, []byte("compressed"))
+			if partSHA != expectedPartSHA {
+				t.Fatalf("part sha256 = %q, want %q", partSHA, expectedPartSHA)
+			}
 			part := manifest.Parts[0]
 			result, err := client.UploadSQLiteBundleFiles(context.Background(), "gitcrawl", "gitcrawl/openclaw__openclaw", manifest, []SQLiteBundlePartFile{{
 				SQLiteBundlePart: part,
@@ -1352,8 +1388,224 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 			if result.Bundle == nil || result.Bundle.Key != tc.manifestKey() {
 				t.Fatalf("result = %#v", result)
 			}
+			if err := os.Rename(partPath, partPath+".closed"); err != nil {
+				t.Fatalf("part file remained open after upload: %v", err)
+			}
 		})
 	}
+}
+
+func setTestSQLiteBundlePartContent(manifest *SQLiteBundleManifest, index int, content []byte) string {
+	sum := sha256.Sum256(content)
+	value := fmt.Sprintf("%x", sum)
+	part := &manifest.Parts[index]
+	part.SHA256 = value
+	part.Key = SQLiteSnapshotBundlePartKey(
+		manifest.App,
+		manifest.Archive,
+		manifest.SnapshotID,
+		value,
+		index,
+	)
+	if len(manifest.Parts) == 1 {
+		manifest.CompressedObject.SHA256 = value
+		manifest.CompressedObject.Key = SQLiteSnapshotCompressedObjectKey(
+			manifest.App,
+			manifest.Archive,
+			manifest.SnapshotID,
+			value,
+		)
+	}
+	return value
+}
+
+func TestClientRejectsChangedSQLiteBundlePartContentBeforeRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(t *testing.T, path string, content []byte)
+	}{
+		{
+			name: "same-size-mutation",
+			mutate: func(t *testing.T, path string, content []byte) {
+				t.Helper()
+				if err := os.WriteFile(path, content, 0o600); err != nil {
+					t.Fatalf("mutate part: %v", err)
+				}
+			},
+		},
+		{
+			name: "same-size-replacement",
+			mutate: func(t *testing.T, path string, content []byte) {
+				t.Helper()
+				replacement := path + ".replacement"
+				if err := os.WriteFile(replacement, content, 0o600); err != nil {
+					t.Fatalf("write replacement: %v", err)
+				}
+				if err := os.Remove(path); err != nil {
+					t.Fatalf("remove original part: %v", err)
+				}
+				if err := os.Rename(replacement, path); err != nil {
+					t.Fatalf("replace part: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			original := []byte("compressed")
+			changed := []byte("corrupted!")
+			if len(changed) != len(original) {
+				t.Fatal("same-size fixture mismatch")
+			}
+			partPath := filepath.Join(t.TempDir(), "part")
+			if err := os.WriteFile(partPath, original, 0o600); err != nil {
+				t.Fatalf("write part: %v", err)
+			}
+			manifest := testSQLiteBundleManifest(
+				"gitcrawl",
+				"gitcrawl/openclaw__openclaw",
+				"",
+				int64(len(original)),
+			)
+			setTestSQLiteBundlePartContent(&manifest, 0, original)
+			part := manifest.Parts[0]
+			tc.mutate(t, partPath, changed)
+
+			var requests int
+			server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				requests++
+			}))
+			defer server.Close()
+			client, err := NewClient(Options{
+				Endpoint:      server.URL,
+				TokenProvider: StaticToken("secret"),
+			})
+			if err != nil {
+				t.Fatalf("client: %v", err)
+			}
+			_, err = client.UploadSQLiteBundleFiles(
+				context.Background(),
+				manifest.App,
+				manifest.Archive,
+				manifest,
+				[]SQLiteBundlePartFile{{
+					SQLiteBundlePart: part,
+					Path:             partPath,
+				}},
+			)
+			if err == nil || !strings.Contains(err.Error(), "sha256 does not match") {
+				t.Fatalf("upload error = %v", err)
+			}
+			if requests != 0 {
+				t.Fatalf("requests = %d", requests)
+			}
+			if err := os.Rename(partPath, partPath+".closed"); err != nil {
+				t.Fatalf("part file remained open after failed preflight: %v", err)
+			}
+		})
+	}
+}
+
+func TestOpenValidatedSQLiteBundleFilesRetainsValidatedHandles(t *testing.T) {
+	original := []byte("compressed")
+	replacement := []byte("corrupted!")
+	partPath := filepath.Join(t.TempDir(), "part")
+	if err := os.WriteFile(partPath, original, 0o600); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+	manifest := testSQLiteBundleManifest(
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		"",
+		int64(len(original)),
+	)
+	setTestSQLiteBundlePartContent(&manifest, 0, original)
+	parts, err := openValidatedSQLiteBundleFiles(
+		context.Background(),
+		manifest,
+		[]SQLiteBundlePartFile{{
+			SQLiteBundlePart: manifest.Parts[0],
+			Path:             partPath,
+		}},
+	)
+	if err != nil {
+		t.Fatalf("open validated parts: %v", err)
+	}
+	defer closeValidatedSQLiteBundleFiles(parts)
+
+	replacementPath := partPath + ".replacement"
+	if err := os.WriteFile(replacementPath, replacement, 0o600); err != nil {
+		t.Fatalf("write replacement: %v", err)
+	}
+	if err := os.Remove(partPath); err != nil {
+		t.Fatalf("remove original path: %v", err)
+	}
+	if err := os.Rename(replacementPath, partPath); err != nil {
+		t.Fatalf("replace part path: %v", err)
+	}
+	body, err := io.ReadAll(parts[0].file)
+	if err != nil {
+		t.Fatalf("read retained part: %v", err)
+	}
+	if !bytes.Equal(body, original) {
+		t.Fatalf("retained part = %q, want %q", body, original)
+	}
+}
+
+func TestOpenValidatedSQLiteBundleFilesClosesHandlesOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "part-0")
+	secondPath := filepath.Join(dir, "part-1")
+	firstContent := []byte("first-part")
+	secondContent := []byte("second-par")
+	for path, content := range map[string][]byte{
+		firstPath:  firstContent,
+		secondPath: secondContent,
+	} {
+		if err := os.WriteFile(path, content, 0o600); err != nil {
+			t.Fatalf("write %s: %v", filepath.Base(path), err)
+		}
+	}
+	manifest := testSQLiteBundleManifest(
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		"",
+		int64(len(firstContent)),
+		int64(len(secondContent)),
+	)
+	setTestSQLiteBundlePartContent(&manifest, 0, firstContent)
+	setTestSQLiteBundlePartContent(&manifest, 1, []byte("other-data"))
+	partFiles := []SQLiteBundlePartFile{
+		{SQLiteBundlePart: manifest.Parts[0], Path: firstPath},
+		{SQLiteBundlePart: manifest.Parts[1], Path: secondPath},
+	}
+	before, countable := openFileDescriptorCount()
+	for range 32 {
+		_, err := openValidatedSQLiteBundleFiles(context.Background(), manifest, partFiles)
+		if err == nil || !strings.Contains(err.Error(), "sha256 does not match") {
+			t.Fatalf("validation error = %v", err)
+		}
+	}
+	if countable {
+		after, _ := openFileDescriptorCount()
+		if after != before {
+			t.Fatalf("open descriptors = %d, want %d", after, before)
+		}
+	}
+	for _, path := range []string{firstPath, secondPath} {
+		if err := os.Rename(path, path+".closed"); err != nil {
+			t.Fatalf("%s remained open after failed preflight: %v", filepath.Base(path), err)
+		}
+	}
+}
+
+func openFileDescriptorCount() (int, bool) {
+	for _, dir := range []string{"/proc/self/fd", "/dev/fd"} {
+		entries, err := os.ReadDir(dir)
+		if err == nil {
+			return len(entries), true
+		}
+	}
+	return 0, false
 }
 
 func TestSQLiteBundleUploadLimitsMatchRemoteContract(t *testing.T) {
@@ -1472,6 +1724,14 @@ func TestClientPreflightsCompleteSQLiteBundleManifestBeforePartUploads(t *testin
 				manifest.Reconstruct = "concatenate the parts somehow"
 			},
 			wantErr: "sqlite bundle reconstruct must be",
+		},
+		{
+			name:       "snapshot-generated-at",
+			snapshotID: strings.Repeat("c", 64),
+			mutate: func(manifest *SQLiteBundleManifest) {
+				manifest.GeneratedAt = "2026-07-12T15:00:00Z"
+			},
+			wantErr: "snapshot sqlite bundle generated_at must be omitted",
 		},
 		{
 			name:       "empty-snapshot-privacy-key",

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -476,6 +476,12 @@ func TestBuildGzipSQLiteBundlePreservesCurrentKeyLayout(t *testing.T) {
 	assertSQLiteBundlePayload(t, compressed.String(), payload)
 }
 
+func TestDefaultSQLiteBundleChunkSizeMatchesRemoteUploadLimit(t *testing.T) {
+	if got, want := DefaultSQLiteBundleChunkSize, int64(64*1024*1024); got != want {
+		t.Fatalf("default sqlite bundle chunk size = %d, want %d", got, want)
+	}
+}
+
 func TestBuildSnapshotGzipSQLiteBundleUsesSnapshotKeyLayout(t *testing.T) {
 	dir := t.TempDir()
 	source := filepath.Join(dir, "archive.db")
@@ -796,13 +802,15 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 				case "bundle-part":
 					if r.Header.Get("x-crawl-bundle-part-index") != "0" ||
 						r.Header.Get("content-type") != "application/gzip" ||
+						r.ContentLength != int64(len("compressed")) ||
 						r.Header.Get("x-crawl-content-sha256") != strings.Repeat("d", 64) ||
 						r.Header.Get("x-crawl-compression") != SQLiteGzipCompression ||
 						r.Header.Get("x-crawl-snapshot-id") != tc.snapshotID {
 						t.Fatalf(
-							"part headers index=%q content-type=%q sha=%q compression=%q snapshot=%q",
+							"part headers index=%q content-type=%q length=%d sha=%q compression=%q snapshot=%q",
 							r.Header.Get("x-crawl-bundle-part-index"),
 							r.Header.Get("content-type"),
+							r.ContentLength,
 							r.Header.Get("x-crawl-content-sha256"),
 							r.Header.Get("x-crawl-compression"),
 							r.Header.Get("x-crawl-snapshot-id"),

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -927,13 +927,35 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 			if err != nil {
 				t.Fatalf("client: %v", err)
 			}
+			part := SQLiteBundlePart{
+				Index:  0,
+				Key:    SQLiteBundlePartKey("gitcrawl", "gitcrawl/openclaw__openclaw", 0),
+				Size:   int64(len("compressed")),
+				SHA256: strings.Repeat("d", 64),
+			}
+			if tc.snapshotID != "" {
+				part.Key = SQLiteSnapshotBundlePartKey(
+					"gitcrawl",
+					"gitcrawl/openclaw__openclaw",
+					tc.snapshotID,
+					part.SHA256,
+					part.Index,
+				)
+			}
 			result, err := client.UploadSQLiteBundleFiles(context.Background(), "gitcrawl", "gitcrawl/openclaw__openclaw", SQLiteBundleManifest{
 				Format:     SQLiteGzipChunkedBundleFormat,
 				App:        "gitcrawl",
 				Archive:    "gitcrawl/openclaw__openclaw",
 				SnapshotID: tc.snapshotID,
+				Object: SQLiteBundleObject{
+					Size: int64(len("uncompressed")),
+				},
+				CompressedObject: SQLiteBundleObject{
+					Size: part.Size,
+				},
+				Parts: []SQLiteBundlePart{part},
 			}, []SQLiteBundlePartFile{{
-				SQLiteBundlePart: SQLiteBundlePart{Index: 0, Size: int64(len("compressed")), SHA256: strings.Repeat("d", 64)},
+				SQLiteBundlePart: part,
 				Path:             partPath,
 			}})
 			if err != nil {
@@ -946,6 +968,104 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 				t.Fatalf("result = %#v", result)
 			}
 		})
+	}
+}
+
+func TestSQLiteBundleUploadLimitsMatchRemoteContract(t *testing.T) {
+	manifest := func(snapshotScoped bool, sizes ...int64) SQLiteBundleManifest {
+		snapshotID := ""
+		if snapshotScoped {
+			snapshotID = strings.Repeat("a", 64)
+		}
+		parts := make([]SQLiteBundlePart, len(sizes))
+		var total int64
+		for index, size := range sizes {
+			parts[index] = SQLiteBundlePart{Index: index, Size: size}
+			total += size
+		}
+		return SQLiteBundleManifest{
+			SnapshotID:       snapshotID,
+			Object:           SQLiteBundleObject{Size: 1},
+			CompressedObject: SQLiteBundleObject{Size: total},
+			Parts:            parts,
+		}
+	}
+
+	for _, tc := range []struct {
+		name     string
+		manifest SQLiteBundleManifest
+		wantErr  string
+	}{
+		{
+			name:     "mutable-boundary",
+			manifest: manifest(false, DefaultMutableSQLiteBundleChunkSize),
+		},
+		{
+			name:     "snapshot-compatibility-boundary",
+			manifest: manifest(true, DefaultSQLiteBundleChunkSize),
+		},
+		{
+			name:     "mutable-part-too-large",
+			manifest: manifest(false, DefaultMutableSQLiteBundleChunkSize+1),
+			wantErr:  "part 0 size",
+		},
+		{
+			name:     "snapshot-part-too-large",
+			manifest: manifest(true, DefaultSQLiteBundleChunkSize+1),
+			wantErr:  "part 0 size",
+		},
+		{
+			name:     "too-many-parts",
+			manifest: manifest(false, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+			wantErr:  "between 1 and 8 parts",
+		},
+		{
+			name:     "compressed-total-too-large",
+			manifest: manifest(true, DefaultSQLiteBundleChunkSize, DefaultSQLiteBundleChunkSize, 1),
+			wantErr:  "compressed size",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSQLiteBundleManifestLimits(tc.manifest)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validate limits: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("validate limits err = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestClientRejectsOversizedSQLiteBundleBeforeRequest(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		t.Fatalf("unexpected request")
+	}))
+	defer server.Close()
+	client, err := NewClient(Options{Endpoint: server.URL, TokenProvider: StaticToken("secret")})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if _, err := client.UploadSQLiteBundlePart(context.Background(), "gitcrawl", "archive", SQLiteBundlePartUpload{
+		Body: strings.NewReader("x"),
+		Size: DefaultMutableSQLiteBundleChunkSize + 1,
+	}); err == nil || !strings.Contains(err.Error(), "part 0 size") {
+		t.Fatalf("mutable part upload err = %v", err)
+	}
+	if _, err := client.UploadSQLiteBundlePart(context.Background(), "gitcrawl", "archive", SQLiteBundlePartUpload{
+		Body:       strings.NewReader("x"),
+		Size:       DefaultSQLiteBundleChunkSize + 1,
+		SnapshotID: strings.Repeat("a", 64),
+	}); err == nil || !strings.Contains(err.Error(), "part 0 size") {
+		t.Fatalf("snapshot part upload err = %v", err)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d", requests)
 	}
 }
 

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -31,6 +32,42 @@ type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+type marshalerProbe struct {
+	called *bool
+}
+
+func (probe marshalerProbe) MarshalJSON() ([]byte, error) {
+	*probe.called = true
+	return bytes.Repeat([]byte("x"), int(maxSQLiteMutableBundleManifestBytes)*2), nil
+}
+
+type appendOnWrite struct {
+	dst      io.Writer
+	path     string
+	tail     []byte
+	appended bool
+	written  int64
+}
+
+func (writer *appendOnWrite) Write(p []byte) (int, error) {
+	n, err := writer.dst.Write(p)
+	writer.written += int64(n)
+	if err != nil || writer.appended {
+		return n, err
+	}
+	writer.appended = true
+	file, openErr := os.OpenFile(writer.path, os.O_WRONLY|os.O_APPEND, 0)
+	if openErr != nil {
+		return n, openErr
+	}
+	_, writeErr := file.Write(writer.tail)
+	closeErr := file.Close()
+	if writeErr != nil {
+		return n, writeErr
+	}
+	return n, closeErr
 }
 
 func TestConfigNormalizeAndEnabled(t *testing.T) {
@@ -163,8 +200,8 @@ func TestClientPublishStatusForSnapshotUsesEncodedQuery(t *testing.T) {
 	}
 	status, err := client.PublishStatusForSnapshot(
 		context.Background(),
-		"gitcrawl",
-		"gitcrawl/openclaw",
+		" gitcrawl ",
+		" gitcrawl/openclaw ",
 		" "+snapshotID+" ",
 	)
 	if err != nil {
@@ -258,6 +295,57 @@ func TestClientPublishStatusForSnapshotRejectsIgnoredScope(t *testing.T) {
 	)
 	if err == nil || !strings.Contains(err.Error(), "publish status returned snapshot") {
 		t.Fatalf("publish status error = %v", err)
+	}
+}
+
+func TestClientPublishStatusForSnapshotRejectsWrongRoute(t *testing.T) {
+	snapshotID := strings.Repeat("a", 64)
+	for _, tc := range []struct {
+		name    string
+		app     string
+		archive string
+	}{
+		{
+			name:    "app",
+			app:     "discrawl",
+			archive: "gitcrawl/openclaw",
+		},
+		{
+			name:    "archive",
+			app:     "gitcrawl",
+			archive: "gitcrawl/other",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.URL.Query().Get("snapshot_id"); got != snapshotID {
+					t.Fatalf("snapshot id = %q, want %q", got, snapshotID)
+				}
+				_ = json.NewEncoder(w).Encode(PublisherStatus{
+					App:      tc.app,
+					Archive:  tc.archive,
+					Snapshot: &ArchiveSnapshot{ID: snapshotID},
+				})
+			}))
+			defer server.Close()
+
+			client, err := NewClient(Options{
+				Endpoint:      server.URL,
+				TokenProvider: StaticToken("secret"),
+			})
+			if err != nil {
+				t.Fatalf("client: %v", err)
+			}
+			_, err = client.PublishStatusForSnapshot(
+				context.Background(),
+				" gitcrawl ",
+				" gitcrawl/openclaw ",
+				snapshotID,
+			)
+			if err == nil || !strings.Contains(err.Error(), "publish status returned route") {
+				t.Fatalf("publish status error = %v", err)
+			}
+		})
 	}
 }
 
@@ -853,6 +941,72 @@ func TestBuildGzipSQLiteBundleRejectsSourceDriftAndCleansArtifacts(t *testing.T)
 	}
 }
 
+func TestBuildGzipSQLiteBundleBoundsGrowingSourceReads(t *testing.T) {
+	payload := bytes.Repeat([]byte("sqlite-source-block-"), 4096)
+	sourcePath := filepath.Join(t.TempDir(), "archive.db")
+	if err := os.WriteFile(sourcePath, payload, 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	tail := bytes.Repeat([]byte("appended-tail"), 256*1024)
+	var copied int64
+	copySource := func(
+		ctx context.Context,
+		dst io.Writer,
+		src io.Reader,
+	) (int64, error) {
+		first := make([]byte, 1)
+		n, err := src.Read(first)
+		if n > 0 {
+			written, writeErr := dst.Write(first[:n])
+			copied += int64(written)
+			if writeErr != nil {
+				return copied, writeErr
+			}
+		}
+		if err != nil && !errors.Is(err, io.EOF) {
+			return copied, err
+		}
+		file, err := os.OpenFile(sourcePath, os.O_WRONLY|os.O_APPEND, 0)
+		if err != nil {
+			return copied, err
+		}
+		if _, err := file.Write(tail); err != nil {
+			_ = file.Close()
+			return copied, err
+		}
+		if err := file.Close(); err != nil {
+			return copied, err
+		}
+		rest, err := copyWithContext(ctx, dst, src)
+		copied += rest
+		return copied, err
+	}
+
+	_, err := buildGzipSQLiteBundleWithSourceCopy(
+		context.Background(),
+		SQLiteBundleBuildOptions{
+			App:              "gitcrawl",
+			Archive:          "gitcrawl/openclaw__openclaw",
+			SourcePath:       sourcePath,
+			WorkDir:          t.TempDir(),
+			ChunkSize:        64 * 1024,
+			CompressionLevel: gzip.NoCompression,
+		},
+		true,
+		sqliteBundleBuildLimits{
+			maxCompressedSize: maxSQLiteBundleCompressedSize,
+			maxParts:          maxSQLiteBundleParts,
+		},
+		copySource,
+	)
+	if err == nil || !strings.Contains(err.Error(), "source changed during bundle construction") {
+		t.Fatalf("build error = %v", err)
+	}
+	if copied != int64(len(payload))+1 {
+		t.Fatalf("source bytes read = %d, want declared size plus one", copied)
+	}
+}
+
 func TestBuildGzipSQLiteBundleRejectsBoundedOutputAndCleansPartialArtifacts(t *testing.T) {
 	sourceDir := t.TempDir()
 	source := filepath.Join(sourceDir, "archive.db")
@@ -978,6 +1132,24 @@ func TestSplitBundlePartsRejectsPartOverflowBeforeCreatingFiles(t *testing.T) {
 	}
 	if len(matches) != 0 {
 		t.Fatalf("unexpected partial parts: %#v", matches)
+	}
+}
+
+func TestSQLiteBundleInitialPartsCapacityIsBounded(t *testing.T) {
+	for _, tc := range []struct {
+		partCount int64
+		want      int
+	}{
+		{partCount: -1, want: 0},
+		{partCount: 0, want: 0},
+		{partCount: 1, want: 1},
+		{partCount: maxSQLiteBundleInitialPartsCapacity, want: maxSQLiteBundleInitialPartsCapacity},
+		{partCount: maxSQLiteBundleInitialPartsCapacity + 1, want: maxSQLiteBundleInitialPartsCapacity},
+		{partCount: 1 << 40, want: maxSQLiteBundleInitialPartsCapacity},
+	} {
+		if got := sqliteBundleInitialPartsCapacity(tc.partCount); got != tc.want {
+			t.Fatalf("capacity(%d) = %d, want %d", tc.partCount, got, tc.want)
+		}
 	}
 }
 
@@ -1574,6 +1746,9 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 					}
 					_ = json.NewEncoder(w).Encode(SQLiteUploadResult{Complete: true})
 				case "bundle-manifest":
+					if got := r.Header.Get("x-crawl-snapshot-id"); got != snapshotID {
+						t.Fatalf("manifest snapshot header = %q, want %q", got, snapshotID)
+					}
 					body, err := io.ReadAll(r.Body)
 					if err != nil {
 						t.Fatalf("read manifest: %v", err)
@@ -1626,6 +1801,73 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 				t.Fatalf("part file remained open after upload: %v", err)
 			}
 		})
+	}
+}
+
+func TestClientPreservesMinimalMutableBundleManifestCompatibility(t *testing.T) {
+	content := []byte("compressed")
+	digest := sha256.Sum256(content)
+	part := SQLiteBundlePartFile{
+		SQLiteBundlePart: SQLiteBundlePart{
+			Index:  3,
+			Key:    "legacy-part",
+			Size:   int64(len(content)),
+			SHA256: fmt.Sprintf("%x", digest),
+		},
+		Path: filepath.Join(t.TempDir(), "part"),
+	}
+	if err := os.WriteFile(part.Path, content, 0o600); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+
+	var uploads []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uploads = append(uploads, r.Header.Get("x-crawl-sqlite-upload"))
+		switch r.Header.Get("x-crawl-sqlite-upload") {
+		case "bundle-part":
+			if got := r.Header.Get("x-crawl-bundle-part-index"); got != "3" {
+				t.Fatalf("part index = %q", got)
+			}
+			if _, err := io.Copy(io.Discard, r.Body); err != nil {
+				t.Fatalf("read part: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(SQLiteUploadResult{Complete: true})
+		case "bundle-manifest":
+			var manifest SQLiteBundleManifest
+			if err := json.NewDecoder(r.Body).Decode(&manifest); err != nil {
+				t.Fatalf("decode manifest: %v", err)
+			}
+			if manifest.App != "gitcrawl" ||
+				manifest.Archive != "gitcrawl/openclaw__openclaw" ||
+				manifest.Format != "" ||
+				len(manifest.Parts) != 0 {
+				t.Fatalf("minimal mutable manifest = %#v", manifest)
+			}
+			_ = json.NewEncoder(w).Encode(SQLiteBundleUploadResult{Complete: true})
+		default:
+			t.Fatalf("unexpected upload kind %q", r.Header.Get("x-crawl-sqlite-upload"))
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Options{
+		Endpoint:      server.URL,
+		TokenProvider: StaticToken("secret"),
+	})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if _, err := client.UploadSQLiteBundleFiles(
+		context.Background(),
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		SQLiteBundleManifest{},
+		[]SQLiteBundlePartFile{part},
+	); err != nil {
+		t.Fatalf("upload minimal mutable bundle: %v", err)
+	}
+	if !slices.Equal(uploads, []string{"bundle-part", "bundle-manifest"}) {
+		t.Fatalf("uploads = %#v", uploads)
 	}
 }
 
@@ -1919,6 +2161,156 @@ func TestClientUploadsMutableBundleWithoutTemporaryStaging(t *testing.T) {
 	}
 }
 
+func TestClientMatchesMutablePartFilesByDeclaredIndex(t *testing.T) {
+	contents := [][]byte{[]byte("first-part"), []byte("second-part")}
+	manifest := testSQLiteBundleManifest(
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		"",
+		int64(len(contents[0])),
+		int64(len(contents[1])),
+	)
+	parts := make([]SQLiteBundlePartFile, len(contents))
+	for index, content := range contents {
+		setTestSQLiteBundlePartContent(&manifest, index, content)
+		path := filepath.Join(t.TempDir(), fmt.Sprintf("part-%d", index))
+		if err := os.WriteFile(path, content, 0o600); err != nil {
+			t.Fatalf("write part %d: %v", index, err)
+		}
+		parts[index] = SQLiteBundlePartFile{
+			SQLiteBundlePart: manifest.Parts[index],
+			Path:             path,
+		}
+	}
+	parts[0], parts[1] = parts[1], parts[0]
+
+	var uploaded []int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("x-crawl-sqlite-upload") {
+		case "bundle-part":
+			index, err := strconv.Atoi(r.Header.Get("x-crawl-bundle-part-index"))
+			if err != nil {
+				t.Fatalf("parse part index: %v", err)
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read part %d: %v", index, err)
+			}
+			if !bytes.Equal(body, contents[index]) {
+				t.Fatalf("part %d body = %q", index, body)
+			}
+			uploaded = append(uploaded, index)
+			_ = json.NewEncoder(w).Encode(SQLiteUploadResult{Complete: true})
+		case "bundle-manifest":
+			_ = json.NewEncoder(w).Encode(SQLiteBundleUploadResult{Complete: true})
+		default:
+			t.Fatalf("unexpected upload kind %q", r.Header.Get("x-crawl-sqlite-upload"))
+		}
+	}))
+	defer server.Close()
+	client, err := NewClient(Options{
+		Endpoint:      server.URL,
+		TokenProvider: StaticToken("secret"),
+	})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if _, err := client.UploadSQLiteBundleFiles(
+		context.Background(),
+		manifest.App,
+		manifest.Archive,
+		manifest,
+		parts,
+	); err != nil {
+		t.Fatalf("upload reordered mutable bundle: %v", err)
+	}
+	if !slices.Equal(uploaded, []int{1, 0}) {
+		t.Fatalf("uploaded indexes = %#v", uploaded)
+	}
+}
+
+func TestClientRejectsDuplicateMutablePartIndexesBeforeRequest(t *testing.T) {
+	content := []byte("compressed")
+	manifest := testSQLiteBundleManifest(
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		"",
+		int64(len(content)),
+		int64(len(content)),
+	)
+	setTestSQLiteBundlePartContent(&manifest, 0, content)
+	setTestSQLiteBundlePartContent(&manifest, 1, content)
+	paths := []string{
+		filepath.Join(t.TempDir(), "part-0"),
+		filepath.Join(t.TempDir(), "part-1"),
+	}
+	for _, path := range paths {
+		if err := os.WriteFile(path, content, 0o600); err != nil {
+			t.Fatalf("write part: %v", err)
+		}
+	}
+	baseParts := []SQLiteBundlePartFile{
+		{SQLiteBundlePart: manifest.Parts[0], Path: paths[0]},
+		{SQLiteBundlePart: manifest.Parts[1], Path: paths[1]},
+	}
+
+	for _, tc := range []struct {
+		name     string
+		manifest SQLiteBundleManifest
+		parts    []SQLiteBundlePartFile
+		wantErr  string
+	}{
+		{
+			name: "manifest",
+			manifest: func() SQLiteBundleManifest {
+				value := manifest
+				value.Parts = append([]SQLiteBundlePart(nil), manifest.Parts...)
+				value.Parts[1].Index = value.Parts[0].Index
+				return value
+			}(),
+			parts:   baseParts,
+			wantErr: "manifest repeats part index 0",
+		},
+		{
+			name:     "files",
+			manifest: manifest,
+			parts: []SQLiteBundlePartFile{
+				baseParts[0],
+				{SQLiteBundlePart: manifest.Parts[0], Path: paths[1]},
+			},
+			wantErr: "part files repeat index 0",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var requests int
+			server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				requests++
+			}))
+			defer server.Close()
+			client, err := NewClient(Options{
+				Endpoint:      server.URL,
+				TokenProvider: StaticToken("secret"),
+			})
+			if err != nil {
+				t.Fatalf("client: %v", err)
+			}
+			_, err = client.UploadSQLiteBundleFiles(
+				context.Background(),
+				manifest.App,
+				manifest.Archive,
+				tc.manifest,
+				tc.parts,
+			)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("upload error = %v, want %q", err, tc.wantErr)
+			}
+			if requests != 0 {
+				t.Fatalf("requests = %d", requests)
+			}
+		})
+	}
+}
+
 func TestClientRejectsMutablePartChangedDuringUploadBeforeManifest(t *testing.T) {
 	original := []byte("compressed")
 	changed := []byte("corrupted!")
@@ -1974,6 +2366,85 @@ func TestClientRejectsMutablePartChangedDuringUploadBeforeManifest(t *testing.T)
 	client, err := NewClient(Options{
 		Endpoint:      server.URL,
 		TokenProvider: provider,
+	})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	_, err = client.UploadSQLiteBundleFiles(
+		context.Background(),
+		manifest.App,
+		manifest.Archive,
+		manifest,
+		parts,
+	)
+	if err == nil || !strings.Contains(err.Error(), "changed during upload") {
+		t.Fatalf("upload error = %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want part only", requests)
+	}
+}
+
+func TestClientBoundsMutablePartGrowthDuringUpload(t *testing.T) {
+	content := []byte("compressed")
+	partPath := filepath.Join(t.TempDir(), "part")
+	if err := os.WriteFile(partPath, content, 0o600); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+	manifest := testSQLiteBundleManifest(
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		"",
+		int64(len(content)),
+	)
+	setTestSQLiteBundlePartContent(&manifest, 0, content)
+	parts := []SQLiteBundlePartFile{{
+		SQLiteBundlePart: manifest.Parts[0],
+		Path:             partPath,
+	}}
+
+	var requests int
+	httpClient := &http.Client{Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		requests++
+		if got := r.Header.Get("x-crawl-sqlite-upload"); got != "bundle-part" {
+			t.Fatalf("unexpected upload kind %q", got)
+		}
+		body := make([]byte, len(content))
+		if _, err := io.ReadFull(r.Body, body); err != nil {
+			t.Fatalf("read declared part body: %v", err)
+		}
+		if !bytes.Equal(body, content) {
+			t.Fatalf("part body = %q", body)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"complete":true}`)),
+			Request:    r,
+		}, nil
+	})}
+	appended := false
+	client, err := NewClient(Options{
+		Endpoint:   "https://remote.test",
+		HTTPClient: httpClient,
+		TokenProvider: tokenProviderFunc(func(context.Context) (string, error) {
+			if !appended {
+				appended = true
+				file, err := os.OpenFile(partPath, os.O_WRONLY|os.O_APPEND, 0)
+				if err != nil {
+					return "", err
+				}
+				_, writeErr := file.Write(bytes.Repeat([]byte("tail"), 1024*1024))
+				closeErr := file.Close()
+				if writeErr != nil {
+					return "", writeErr
+				}
+				if closeErr != nil {
+					return "", closeErr
+				}
+			}
+			return "secret", nil
+		}),
 	})
 	if err != nil {
 		t.Fatalf("client: %v", err)
@@ -2100,6 +2571,40 @@ func TestClientRejectsChangedSQLiteBundlePartContentBeforeRequest(t *testing.T) 
 				t.Fatalf("part file remained open after failed preflight: %v", err)
 			}
 		})
+	}
+}
+
+func TestCopyValidatedSQLiteBundlePartBoundsGrowingFileReads(t *testing.T) {
+	content := bytes.Repeat([]byte("compressed"), 1024)
+	path := filepath.Join(t.TempDir(), "part")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+	digest := sha256.Sum256(content)
+	part := SQLiteBundlePartFile{
+		SQLiteBundlePart: SQLiteBundlePart{
+			Index:  0,
+			Size:   int64(len(content)),
+			SHA256: fmt.Sprintf("%x", digest),
+		},
+		Path: path,
+	}
+	writer := &appendOnWrite{
+		dst:  io.Discard,
+		path: path,
+		tail: bytes.Repeat([]byte("appended-tail"), 256*1024),
+	}
+	err := copyValidatedSQLiteBundlePart(
+		context.Background(),
+		0,
+		part,
+		writer,
+	)
+	if err == nil || !strings.Contains(err.Error(), "changed during validation") {
+		t.Fatalf("validation error = %v", err)
+	}
+	if writer.written != int64(len(content))+1 {
+		t.Fatalf("part bytes read = %d, want declared size plus one", writer.written)
 	}
 }
 
@@ -2351,6 +2856,117 @@ func TestSQLiteBundleManifestSizeLimitsMatchAddressingMode(t *testing.T) {
 	}
 }
 
+func TestSQLiteBundleManifestUsesPersistedRepresentation(t *testing.T) {
+	app := "gitcrawl"
+	archive := "gitcrawl/openclaw__openclaw"
+	manifest := testSQLiteBundleManifest(app, archive, strings.Repeat("a", 64), 1)
+	manifest.Privacy["html"] = "<>&"
+	manifest.Privacy["nested"] = map[string]any{
+		"list": []any{
+			nil,
+			true,
+			false,
+			int64(-2),
+			uint64(3),
+			1e-9,
+			json.Number("1.25"),
+			[]byte("bytes"),
+		},
+	}
+
+	size, err := preflightSQLiteBundleManifestEncoding(
+		manifest,
+		maxSQLiteSnapshotBundleManifestBytes,
+	)
+	if err != nil {
+		t.Fatalf("preflight manifest: %v", err)
+	}
+	_, body, err := prepareSQLiteBundleManifest(app, archive, manifest)
+	if err != nil {
+		t.Fatalf("prepare manifest: %v", err)
+	}
+	if int64(len(body)) != size {
+		t.Fatalf("manifest body size = %d, preflight = %d", len(body), size)
+	}
+	if bytes.HasSuffix(body, []byte("\n")) {
+		t.Fatal("persisted manifest representation has a trailing newline")
+	}
+	if !bytes.Contains(body, []byte("\n  \"format\":")) ||
+		!bytes.Contains(body, []byte(`"html": "<>&"`)) {
+		t.Fatalf("manifest body is not crawl-remote persisted JSON:\n%s", body)
+	}
+}
+
+func TestSQLiteBundleManifestRejectsCompactInputThatExpandsPastPersistedLimit(t *testing.T) {
+	app := "gitcrawl"
+	archive := "gitcrawl/openclaw__openclaw"
+	manifest := testSQLiteBundleManifest(app, archive, strings.Repeat("a", 64), 1)
+	manifest.Privacy["padding"] = ""
+
+	compactBase, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal compact base: %v", err)
+	}
+	var prettyBase bytes.Buffer
+	encoder := json.NewEncoder(&prettyBase)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(manifest); err != nil {
+		t.Fatalf("encode pretty base: %v", err)
+	}
+	prettyBytes := bytes.TrimSuffix(prettyBase.Bytes(), []byte("\n"))
+	if len(prettyBytes) <= len(compactBase) {
+		t.Fatalf("pretty base size = %d, compact = %d", len(prettyBytes), len(compactBase))
+	}
+
+	padding := int(maxSQLiteSnapshotBundleManifestBytes) - len(compactBase)
+	if padding <= 0 {
+		t.Fatalf("base manifest already exceeds snapshot limit: %d", len(compactBase))
+	}
+	manifest.Privacy["padding"] = strings.Repeat("x", padding)
+	compact, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal compact manifest: %v", err)
+	}
+	var pretty bytes.Buffer
+	encoder = json.NewEncoder(&pretty)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(manifest); err != nil {
+		t.Fatalf("encode pretty manifest: %v", err)
+	}
+	prettyBytes = bytes.TrimSuffix(pretty.Bytes(), []byte("\n"))
+	if len(compact) != int(maxSQLiteSnapshotBundleManifestBytes) ||
+		len(prettyBytes) <= int(maxSQLiteSnapshotBundleManifestBytes) {
+		t.Fatalf(
+			"fixture sizes compact=%d pretty=%d limit=%d",
+			len(compact),
+			len(prettyBytes),
+			maxSQLiteSnapshotBundleManifestBytes,
+		)
+	}
+	if _, _, err := prepareSQLiteBundleManifest(app, archive, manifest); err == nil ||
+		!strings.Contains(err.Error(), "must not exceed 65536 bytes") {
+		t.Fatalf("prepare compact-expansion manifest error = %v", err)
+	}
+}
+
+func TestSQLiteBundleManifestPreflightDoesNotInvokeCustomMarshalers(t *testing.T) {
+	app := "gitcrawl"
+	archive := "gitcrawl/openclaw__openclaw"
+	manifest := testSQLiteBundleManifest(app, archive, "", 1)
+	called := false
+	manifest.Privacy["payload"] = marshalerProbe{called: &called}
+
+	if _, _, err := prepareSQLiteBundleManifest(app, archive, manifest); err == nil ||
+		!strings.Contains(err.Error(), "unsupported type") {
+		t.Fatalf("prepare custom marshaler error = %v", err)
+	}
+	if called {
+		t.Fatal("custom marshaler was invoked before the manifest allocation bound")
+	}
+}
+
 func TestClientAllowsLegacyMutablePartIndexesBeyondSnapshotLimit(t *testing.T) {
 	var requests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2387,6 +3003,61 @@ func TestClientAllowsLegacyMutablePartIndexesBeyondSnapshotLimit(t *testing.T) {
 	}
 }
 
+func TestClientPreservesUnknownLengthMutablePartTransport(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.ContentLength != -1 {
+			t.Fatalf("content length = %d, want unknown", r.ContentLength)
+		}
+		if !slices.Contains(r.TransferEncoding, "chunked") {
+			t.Fatalf("transfer encoding = %#v", r.TransferEncoding)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if string(body) != "compressed" {
+			t.Fatalf("body = %q", body)
+		}
+		_ = json.NewEncoder(w).Encode(SQLiteUploadResult{Complete: true})
+	}))
+	defer server.Close()
+	client, err := NewClient(Options{
+		Endpoint:      server.URL,
+		TokenProvider: StaticToken("secret"),
+	})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if _, err := client.UploadSQLiteBundlePart(
+		context.Background(),
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		SQLiteBundlePartUpload{
+			Body: strings.NewReader("compressed"),
+			Size: -1,
+		},
+	); err != nil {
+		t.Fatalf("upload unknown-length mutable part: %v", err)
+	}
+	if _, err := client.UploadSQLiteBundlePart(
+		context.Background(),
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		SQLiteBundlePartUpload{
+			Body:       strings.NewReader("compressed"),
+			Size:       -1,
+			SnapshotID: strings.Repeat("a", 64),
+		},
+	); err == nil || !strings.Contains(err.Error(), "size must be non-negative") {
+		t.Fatalf("snapshot unknown-length error = %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d", requests)
+	}
+}
+
 func TestClientPreflightsCompleteSQLiteBundleManifestBeforePartUploads(t *testing.T) {
 	var requests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2417,7 +3088,8 @@ func TestClientPreflightsCompleteSQLiteBundleManifestBeforePartUploads(t *testin
 			wantErr: "unsupported value",
 		},
 		{
-			name: "invalid-schema",
+			name:       "invalid-schema",
+			snapshotID: strings.Repeat("c", 64),
 			mutate: func(manifest *SQLiteBundleManifest) {
 				manifest.Compression.Algorithm = "zstd"
 			},

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -496,6 +496,43 @@ func TestDefaultSQLiteBundleChunkSizeMatchesRemoteUploadLimit(t *testing.T) {
 	if got, want := sqliteBundleChunkSize(DefaultSQLiteBundleChunkSize, true), int64(256*1024*1024); got != want {
 		t.Fatalf("legacy explicit snapshot sqlite bundle chunk size = %d, want %d", got, want)
 	}
+	if got, want := sqliteBundleChunkSize(DefaultSQLiteBundleChunkSize, false), int64(256*1024*1024); got != want {
+		t.Fatalf("legacy explicit mutable sqlite bundle chunk size = %d, want %d", got, want)
+	}
+}
+
+func TestBuildSQLiteBundlesRejectEmptySources(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "archive.db")
+	if err := os.WriteFile(source, nil, 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	for _, tc := range []struct {
+		name  string
+		build func(context.Context, SQLiteBundleBuildOptions) (SQLiteBundleBuild, error)
+	}{
+		{name: "mutable", build: BuildGzipSQLiteBundle},
+		{name: "snapshot", build: BuildSnapshotGzipSQLiteBundle},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			workDir := t.TempDir()
+			_, err := tc.build(context.Background(), SQLiteBundleBuildOptions{
+				App:        "gitcrawl",
+				Archive:    "gitcrawl/openclaw__openclaw",
+				SourcePath: source,
+				WorkDir:    workDir,
+			})
+			if err == nil || !strings.Contains(err.Error(), "object size must be between 1") {
+				t.Fatalf("build err = %v", err)
+			}
+			entries, readErr := os.ReadDir(workDir)
+			if readErr != nil {
+				t.Fatalf("read work dir: %v", readErr)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("bundle temp files created for empty source: %#v", entries)
+			}
+		})
+	}
 }
 
 func TestBuildGzipSQLiteBundleRejectsBoundedOutputAndCleansPartialArtifacts(t *testing.T) {
@@ -603,7 +640,7 @@ func TestBuildGzipSQLiteBundleRejectsOversizedChunkBeforeCreatingTempFiles(t *te
 		Archive:    "gitcrawl/openclaw__openclaw",
 		SourcePath: source,
 		WorkDir:    workDir,
-		ChunkSize:  DefaultMutableSQLiteBundleChunkSize + 1,
+		ChunkSize:  DefaultSQLiteBundleChunkSize + 1,
 	})
 	if err == nil || !strings.Contains(err.Error(), "chunk size must not exceed") {
 		t.Fatalf("build err = %v", err)
@@ -1226,8 +1263,12 @@ func TestSQLiteBundleUploadLimitsMatchRemoteContract(t *testing.T) {
 		wantErr  string
 	}{
 		{
-			name:     "mutable-boundary",
+			name:     "mutable-default-boundary",
 			manifest: manifest(false, DefaultMutableSQLiteBundleChunkSize),
+		},
+		{
+			name:     "legacy-mutable-boundary",
+			manifest: manifest(false, DefaultSQLiteBundleChunkSize),
 		},
 		{
 			name:     "snapshot-compatibility-boundary",
@@ -1235,7 +1276,7 @@ func TestSQLiteBundleUploadLimitsMatchRemoteContract(t *testing.T) {
 		},
 		{
 			name:     "mutable-part-too-large",
-			manifest: manifest(false, DefaultMutableSQLiteBundleChunkSize+1),
+			manifest: manifest(false, DefaultSQLiteBundleChunkSize+1),
 			wantErr:  "part 0 size",
 		},
 		{
@@ -1357,7 +1398,7 @@ func TestClientRejectsOversizedSQLiteBundleBeforeRequest(t *testing.T) {
 	}
 	if _, err := client.UploadSQLiteBundlePart(context.Background(), "gitcrawl", "archive", SQLiteBundlePartUpload{
 		Body: strings.NewReader("x"),
-		Size: DefaultMutableSQLiteBundleChunkSize + 1,
+		Size: DefaultSQLiteBundleChunkSize + 1,
 	}); err == nil || !strings.Contains(err.Error(), "part 0 size") {
 		t.Fatalf("mutable part upload err = %v", err)
 	}

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -1871,6 +1871,135 @@ func TestClientPreservesMinimalMutableBundleManifestCompatibility(t *testing.T) 
 	}
 }
 
+func TestClientPreservesUnknownLengthMutableBundleFileTransport(t *testing.T) {
+	content := []byte("compressed")
+	digest := sha256.Sum256(content)
+	part := SQLiteBundlePartFile{
+		SQLiteBundlePart: SQLiteBundlePart{
+			Index:  3,
+			Key:    "legacy-part",
+			Size:   -1,
+			SHA256: fmt.Sprintf("%x", digest),
+		},
+		Path: filepath.Join(t.TempDir(), "part"),
+	}
+	if err := os.WriteFile(part.Path, content, 0o600); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+
+	var uploads []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uploads = append(uploads, r.Header.Get("x-crawl-sqlite-upload"))
+		switch r.Header.Get("x-crawl-sqlite-upload") {
+		case "bundle-part":
+			if r.ContentLength != -1 {
+				t.Fatalf("content length = %d, want unknown", r.ContentLength)
+			}
+			if got := r.Header.Get("x-crawl-content-sha256"); got != fmt.Sprintf("%x", digest) {
+				t.Fatalf("sha256 header = %q", got)
+			}
+			if !slices.Contains(r.TransferEncoding, "chunked") {
+				t.Fatalf("transfer encoding = %#v", r.TransferEncoding)
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read part: %v", err)
+			}
+			if !bytes.Equal(body, content) {
+				t.Fatalf("part body = %q", body)
+			}
+			_ = json.NewEncoder(w).Encode(SQLiteUploadResult{Complete: true})
+		case "bundle-manifest":
+			_ = json.NewEncoder(w).Encode(SQLiteBundleUploadResult{Complete: true})
+		default:
+			t.Fatalf("unexpected upload kind %q", r.Header.Get("x-crawl-sqlite-upload"))
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Options{
+		Endpoint:      server.URL,
+		TokenProvider: StaticToken("secret"),
+	})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if _, err := client.UploadSQLiteBundleFiles(
+		context.Background(),
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		SQLiteBundleManifest{},
+		[]SQLiteBundlePartFile{part},
+	); err != nil {
+		t.Fatalf("upload unknown-length mutable bundle file: %v", err)
+	}
+	if !slices.Equal(uploads, []string{"bundle-part", "bundle-manifest"}) {
+		t.Fatalf("uploads = %#v", uploads)
+	}
+}
+
+func TestClientAllowsMutableBundleFileWithoutSHA256(t *testing.T) {
+	content := []byte("compressed")
+	part := SQLiteBundlePartFile{
+		SQLiteBundlePart: SQLiteBundlePart{
+			Index: 3,
+			Key:   "legacy-part",
+			Size:  int64(len(content)),
+		},
+		Path: filepath.Join(t.TempDir(), "part"),
+	}
+	if err := os.WriteFile(part.Path, content, 0o600); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+
+	var uploads []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uploads = append(uploads, r.Header.Get("x-crawl-sqlite-upload"))
+		switch r.Header.Get("x-crawl-sqlite-upload") {
+		case "bundle-part":
+			if r.ContentLength != int64(len(content)) {
+				t.Fatalf("content length = %d, want %d", r.ContentLength, len(content))
+			}
+			if got := r.Header.Get("x-crawl-content-sha256"); got != "" {
+				t.Fatalf("sha256 header = %q", got)
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read part: %v", err)
+			}
+			if !bytes.Equal(body, content) {
+				t.Fatalf("part body = %q", body)
+			}
+			_ = json.NewEncoder(w).Encode(SQLiteUploadResult{Complete: true})
+		case "bundle-manifest":
+			_ = json.NewEncoder(w).Encode(SQLiteBundleUploadResult{Complete: true})
+		default:
+			t.Fatalf("unexpected upload kind %q", r.Header.Get("x-crawl-sqlite-upload"))
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Options{
+		Endpoint:      server.URL,
+		TokenProvider: StaticToken("secret"),
+	})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if _, err := client.UploadSQLiteBundleFiles(
+		context.Background(),
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		SQLiteBundleManifest{},
+		[]SQLiteBundlePartFile{part},
+	); err != nil {
+		t.Fatalf("upload mutable bundle file without sha256: %v", err)
+	}
+	if !slices.Equal(uploads, []string{"bundle-part", "bundle-manifest"}) {
+		t.Fatalf("uploads = %#v", uploads)
+	}
+}
+
 func gzipTestPayload(t *testing.T, payload []byte) []byte {
 	t.Helper()
 	var out bytes.Buffer

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -2593,6 +2593,85 @@ func TestClientBoundsMutablePartGrowthDuringUpload(t *testing.T) {
 	}
 }
 
+func TestClientKeepsUnknownLengthGrowthProbeOutOfMutableBundleUpload(t *testing.T) {
+	content := []byte("compressed")
+	partPath := filepath.Join(t.TempDir(), "part")
+	if err := os.WriteFile(partPath, content, 0o600); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+	part := SQLiteBundlePartFile{
+		SQLiteBundlePart: SQLiteBundlePart{
+			Index: 0,
+			Size:  -1,
+		},
+		Path: partPath,
+	}
+
+	var requests int
+	var uploaded []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if got := r.Header.Get("x-crawl-sqlite-upload"); got != "bundle-part" {
+			t.Fatalf("unexpected upload kind %q", got)
+		}
+		if r.ContentLength != -1 {
+			t.Fatalf("content length = %d, want unknown", r.ContentLength)
+		}
+		if !slices.Contains(r.TransferEncoding, "chunked") {
+			t.Fatalf("transfer encoding = %#v", r.TransferEncoding)
+		}
+		var err error
+		uploaded, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read part: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(SQLiteUploadResult{Complete: true})
+	}))
+	defer server.Close()
+
+	appended := false
+	client, err := NewClient(Options{
+		Endpoint: server.URL,
+		TokenProvider: tokenProviderFunc(func(context.Context) (string, error) {
+			if !appended {
+				appended = true
+				file, err := os.OpenFile(partPath, os.O_WRONLY|os.O_APPEND, 0)
+				if err != nil {
+					return "", err
+				}
+				_, writeErr := file.Write(bytes.Repeat([]byte("tail"), 1024*1024))
+				closeErr := file.Close()
+				if writeErr != nil {
+					return "", writeErr
+				}
+				if closeErr != nil {
+					return "", closeErr
+				}
+			}
+			return "secret", nil
+		}),
+	})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	_, err = client.UploadSQLiteBundleFiles(
+		context.Background(),
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		SQLiteBundleManifest{},
+		[]SQLiteBundlePartFile{part},
+	)
+	if err == nil || !strings.Contains(err.Error(), "changed during upload") {
+		t.Fatalf("upload error = %v", err)
+	}
+	if !bytes.Equal(uploaded, content) {
+		t.Fatalf("uploaded part = %q, want original content only", uploaded)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want part only", requests)
+	}
+}
+
 func setTestSQLiteBundlePartContent(manifest *SQLiteBundleManifest, index int, content []byte) string {
 	sum := sha256.Sum256(content)
 	value := fmt.Sprintf("%x", sum)

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -869,6 +869,40 @@ func TestBuildGzipSQLiteBundleRejectsBoundedOutputAndCleansPartialArtifacts(t *t
 	}
 }
 
+func TestBuildGzipSQLiteBundlePreservesLegacyMutablePartCounts(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "archive.db")
+	payload := make([]byte, 4096)
+	for offset := 0; offset < len(payload); offset += sha256.Size {
+		sum := sha256.Sum256([]byte(fmt.Sprintf("legacy-mutable-block-%d", offset)))
+		copy(payload[offset:], sum[:])
+	}
+	if err := os.WriteFile(source, payload, 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	opts := SQLiteBundleBuildOptions{
+		App:              "gitcrawl",
+		Archive:          "gitcrawl/openclaw__openclaw",
+		SourcePath:       source,
+		WorkDir:          t.TempDir(),
+		ChunkSize:        128,
+		CompressionLevel: gzip.NoCompression,
+	}
+	mutable, err := BuildGzipSQLiteBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("build legacy mutable bundle: %v", err)
+	}
+	defer mutable.Cleanup()
+	if len(mutable.Parts) <= maxSQLiteBundleParts {
+		t.Fatalf("mutable parts = %d, want more than %d", len(mutable.Parts), maxSQLiteBundleParts)
+	}
+
+	opts.WorkDir = t.TempDir()
+	_, err = BuildSnapshotGzipSQLiteBundle(context.Background(), opts)
+	if err == nil || !strings.Contains(err.Error(), "requires more than 8 parts") {
+		t.Fatalf("snapshot build error = %v", err)
+	}
+}
+
 func TestSplitBundlePartsRejectsPartOverflowBeforeCreatingFiles(t *testing.T) {
 	dir := t.TempDir()
 	compressedPath := filepath.Join(dir, "current.db.gz")
@@ -1789,12 +1823,25 @@ func TestSQLiteBundleUploadLimitsMatchRemoteContract(t *testing.T) {
 			wantErr:  "part 0 size",
 		},
 		{
-			name:     "too-many-parts",
+			name:     "legacy-mutable-many-parts",
 			manifest: manifest(false, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+		},
+		{
+			name: "legacy-mutable-large-total",
+			manifest: manifest(
+				false,
+				DefaultSQLiteBundleChunkSize,
+				DefaultSQLiteBundleChunkSize,
+				1,
+			),
+		},
+		{
+			name:     "snapshot-too-many-parts",
+			manifest: manifest(true, 1, 1, 1, 1, 1, 1, 1, 1, 1),
 			wantErr:  "between 1 and 8 parts",
 		},
 		{
-			name:     "compressed-total-too-large",
+			name:     "snapshot-compressed-total-too-large",
 			manifest: manifest(true, DefaultSQLiteBundleChunkSize, DefaultSQLiteBundleChunkSize, 1),
 			wantErr:  "compressed size",
 		},
@@ -1815,6 +1862,42 @@ func TestSQLiteBundleUploadLimitsMatchRemoteContract(t *testing.T) {
 				t.Fatalf("validate limits err = %v, want %q", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestClientAllowsLegacyMutablePartIndexesBeyondSnapshotLimit(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if got := r.Header.Get("x-crawl-bundle-part-index"); got != "8" {
+			t.Fatalf("part index = %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(SQLiteUploadResult{Complete: true})
+	}))
+	defer server.Close()
+	client, err := NewClient(Options{
+		Endpoint:      server.URL,
+		TokenProvider: StaticToken("secret"),
+	})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if _, err := client.UploadSQLiteBundlePart(
+		context.Background(),
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		SQLiteBundlePartUpload{
+			Index:       maxSQLiteBundleParts,
+			Body:        strings.NewReader("x"),
+			Size:        1,
+			SHA256:      strings.Repeat("a", 64),
+			Compression: SQLiteGzipCompression,
+		},
+	); err != nil {
+		t.Fatalf("upload legacy mutable part: %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d", requests)
 	}
 }
 

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -21,6 +21,12 @@ import (
 	"time"
 )
 
+type tokenProviderFunc func(context.Context) (string, error)
+
+func (f tokenProviderFunc) Token(ctx context.Context) (string, error) {
+	return f(ctx)
+}
+
 func TestConfigNormalizeAndEnabled(t *testing.T) {
 	cfg := Config{Mode: " Cloud ", Endpoint: "https://remote.test/", Archive: " gitcrawl/openclaw ", Auth: AuthConfig{TokenSource: " Env "}}
 	cfg.Normalize()
@@ -245,6 +251,34 @@ func TestClientPublishStatusForSnapshotRejectsIgnoredScope(t *testing.T) {
 		requestedSnapshotID,
 	)
 	if err == nil || !strings.Contains(err.Error(), "publish status returned snapshot") {
+		t.Fatalf("publish status error = %v", err)
+	}
+}
+
+func TestClientPublishStatusForSnapshotRejectsMissingSnapshot(t *testing.T) {
+	requestedSnapshotID := strings.Repeat("a", 64)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("snapshot_id"); got != requestedSnapshotID {
+			t.Fatalf("snapshot id = %q, want %q", got, requestedSnapshotID)
+		}
+		_ = json.NewEncoder(w).Encode(PublisherStatus{
+			App:     "gitcrawl",
+			Archive: "gitcrawl/openclaw",
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Options{Endpoint: server.URL, TokenProvider: StaticToken("secret")})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	_, err = client.PublishStatusForSnapshot(
+		context.Background(),
+		"gitcrawl",
+		"gitcrawl/openclaw",
+		requestedSnapshotID,
+	)
+	if err == nil || !strings.Contains(err.Error(), "did not return requested snapshot") {
 		t.Fatalf("publish status error = %v", err)
 	}
 }
@@ -1437,30 +1471,48 @@ func TestSQLiteBundleManifestMatchesNegotiatedWireSchema(t *testing.T) {
 
 func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 	for _, tc := range []struct {
-		name        string
-		snapshotID  string
-		manifestKey func() string
+		name           string
+		snapshotScoped bool
 	}{
-		{
-			name: "legacy",
-			manifestKey: func() string {
-				return SQLiteBundleManifestKey("gitcrawl", "gitcrawl/openclaw__openclaw")
-			},
-		},
-		{
-			name:       "snapshot",
-			snapshotID: strings.Repeat("c", 64),
-			manifestKey: func() string {
-				return SQLiteSnapshotBundleManifestKey("gitcrawl", "gitcrawl/openclaw__openclaw", strings.Repeat("c", 64))
-			},
-		},
+		{name: "legacy"},
+		{name: "snapshot", snapshotScoped: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			app := "gitcrawl"
+			archive := "gitcrawl/openclaw__openclaw"
+			objectContent := []byte("SQLite format 3\x00test payload")
+			partContent := []byte("compressed")
+			snapshotID := ""
+			if tc.snapshotScoped {
+				partContent = gzipTestPayload(t, objectContent)
+				objectDigest := sha256.Sum256(objectContent)
+				snapshotID = fmt.Sprintf("%x", objectDigest)
+			}
+			manifest := testSQLiteBundleManifest(
+				app,
+				archive,
+				snapshotID,
+				int64(len(partContent)),
+			)
+			if tc.snapshotScoped {
+				manifest.Object = SQLiteBundleObject{
+					Key:    SQLiteSnapshotObjectKey(app, archive, snapshotID),
+					Size:   int64(len(objectContent)),
+					SHA256: snapshotID,
+				}
+			}
+			expectedPartSHA := setTestSQLiteBundlePartContent(
+				&manifest,
+				0,
+				partContent,
+			)
+			part := manifest.Parts[0]
+			expectedManifestKey := SQLiteBundleManifestKey(app, archive)
+			if tc.snapshotScoped {
+				expectedManifestKey = SQLiteSnapshotBundleManifestKey(app, archive, snapshotID)
+			}
 			dir := t.TempDir()
 			partPath := filepath.Join(dir, "part")
-			partContent := []byte("compressed")
-			partDigest := sha256.Sum256(partContent)
-			expectedPartSHA := fmt.Sprintf("%x", partDigest)
 			if err := os.WriteFile(partPath, partContent, 0o600); err != nil {
 				t.Fatalf("write part: %v", err)
 			}
@@ -1471,10 +1523,10 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 				case "bundle-part":
 					if r.Header.Get("x-crawl-bundle-part-index") != "0" ||
 						r.Header.Get("content-type") != "application/gzip" ||
-						r.ContentLength != int64(len("compressed")) ||
+						r.ContentLength != int64(len(partContent)) ||
 						r.Header.Get("x-crawl-content-sha256") != expectedPartSHA ||
 						r.Header.Get("x-crawl-compression") != SQLiteGzipCompression ||
-						r.Header.Get("x-crawl-snapshot-id") != tc.snapshotID {
+						r.Header.Get("x-crawl-snapshot-id") != snapshotID {
 						t.Fatalf(
 							"part headers index=%q content-type=%q length=%d sha=%q compression=%q snapshot=%q",
 							r.Header.Get("x-crawl-bundle-part-index"),
@@ -1489,8 +1541,8 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 					if err != nil {
 						t.Fatalf("read part body: %v", err)
 					}
-					if string(body) != "compressed" {
-						t.Fatalf("part body = %q", body)
+					if !bytes.Equal(body, partContent) {
+						t.Fatalf("part body differs")
 					}
 					_ = json.NewEncoder(w).Encode(SQLiteUploadResult{Complete: true})
 				case "bundle-manifest":
@@ -1500,7 +1552,7 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 					}
 					wireManifest := decodeStrictSQLiteBundleManifest(t, bytes.NewReader(body))
 					if wireManifest.Format != SQLiteGzipChunkedBundleFormat ||
-						wireManifest.SnapshotID != tc.snapshotID ||
+						wireManifest.SnapshotID != snapshotID ||
 						wireManifest.ContentType != "application/vnd.sqlite3" ||
 						wireManifest.Reconstruct == "" ||
 						wireManifest.Privacy["policy"] != "public-only" ||
@@ -1516,7 +1568,7 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 						Archive:  "gitcrawl/openclaw__openclaw",
 						Complete: true,
 						Bundle: &SQLiteBundle{
-							Key:      tc.manifestKey(),
+							Key:      expectedManifestKey,
 							Manifest: &manifest,
 						},
 					})
@@ -1529,18 +1581,7 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 			if err != nil {
 				t.Fatalf("client: %v", err)
 			}
-			manifest := testSQLiteBundleManifest(
-				"gitcrawl",
-				"gitcrawl/openclaw__openclaw",
-				tc.snapshotID,
-				int64(len("compressed")),
-			)
-			partSHA := setTestSQLiteBundlePartContent(&manifest, 0, []byte("compressed"))
-			if partSHA != expectedPartSHA {
-				t.Fatalf("part sha256 = %q, want %q", partSHA, expectedPartSHA)
-			}
-			part := manifest.Parts[0]
-			result, err := client.UploadSQLiteBundleFiles(context.Background(), "gitcrawl", "gitcrawl/openclaw__openclaw", manifest, []SQLiteBundlePartFile{{
+			result, err := client.UploadSQLiteBundleFiles(context.Background(), app, archive, manifest, []SQLiteBundlePartFile{{
 				SQLiteBundlePart: part,
 				Path:             partPath,
 			}})
@@ -1550,13 +1591,249 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 			if len(uploads) != 2 || uploads[0] != "bundle-part" || uploads[1] != "bundle-manifest" {
 				t.Fatalf("uploads = %#v", uploads)
 			}
-			if result.Bundle == nil || result.Bundle.Key != tc.manifestKey() {
+			if result.Bundle == nil || result.Bundle.Key != expectedManifestKey {
 				t.Fatalf("result = %#v", result)
 			}
 			if err := os.Rename(partPath, partPath+".closed"); err != nil {
 				t.Fatalf("part file remained open after upload: %v", err)
 			}
 		})
+	}
+}
+
+func gzipTestPayload(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	var out bytes.Buffer
+	writer := gzip.NewWriter(&out)
+	if _, err := writer.Write(payload); err != nil {
+		t.Fatalf("gzip payload: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close gzip payload: %v", err)
+	}
+	return out.Bytes()
+}
+
+func testSnapshotSQLiteBundleFiles(
+	t *testing.T,
+	objectContent []byte,
+	compressedContent []byte,
+) (SQLiteBundleManifest, []SQLiteBundlePartFile) {
+	t.Helper()
+	app := "gitcrawl"
+	archive := "gitcrawl/openclaw__openclaw"
+	objectDigest := sha256.Sum256(objectContent)
+	snapshotID := fmt.Sprintf("%x", objectDigest)
+	manifest := testSQLiteBundleManifest(
+		app,
+		archive,
+		snapshotID,
+		int64(len(compressedContent)),
+	)
+	manifest.Object = SQLiteBundleObject{
+		Key:    SQLiteSnapshotObjectKey(app, archive, snapshotID),
+		Size:   int64(len(objectContent)),
+		SHA256: snapshotID,
+	}
+	setTestSQLiteBundlePartContent(&manifest, 0, compressedContent)
+	partPath := filepath.Join(t.TempDir(), "part")
+	if err := os.WriteFile(partPath, compressedContent, 0o600); err != nil {
+		t.Fatalf("write snapshot part: %v", err)
+	}
+	return manifest, []SQLiteBundlePartFile{{
+		SQLiteBundlePart: manifest.Parts[0],
+		Path:             partPath,
+	}}
+}
+
+func setTestSQLiteBundleSnapshotID(
+	manifest *SQLiteBundleManifest,
+	parts []SQLiteBundlePartFile,
+	snapshotID string,
+) {
+	manifest.SnapshotID = snapshotID
+	manifest.Object.SHA256 = snapshotID
+	manifest.Object.Key = SQLiteSnapshotObjectKey(manifest.App, manifest.Archive, snapshotID)
+	manifest.CompressedObject.Key = SQLiteSnapshotCompressedObjectKey(
+		manifest.App,
+		manifest.Archive,
+		snapshotID,
+		manifest.CompressedObject.SHA256,
+	)
+	for index := range manifest.Parts {
+		manifest.Parts[index].Key = SQLiteSnapshotBundlePartKey(
+			manifest.App,
+			manifest.Archive,
+			snapshotID,
+			manifest.Parts[index].SHA256,
+			index,
+		)
+		parts[index].SQLiteBundlePart = manifest.Parts[index]
+	}
+}
+
+func TestClientRejectsInvalidSnapshotBundleAggregatesBeforeRequest(t *testing.T) {
+	objectContent := []byte("SQLite format 3\x00test payload")
+	validCompressed := gzipTestPayload(t, objectContent)
+
+	for _, tc := range []struct {
+		name              string
+		compressedContent []byte
+		mutate            func(*SQLiteBundleManifest, []SQLiteBundlePartFile)
+		wantErr           string
+	}{
+		{
+			name:              "compressed-sha256",
+			compressedContent: validCompressed,
+			mutate: func(manifest *SQLiteBundleManifest, _ []SQLiteBundlePartFile) {
+				manifest.CompressedObject.SHA256 = strings.Repeat("0", 64)
+				manifest.CompressedObject.Key = SQLiteSnapshotCompressedObjectKey(
+					manifest.App,
+					manifest.Archive,
+					manifest.SnapshotID,
+					manifest.CompressedObject.SHA256,
+				)
+			},
+			wantErr: "compressed object does not match",
+		},
+		{
+			name:              "decompressed-sqlite-sha256",
+			compressedContent: validCompressed,
+			mutate: func(manifest *SQLiteBundleManifest, parts []SQLiteBundlePartFile) {
+				setTestSQLiteBundleSnapshotID(manifest, parts, strings.Repeat("0", 64))
+			},
+			wantErr: "decompressed object does not match",
+		},
+		{
+			name:              "malformed-gzip",
+			compressedContent: []byte("not a gzip stream"),
+			mutate:            func(*SQLiteBundleManifest, []SQLiteBundlePartFile) {},
+			wantErr:           "decompress sqlite bundle snapshot",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest, parts := testSnapshotSQLiteBundleFiles(
+				t,
+				objectContent,
+				tc.compressedContent,
+			)
+			tc.mutate(&manifest, parts)
+			var requests int
+			server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				requests++
+			}))
+			defer server.Close()
+			client, err := NewClient(Options{
+				Endpoint:      server.URL,
+				TokenProvider: StaticToken("secret"),
+			})
+			if err != nil {
+				t.Fatalf("client: %v", err)
+			}
+			_, err = client.UploadSQLiteBundleFiles(
+				context.Background(),
+				manifest.App,
+				manifest.Archive,
+				manifest,
+				parts,
+			)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("upload error = %v, want %q", err, tc.wantErr)
+			}
+			if requests != 0 {
+				t.Fatalf("requests = %d", requests)
+			}
+			for _, part := range parts {
+				if err := os.Rename(part.Path, part.Path+".closed"); err != nil {
+					t.Fatalf("part file remained open after failed preflight: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestClientUploadsImmutablePartSnapshotAfterSameInodeMutation(t *testing.T) {
+	original := []byte("compressed")
+	changed := []byte("corrupted!")
+	partPath := filepath.Join(t.TempDir(), "part")
+	if err := os.WriteFile(partPath, original, 0o600); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+	infoBefore, err := os.Stat(partPath)
+	if err != nil {
+		t.Fatalf("stat part: %v", err)
+	}
+	manifest := testSQLiteBundleManifest(
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		"",
+		int64(len(original)),
+	)
+	setTestSQLiteBundlePartContent(&manifest, 0, original)
+	part := manifest.Parts[0]
+
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Header.Get("x-crawl-sqlite-upload") == "bundle-part" {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read part: %v", err)
+			}
+			if !bytes.Equal(body, original) {
+				t.Fatalf("uploaded part = %q, want immutable %q", body, original)
+			}
+			_ = json.NewEncoder(w).Encode(SQLiteUploadResult{Complete: true})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(SQLiteBundleUploadResult{Complete: true})
+	}))
+	defer server.Close()
+	mutated := false
+	provider := tokenProviderFunc(func(context.Context) (string, error) {
+		if !mutated {
+			mutated = true
+			if err := os.WriteFile(partPath, changed, 0o600); err != nil {
+				return "", fmt.Errorf("mutate part: %w", err)
+			}
+			infoAfter, err := os.Stat(partPath)
+			if err != nil {
+				return "", fmt.Errorf("restat part: %w", err)
+			}
+			if !os.SameFile(infoBefore, infoAfter) {
+				return "", fmt.Errorf("part mutation replaced the inode")
+			}
+		}
+		return "secret", nil
+	})
+	client, err := NewClient(Options{
+		Endpoint:      server.URL,
+		TokenProvider: provider,
+	})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if _, err := client.UploadSQLiteBundleFiles(
+		context.Background(),
+		manifest.App,
+		manifest.Archive,
+		manifest,
+		[]SQLiteBundlePartFile{{
+			SQLiteBundlePart: part,
+			Path:             partPath,
+		}},
+	); err != nil {
+		t.Fatalf("upload bundle: %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d", requests)
+	}
+	body, err := os.ReadFile(partPath)
+	if err != nil {
+		t.Fatalf("read mutated source: %v", err)
+	}
+	if !bytes.Equal(body, changed) {
+		t.Fatalf("source part = %q, want mutation %q", body, changed)
 	}
 }
 
@@ -1700,19 +1977,6 @@ func TestOpenValidatedSQLiteBundleFilesRetainsValidatedHandles(t *testing.T) {
 	replacementPath := partPath + ".replacement"
 	if err := os.WriteFile(replacementPath, replacement, 0o600); err != nil {
 		t.Fatalf("write replacement: %v", err)
-	}
-	if runtime.GOOS == "windows" {
-		if err := os.Remove(partPath); err == nil {
-			t.Fatal("Windows replaced a part while its validated handle was retained")
-		}
-		body, err := io.ReadAll(parts[0].file)
-		if err != nil {
-			t.Fatalf("read retained part: %v", err)
-		}
-		if !bytes.Equal(body, original) {
-			t.Fatalf("retained part = %q, want %q", body, original)
-		}
-		return
 	}
 	if err := os.Remove(partPath); err != nil {
 		t.Fatalf("remove original path: %v", err)

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -497,6 +498,125 @@ func TestDefaultSQLiteBundleChunkSizeMatchesRemoteUploadLimit(t *testing.T) {
 	}
 }
 
+func TestBuildGzipSQLiteBundleRejectsBoundedOutputAndCleansPartialArtifacts(t *testing.T) {
+	sourceDir := t.TempDir()
+	source := filepath.Join(sourceDir, "archive.db")
+	payload := make([]byte, 4096)
+	for offset := 0; offset < len(payload); offset += sha256.Size {
+		sum := sha256.Sum256([]byte(fmt.Sprintf("sqlite-bundle-block-%d", offset)))
+		copy(payload[offset:], sum[:])
+	}
+	if err := os.WriteFile(source, payload, 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name      string
+		limits    sqliteBundleBuildLimits
+		chunkSize int64
+		wantErr   string
+	}{
+		{
+			name: "compressed-total",
+			limits: sqliteBundleBuildLimits{
+				maxCompressedSize: 256,
+				maxParts:          8,
+			},
+			chunkSize: 128,
+			wantErr:   "compressed sqlite bundle exceeds 256 bytes",
+		},
+		{
+			name: "part-count",
+			limits: sqliteBundleBuildLimits{
+				maxCompressedSize: 4096,
+				maxParts:          2,
+			},
+			chunkSize: 128,
+			wantErr:   "requires more than 2 parts",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			workDir := t.TempDir()
+			_, err := buildGzipSQLiteBundleWithLimits(
+				context.Background(),
+				SQLiteBundleBuildOptions{
+					App:              "gitcrawl",
+					Archive:          "gitcrawl/openclaw__openclaw",
+					SourcePath:       source,
+					WorkDir:          workDir,
+					ChunkSize:        tc.chunkSize,
+					CompressionLevel: gzip.NoCompression,
+				},
+				false,
+				tc.limits,
+			)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("build err = %v, want %q", err, tc.wantErr)
+			}
+			entries, readErr := os.ReadDir(workDir)
+			if readErr != nil {
+				t.Fatalf("read work dir: %v", readErr)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("partial bundle artifacts remain: %#v", entries)
+			}
+		})
+	}
+}
+
+func TestSplitBundlePartsRejectsPartOverflowBeforeCreatingFiles(t *testing.T) {
+	dir := t.TempDir()
+	compressedPath := filepath.Join(dir, "current.db.gz")
+	if err := os.WriteFile(compressedPath, make([]byte, 257), 0o600); err != nil {
+		t.Fatalf("write compressed fixture: %v", err)
+	}
+	_, err := splitBundleParts(
+		context.Background(),
+		compressedPath,
+		dir,
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		"",
+		128,
+		sqliteBundleBuildLimits{maxCompressedSize: 1024, maxParts: 2},
+	)
+	if err == nil || !strings.Contains(err.Error(), "requires 3 parts, maximum is 2") {
+		t.Fatalf("split err = %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "current.db.gz.part-*"))
+	if err != nil {
+		t.Fatalf("glob parts: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("unexpected partial parts: %#v", matches)
+	}
+}
+
+func TestBuildGzipSQLiteBundleRejectsOversizedChunkBeforeCreatingTempFiles(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "archive.db")
+	if err := os.WriteFile(source, []byte("sqlite"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	workDir := t.TempDir()
+	_, err := BuildGzipSQLiteBundle(context.Background(), SQLiteBundleBuildOptions{
+		App:        "gitcrawl",
+		Archive:    "gitcrawl/openclaw__openclaw",
+		SourcePath: source,
+		WorkDir:    workDir,
+		ChunkSize:  DefaultMutableSQLiteBundleChunkSize + 1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "chunk size must not exceed") {
+		t.Fatalf("build err = %v", err)
+	}
+	entries, readErr := os.ReadDir(workDir)
+	if readErr != nil {
+		t.Fatalf("read work dir: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("bundle temp files created before validation: %#v", entries)
+	}
+}
+
 func TestBuildSnapshotGzipSQLiteBundlePreservesReleasedImplicitRepresentation(t *testing.T) {
 	dir := t.TempDir()
 	source := filepath.Join(dir, "archive.db")
@@ -725,9 +845,9 @@ func TestBuildSnapshotGzipSQLiteBundleRepresentationChangesConflictAtSourceManif
 		t.Cleanup(bundle.Cleanup)
 		return bundle
 	}
-	fastSmall := build(t, gzip.BestSpeed, 64)
-	bestSmall := build(t, gzip.BestCompression, 64)
-	fastLarge := build(t, gzip.BestSpeed, 128)
+	fastSmall := build(t, gzip.BestSpeed, 256)
+	bestSmall := build(t, gzip.BestCompression, 256)
+	fastLarge := build(t, gzip.BestSpeed, 1024)
 	if fastSmall.Manifest.SnapshotID != bestSmall.Manifest.SnapshotID ||
 		fastSmall.Manifest.SnapshotID != fastLarge.Manifest.SnapshotID {
 		t.Fatalf("source snapshot ids differ")
@@ -846,6 +966,136 @@ func TestSQLiteBundleKeyLayouts(t *testing.T) {
 	}
 }
 
+type sqliteBundleWireObject struct {
+	Key    string `json:"key"`
+	Size   int64  `json:"size"`
+	SHA256 string `json:"sha256"`
+}
+
+type sqliteBundleWireCompression struct {
+	Algorithm string `json:"algorithm"`
+}
+
+type sqliteBundleWirePart struct {
+	Index  int    `json:"index"`
+	Key    string `json:"key"`
+	Size   int64  `json:"size"`
+	SHA256 string `json:"sha256"`
+}
+
+type sqliteBundleWireManifest struct {
+	Format           string                      `json:"format"`
+	App              string                      `json:"app"`
+	Archive          string                      `json:"archive"`
+	SnapshotID       string                      `json:"snapshot_id,omitempty"`
+	GeneratedAt      string                      `json:"generated_at,omitempty"`
+	ContentType      string                      `json:"content_type,omitempty"`
+	Compression      sqliteBundleWireCompression `json:"compression"`
+	Privacy          map[string]any              `json:"privacy,omitempty"`
+	Object           sqliteBundleWireObject      `json:"object"`
+	CompressedObject sqliteBundleWireObject      `json:"compressed_object"`
+	Reconstruct      string                      `json:"reconstruct,omitempty"`
+	Counts           map[string]int64            `json:"counts,omitempty"`
+	Parts            []sqliteBundleWirePart      `json:"parts"`
+}
+
+func decodeStrictSQLiteBundleManifest(t *testing.T, body io.Reader) sqliteBundleWireManifest {
+	t.Helper()
+	decoder := json.NewDecoder(body)
+	decoder.DisallowUnknownFields()
+	var manifest sqliteBundleWireManifest
+	if err := decoder.Decode(&manifest); err != nil {
+		t.Fatalf("decode strict sqlite bundle manifest: %v", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		t.Fatalf("sqlite bundle manifest has trailing JSON: %v", err)
+	}
+	return manifest
+}
+
+func testSQLiteBundleManifest(app, archive, snapshotID string, sizes ...int64) SQLiteBundleManifest {
+	objectSHA := strings.Repeat("a", 64)
+	if snapshotID != "" {
+		objectSHA = snapshotID
+	}
+	compressedSHA := strings.Repeat("b", 64)
+	parts := make([]SQLiteBundlePart, len(sizes))
+	var total int64
+	for index, size := range sizes {
+		partSHA := strings.Repeat("d", 64)
+		parts[index] = SQLiteBundlePart{
+			Index:  index,
+			Key:    SQLiteSnapshotBundlePartKey(app, archive, snapshotID, partSHA, index),
+			Size:   size,
+			SHA256: partSHA,
+		}
+		total += size
+	}
+	reconstruct := "concatenate parts in index order to current.db.gz, then gzip-decompress to current.db"
+	generatedAt := "2026-07-12T12:00:00Z"
+	if snapshotID != "" {
+		reconstruct = "concatenate parts in index order to archive.db.gz, then gzip-decompress to archive.db"
+		generatedAt = ""
+	}
+	return SQLiteBundleManifest{
+		Format:      SQLiteGzipChunkedBundleFormat,
+		App:         app,
+		Archive:     archive,
+		SnapshotID:  snapshotID,
+		GeneratedAt: generatedAt,
+		ContentType: "application/vnd.sqlite3",
+		Compression: SQLiteBundleCompression{
+			Algorithm: SQLiteGzipCompression,
+		},
+		Privacy: map[string]any{
+			"policy":   "public-only",
+			"scrubbed": true,
+		},
+		Object: SQLiteBundleObject{
+			Key:    SQLiteSnapshotObjectKey(app, archive, snapshotID),
+			Size:   1,
+			SHA256: objectSHA,
+		},
+		CompressedObject: SQLiteBundleObject{
+			Key:    SQLiteSnapshotCompressedObjectKey(app, archive, snapshotID, compressedSHA),
+			Size:   total,
+			SHA256: compressedSHA,
+		},
+		Reconstruct: reconstruct,
+		Counts:      map[string]int64{"rows": 1},
+		Parts:       parts,
+	}
+}
+
+func TestSQLiteBundleManifestMatchesNegotiatedWireSchema(t *testing.T) {
+	snapshotID := strings.Repeat("c", 64)
+	manifest := testSQLiteBundleManifest(
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		snapshotID,
+		DefaultSQLiteBundleChunkSize,
+	)
+	_, body, err := prepareSQLiteBundleManifest(
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		manifest,
+	)
+	if err != nil {
+		t.Fatalf("prepare manifest: %v", err)
+	}
+	wireManifest := decodeStrictSQLiteBundleManifest(t, bytes.NewReader(body))
+	if wireManifest.SnapshotID != snapshotID ||
+		wireManifest.ContentType != "application/vnd.sqlite3" ||
+		wireManifest.Reconstruct == "" ||
+		wireManifest.Privacy["scrubbed"] != true ||
+		wireManifest.Counts["rows"] != 1 ||
+		len(wireManifest.Parts) != 1 ||
+		wireManifest.Parts[0].Size != DefaultSQLiteBundleChunkSize {
+		t.Fatalf("wire manifest = %#v", wireManifest)
+	}
+}
+
 func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
@@ -902,12 +1152,22 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 					}
 					_ = json.NewEncoder(w).Encode(SQLiteUploadResult{Complete: true})
 				case "bundle-manifest":
-					var manifest SQLiteBundleManifest
-					if err := json.NewDecoder(r.Body).Decode(&manifest); err != nil {
-						t.Fatalf("decode manifest: %v", err)
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Fatalf("read manifest: %v", err)
 					}
-					if manifest.Format != SQLiteGzipChunkedBundleFormat || manifest.SnapshotID != tc.snapshotID {
-						t.Fatalf("manifest = %#v", manifest)
+					wireManifest := decodeStrictSQLiteBundleManifest(t, bytes.NewReader(body))
+					if wireManifest.Format != SQLiteGzipChunkedBundleFormat ||
+						wireManifest.SnapshotID != tc.snapshotID ||
+						wireManifest.ContentType != "application/vnd.sqlite3" ||
+						wireManifest.Reconstruct == "" ||
+						wireManifest.Privacy["policy"] != "public-only" ||
+						wireManifest.Counts["rows"] != 1 {
+						t.Fatalf("wire manifest = %#v", wireManifest)
+					}
+					var manifest SQLiteBundleManifest
+					if err := json.Unmarshal(body, &manifest); err != nil {
+						t.Fatalf("decode response manifest: %v", err)
 					}
 					_ = json.NewEncoder(w).Encode(SQLiteBundleUploadResult{
 						App:      "gitcrawl",
@@ -927,34 +1187,14 @@ func TestClientUploadSQLiteBundleFilesPreservesAddressingMode(t *testing.T) {
 			if err != nil {
 				t.Fatalf("client: %v", err)
 			}
-			part := SQLiteBundlePart{
-				Index:  0,
-				Key:    SQLiteBundlePartKey("gitcrawl", "gitcrawl/openclaw__openclaw", 0),
-				Size:   int64(len("compressed")),
-				SHA256: strings.Repeat("d", 64),
-			}
-			if tc.snapshotID != "" {
-				part.Key = SQLiteSnapshotBundlePartKey(
-					"gitcrawl",
-					"gitcrawl/openclaw__openclaw",
-					tc.snapshotID,
-					part.SHA256,
-					part.Index,
-				)
-			}
-			result, err := client.UploadSQLiteBundleFiles(context.Background(), "gitcrawl", "gitcrawl/openclaw__openclaw", SQLiteBundleManifest{
-				Format:     SQLiteGzipChunkedBundleFormat,
-				App:        "gitcrawl",
-				Archive:    "gitcrawl/openclaw__openclaw",
-				SnapshotID: tc.snapshotID,
-				Object: SQLiteBundleObject{
-					Size: int64(len("uncompressed")),
-				},
-				CompressedObject: SQLiteBundleObject{
-					Size: part.Size,
-				},
-				Parts: []SQLiteBundlePart{part},
-			}, []SQLiteBundlePartFile{{
+			manifest := testSQLiteBundleManifest(
+				"gitcrawl",
+				"gitcrawl/openclaw__openclaw",
+				tc.snapshotID,
+				int64(len("compressed")),
+			)
+			part := manifest.Parts[0]
+			result, err := client.UploadSQLiteBundleFiles(context.Background(), "gitcrawl", "gitcrawl/openclaw__openclaw", manifest, []SQLiteBundlePartFile{{
 				SQLiteBundlePart: part,
 				Path:             partPath,
 			}})
@@ -977,18 +1217,7 @@ func TestSQLiteBundleUploadLimitsMatchRemoteContract(t *testing.T) {
 		if snapshotScoped {
 			snapshotID = strings.Repeat("a", 64)
 		}
-		parts := make([]SQLiteBundlePart, len(sizes))
-		var total int64
-		for index, size := range sizes {
-			parts[index] = SQLiteBundlePart{Index: index, Size: size}
-			total += size
-		}
-		return SQLiteBundleManifest{
-			SnapshotID:       snapshotID,
-			Object:           SQLiteBundleObject{Size: 1},
-			CompressedObject: SQLiteBundleObject{Size: total},
-			Parts:            parts,
-		}
+		return testSQLiteBundleManifest("gitcrawl", "gitcrawl/openclaw__openclaw", snapshotID, sizes...)
 	}
 
 	for _, tc := range []struct {
@@ -1026,7 +1255,11 @@ func TestSQLiteBundleUploadLimitsMatchRemoteContract(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateSQLiteBundleManifestLimits(tc.manifest)
+			err := validateSQLiteBundleManifest(
+				tc.manifest,
+				"gitcrawl",
+				"gitcrawl/openclaw__openclaw",
+			)
 			if tc.wantErr == "" {
 				if err != nil {
 					t.Fatalf("validate limits: %v", err)
@@ -1035,6 +1268,77 @@ func TestSQLiteBundleUploadLimitsMatchRemoteContract(t *testing.T) {
 			}
 			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
 				t.Fatalf("validate limits err = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestClientPreflightsCompleteSQLiteBundleManifestBeforePartUploads(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		t.Fatalf("unexpected request")
+	}))
+	defer server.Close()
+	client, err := NewClient(Options{Endpoint: server.URL, TokenProvider: StaticToken("secret")})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	partPath := filepath.Join(t.TempDir(), "part")
+	if err := os.WriteFile(partPath, []byte("compressed"), 0o600); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		mutate  func(*SQLiteBundleManifest)
+		wantErr string
+	}{
+		{
+			name: "invalid-privacy-json",
+			mutate: func(manifest *SQLiteBundleManifest) {
+				manifest.Privacy["ratio"] = math.NaN()
+			},
+			wantErr: "unsupported value",
+		},
+		{
+			name: "invalid-schema",
+			mutate: func(manifest *SQLiteBundleManifest) {
+				manifest.Compression.Algorithm = "zstd"
+			},
+			wantErr: `compression must be "gzip"`,
+		},
+		{
+			name: "manifest-over-64-kib",
+			mutate: func(manifest *SQLiteBundleManifest) {
+				manifest.Privacy["padding"] = strings.Repeat("x", int(maxSQLiteBundleManifestBytes))
+			},
+			wantErr: "must not exceed 65536 bytes",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := testSQLiteBundleManifest(
+				"gitcrawl",
+				"gitcrawl/openclaw__openclaw",
+				"",
+				int64(len("compressed")),
+			)
+			tc.mutate(&manifest)
+			_, err := client.UploadSQLiteBundleFiles(
+				context.Background(),
+				"gitcrawl",
+				"gitcrawl/openclaw__openclaw",
+				manifest,
+				[]SQLiteBundlePartFile{{
+					SQLiteBundlePart: manifest.Parts[0],
+					Path:             partPath,
+				}},
+			)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("upload err = %v, want %q", err, tc.wantErr)
+			}
+			if requests != 0 {
+				t.Fatalf("requests = %d", requests)
 			}
 		})
 	}

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -477,7 +477,10 @@ func TestBuildGzipSQLiteBundlePreservesCurrentKeyLayout(t *testing.T) {
 }
 
 func TestDefaultSQLiteBundleChunkSizeMatchesRemoteUploadLimit(t *testing.T) {
-	if got, want := DefaultSQLiteBundleChunkSize, int64(64*1024*1024); got != want {
+	if got, want := DefaultSQLiteBundleChunkSize, int64(256*1024*1024); got != want {
+		t.Fatalf("legacy sqlite bundle chunk size = %d, want %d", got, want)
+	}
+	if got, want := DefaultMutableSQLiteBundleChunkSize, int64(64*1024*1024); got != want {
 		t.Fatalf("default sqlite bundle chunk size = %d, want %d", got, want)
 	}
 	if got, want := sqliteBundleChunkSize(0, false), int64(64*1024*1024); got != want {
@@ -488,6 +491,9 @@ func TestDefaultSQLiteBundleChunkSizeMatchesRemoteUploadLimit(t *testing.T) {
 	}
 	if got, want := sqliteBundleChunkSize(32*1024*1024, true), int64(32*1024*1024); got != want {
 		t.Fatalf("explicit snapshot sqlite bundle chunk size = %d, want %d", got, want)
+	}
+	if got, want := sqliteBundleChunkSize(DefaultSQLiteBundleChunkSize, true), int64(256*1024*1024); got != want {
+		t.Fatalf("legacy explicit snapshot sqlite bundle chunk size = %d, want %d", got, want)
 	}
 }
 

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -27,6 +27,12 @@ func (f tokenProviderFunc) Token(ctx context.Context) (string, error) {
 	return f(ctx)
 }
 
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 func TestConfigNormalizeAndEnabled(t *testing.T) {
 	cfg := Config{Mode: " Cloud ", Endpoint: "https://remote.test/", Archive: " gitcrawl/openclaw ", Auth: AuthConfig{TokenSource: " Env "}}
 	cfg.Normalize()
@@ -680,7 +686,7 @@ func TestBuildSQLiteBundlesRejectEmptySources(t *testing.T) {
 				SourcePath: source,
 				WorkDir:    workDir,
 			})
-			if err == nil || !strings.Contains(err.Error(), "object size must be between 1") {
+			if err == nil || !strings.Contains(err.Error(), "object size must be positive") {
 				t.Fatalf("build err = %v", err)
 			}
 			entries, readErr := os.ReadDir(workDir)
@@ -695,15 +701,25 @@ func TestBuildSQLiteBundlesRejectEmptySources(t *testing.T) {
 }
 
 func TestValidateSQLiteBundleSourceSizeBounds(t *testing.T) {
-	for _, size := range []int64{-1, 0, maxSQLiteBundleObjectSize + 1} {
-		if err := validateSQLiteBundleSourceSize(size); err == nil {
-			t.Fatalf("validate size %d succeeded", size)
+	for _, snapshotScoped := range []bool{false, true} {
+		for _, size := range []int64{-1, 0} {
+			if err := validateSQLiteBundleSourceSize(size, snapshotScoped); err == nil {
+				t.Fatalf("validate size %d snapshot=%t succeeded", size, snapshotScoped)
+			}
 		}
 	}
 	for _, size := range []int64{1, maxSQLiteBundleObjectSize} {
-		if err := validateSQLiteBundleSourceSize(size); err != nil {
-			t.Fatalf("validate size %d: %v", size, err)
+		for _, snapshotScoped := range []bool{false, true} {
+			if err := validateSQLiteBundleSourceSize(size, snapshotScoped); err != nil {
+				t.Fatalf("validate size %d snapshot=%t: %v", size, snapshotScoped, err)
+			}
 		}
+	}
+	if err := validateSQLiteBundleSourceSize(maxSQLiteBundleObjectSize+1, false); err != nil {
+		t.Fatalf("validate legacy mutable size: %v", err)
+	}
+	if err := validateSQLiteBundleSourceSize(maxSQLiteBundleObjectSize+1, true); err == nil {
+		t.Fatal("oversized snapshot source succeeded")
 	}
 }
 
@@ -965,13 +981,25 @@ func TestSplitBundlePartsRejectsPartOverflowBeforeCreatingFiles(t *testing.T) {
 	}
 }
 
-func TestBuildGzipSQLiteBundleRejectsOversizedChunkBeforeCreatingTempFiles(t *testing.T) {
+func TestBuildSQLiteBundlesScopeChunkLimitToSnapshots(t *testing.T) {
 	source := filepath.Join(t.TempDir(), "archive.db")
 	if err := os.WriteFile(source, []byte("sqlite"), 0o600); err != nil {
 		t.Fatalf("write source: %v", err)
 	}
+	mutable, err := BuildGzipSQLiteBundle(context.Background(), SQLiteBundleBuildOptions{
+		App:        "gitcrawl",
+		Archive:    "gitcrawl/openclaw__openclaw",
+		SourcePath: source,
+		WorkDir:    t.TempDir(),
+		ChunkSize:  DefaultSQLiteBundleChunkSize + 1,
+	})
+	if err != nil {
+		t.Fatalf("build legacy mutable bundle: %v", err)
+	}
+	mutable.Cleanup()
+
 	workDir := t.TempDir()
-	_, err := BuildGzipSQLiteBundle(context.Background(), SQLiteBundleBuildOptions{
+	_, err = BuildSnapshotGzipSQLiteBundle(context.Background(), SQLiteBundleBuildOptions{
 		App:        "gitcrawl",
 		Archive:    "gitcrawl/openclaw__openclaw",
 		SourcePath: source,
@@ -979,7 +1007,7 @@ func TestBuildGzipSQLiteBundleRejectsOversizedChunkBeforeCreatingTempFiles(t *te
 		ChunkSize:  DefaultSQLiteBundleChunkSize + 1,
 	})
 	if err == nil || !strings.Contains(err.Error(), "chunk size must not exceed") {
-		t.Fatalf("build err = %v", err)
+		t.Fatalf("snapshot build err = %v", err)
 	}
 	entries, readErr := os.ReadDir(workDir)
 	if readErr != nil {
@@ -1753,24 +1781,16 @@ func TestClientRejectsInvalidSnapshotBundleAggregatesBeforeRequest(t *testing.T)
 }
 
 func TestClientUploadsImmutablePartSnapshotAfterSameInodeMutation(t *testing.T) {
-	original := []byte("compressed")
-	changed := []byte("corrupted!")
-	partPath := filepath.Join(t.TempDir(), "part")
-	if err := os.WriteFile(partPath, original, 0o600); err != nil {
-		t.Fatalf("write part: %v", err)
-	}
+	objectContent := []byte("SQLite format 3\x00test payload")
+	original := gzipTestPayload(t, objectContent)
+	changed := append([]byte(nil), original...)
+	changed[len(changed)/2] ^= 0xff
+	manifest, parts := testSnapshotSQLiteBundleFiles(t, objectContent, original)
+	partPath := parts[0].Path
 	infoBefore, err := os.Stat(partPath)
 	if err != nil {
 		t.Fatalf("stat part: %v", err)
 	}
-	manifest := testSQLiteBundleManifest(
-		"gitcrawl",
-		"gitcrawl/openclaw__openclaw",
-		"",
-		int64(len(original)),
-	)
-	setTestSQLiteBundlePartContent(&manifest, 0, original)
-	part := manifest.Parts[0]
 
 	var requests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1818,10 +1838,7 @@ func TestClientUploadsImmutablePartSnapshotAfterSameInodeMutation(t *testing.T) 
 		manifest.App,
 		manifest.Archive,
 		manifest,
-		[]SQLiteBundlePartFile{{
-			SQLiteBundlePart: part,
-			Path:             partPath,
-		}},
+		parts,
 	); err != nil {
 		t.Fatalf("upload bundle: %v", err)
 	}
@@ -1834,6 +1851,145 @@ func TestClientUploadsImmutablePartSnapshotAfterSameInodeMutation(t *testing.T) 
 	}
 	if !bytes.Equal(body, changed) {
 		t.Fatalf("source part = %q, want mutation %q", body, changed)
+	}
+}
+
+func TestClientUploadsMutableBundleWithoutTemporaryStaging(t *testing.T) {
+	content := []byte("compressed")
+	partPath := filepath.Join(t.TempDir(), "part")
+	if err := os.WriteFile(partPath, content, 0o600); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+	manifest := testSQLiteBundleManifest(
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		"",
+		int64(len(content)),
+	)
+	setTestSQLiteBundlePartContent(&manifest, 0, content)
+	parts := []SQLiteBundlePartFile{{
+		SQLiteBundlePart: manifest.Parts[0],
+		Path:             partPath,
+	}}
+
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Header.Get("x-crawl-sqlite-upload") == "bundle-part" {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read part: %v", err)
+			}
+			if !bytes.Equal(body, content) {
+				t.Fatalf("part body = %q", body)
+			}
+			_ = json.NewEncoder(w).Encode(SQLiteUploadResult{Complete: true})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(SQLiteBundleUploadResult{Complete: true})
+	}))
+	defer server.Close()
+
+	tempBlocker := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(tempBlocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write temp blocker: %v", err)
+	}
+	t.Setenv("TMPDIR", tempBlocker)
+	t.Setenv("TMP", tempBlocker)
+	t.Setenv("TEMP", tempBlocker)
+
+	client, err := NewClient(Options{
+		Endpoint:      server.URL,
+		TokenProvider: StaticToken("secret"),
+	})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if _, err := client.UploadSQLiteBundleFiles(
+		context.Background(),
+		manifest.App,
+		manifest.Archive,
+		manifest,
+		parts,
+	); err != nil {
+		t.Fatalf("upload mutable bundle: %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d", requests)
+	}
+}
+
+func TestClientRejectsMutablePartChangedDuringUploadBeforeManifest(t *testing.T) {
+	original := []byte("compressed")
+	changed := []byte("corrupted!")
+	partPath := filepath.Join(t.TempDir(), "part")
+	if err := os.WriteFile(partPath, original, 0o600); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+	infoBefore, err := os.Stat(partPath)
+	if err != nil {
+		t.Fatalf("stat part: %v", err)
+	}
+	manifest := testSQLiteBundleManifest(
+		"gitcrawl",
+		"gitcrawl/openclaw__openclaw",
+		"",
+		int64(len(original)),
+	)
+	setTestSQLiteBundlePartContent(&manifest, 0, original)
+	parts := []SQLiteBundlePartFile{{
+		SQLiteBundlePart: manifest.Parts[0],
+		Path:             partPath,
+	}}
+
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if got := r.Header.Get("x-crawl-sqlite-upload"); got != "bundle-part" {
+			t.Fatalf("unexpected upload kind %q", got)
+		}
+		if _, err := io.Copy(io.Discard, r.Body); err != nil {
+			t.Fatalf("read part: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(SQLiteUploadResult{Complete: true})
+	}))
+	defer server.Close()
+	mutated := false
+	provider := tokenProviderFunc(func(context.Context) (string, error) {
+		if !mutated {
+			mutated = true
+			if err := os.WriteFile(partPath, changed, 0o600); err != nil {
+				return "", fmt.Errorf("mutate part: %w", err)
+			}
+			infoAfter, err := os.Stat(partPath)
+			if err != nil {
+				return "", fmt.Errorf("restat part: %w", err)
+			}
+			if !os.SameFile(infoBefore, infoAfter) {
+				return "", fmt.Errorf("part mutation replaced the inode")
+			}
+		}
+		return "secret", nil
+	})
+	client, err := NewClient(Options{
+		Endpoint:      server.URL,
+		TokenProvider: provider,
+	})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	_, err = client.UploadSQLiteBundleFiles(
+		context.Background(),
+		manifest.App,
+		manifest.Archive,
+		manifest,
+		parts,
+	)
+	if err == nil || !strings.Contains(err.Error(), "changed during upload") {
+		t.Fatalf("upload error = %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want part only", requests)
 	}
 }
 
@@ -1947,32 +2103,21 @@ func TestClientRejectsChangedSQLiteBundlePartContentBeforeRequest(t *testing.T) 
 	}
 }
 
-func TestOpenValidatedSQLiteBundleFilesRetainsValidatedHandles(t *testing.T) {
-	original := []byte("compressed")
+func TestOpenValidatedSnapshotSQLiteBundleFilesRetainsImmutableCopies(t *testing.T) {
+	objectContent := []byte("SQLite format 3\x00test payload")
+	original := gzipTestPayload(t, objectContent)
 	replacement := []byte("corrupted!")
-	partPath := filepath.Join(t.TempDir(), "part")
-	if err := os.WriteFile(partPath, original, 0o600); err != nil {
-		t.Fatalf("write part: %v", err)
-	}
-	manifest := testSQLiteBundleManifest(
-		"gitcrawl",
-		"gitcrawl/openclaw__openclaw",
-		"",
-		int64(len(original)),
-	)
-	setTestSQLiteBundlePartContent(&manifest, 0, original)
-	parts, err := openValidatedSQLiteBundleFiles(
+	manifest, partFiles := testSnapshotSQLiteBundleFiles(t, objectContent, original)
+	partPath := partFiles[0].Path
+	parts, err := openValidatedSnapshotSQLiteBundleFiles(
 		context.Background(),
 		manifest,
-		[]SQLiteBundlePartFile{{
-			SQLiteBundlePart: manifest.Parts[0],
-			Path:             partPath,
-		}},
+		partFiles,
 	)
 	if err != nil {
 		t.Fatalf("open validated parts: %v", err)
 	}
-	defer closeValidatedSQLiteBundleFiles(parts)
+	defer closeValidatedSnapshotSQLiteBundleFiles(parts)
 
 	replacementPath := partPath + ".replacement"
 	if err := os.WriteFile(replacementPath, replacement, 0o600); err != nil {
@@ -1993,7 +2138,7 @@ func TestOpenValidatedSQLiteBundleFilesRetainsValidatedHandles(t *testing.T) {
 	}
 }
 
-func TestOpenValidatedSQLiteBundleFilesClosesHandlesOnFailure(t *testing.T) {
+func TestOpenValidatedSnapshotSQLiteBundleFilesClosesHandlesOnFailure(t *testing.T) {
 	dir := t.TempDir()
 	firstPath := filepath.Join(dir, "part-0")
 	secondPath := filepath.Join(dir, "part-1")
@@ -2010,7 +2155,7 @@ func TestOpenValidatedSQLiteBundleFilesClosesHandlesOnFailure(t *testing.T) {
 	manifest := testSQLiteBundleManifest(
 		"gitcrawl",
 		"gitcrawl/openclaw__openclaw",
-		"",
+		strings.Repeat("c", 64),
 		int64(len(firstContent)),
 		int64(len(secondContent)),
 	)
@@ -2022,7 +2167,7 @@ func TestOpenValidatedSQLiteBundleFilesClosesHandlesOnFailure(t *testing.T) {
 	}
 	before, countable := openFileDescriptorCount()
 	for range 32 {
-		_, err := openValidatedSQLiteBundleFiles(context.Background(), manifest, partFiles)
+		_, err := openValidatedSnapshotSQLiteBundleFiles(context.Background(), manifest, partFiles)
 		if err == nil || !strings.Contains(err.Error(), "sha256 does not match") {
 			t.Fatalf("validation error = %v", err)
 		}
@@ -2058,6 +2203,10 @@ func TestSQLiteBundleUploadLimitsMatchRemoteContract(t *testing.T) {
 		}
 		return testSQLiteBundleManifest("gitcrawl", "gitcrawl/openclaw__openclaw", snapshotID, sizes...)
 	}
+	withObjectSize := func(manifest SQLiteBundleManifest, size int64) SQLiteBundleManifest {
+		manifest.Object.Size = size
+		return manifest
+	}
 
 	for _, tc := range []struct {
 		name     string
@@ -2077,14 +2226,28 @@ func TestSQLiteBundleUploadLimitsMatchRemoteContract(t *testing.T) {
 			manifest: manifest(true, DefaultSQLiteBundleChunkSize),
 		},
 		{
-			name:     "mutable-part-too-large",
+			name:     "legacy-mutable-part-over-snapshot-limit",
 			manifest: manifest(false, DefaultSQLiteBundleChunkSize+1),
-			wantErr:  "part 0 size",
 		},
 		{
 			name:     "snapshot-part-too-large",
 			manifest: manifest(true, DefaultSQLiteBundleChunkSize+1),
 			wantErr:  "part 0 size",
+		},
+		{
+			name: "legacy-mutable-object-over-snapshot-limit",
+			manifest: withObjectSize(
+				manifest(false, 1),
+				maxSQLiteBundleObjectSize+1,
+			),
+		},
+		{
+			name: "snapshot-object-too-large",
+			manifest: withObjectSize(
+				manifest(true, 1),
+				maxSQLiteBundleObjectSize+1,
+			),
+			wantErr: "object size",
 		},
 		{
 			name:     "legacy-mutable-many-parts",
@@ -2126,6 +2289,65 @@ func TestSQLiteBundleUploadLimitsMatchRemoteContract(t *testing.T) {
 				t.Fatalf("validate limits err = %v, want %q", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestSQLiteBundleManifestSizeLimitsMatchAddressingMode(t *testing.T) {
+	if got := sqliteBundleManifestSizeLimit(true); got != maxSQLiteSnapshotBundleManifestBytes {
+		t.Fatalf("snapshot manifest limit = %d", got)
+	}
+	if got := sqliteBundleManifestSizeLimit(false); got != maxSQLiteMutableBundleManifestBytes {
+		t.Fatalf("mutable manifest limit = %d", got)
+	}
+	for _, tc := range []struct {
+		name           string
+		snapshotScoped bool
+		limit          int64
+	}{
+		{
+			name:           "snapshot",
+			snapshotScoped: true,
+			limit:          maxSQLiteSnapshotBundleManifestBytes,
+		},
+		{
+			name:  "mutable",
+			limit: maxSQLiteMutableBundleManifestBytes,
+		},
+	} {
+		t.Run(tc.name+"-exact", func(t *testing.T) {
+			if err := validateSQLiteBundleManifestSize(tc.limit, tc.snapshotScoped); err != nil {
+				t.Fatalf("validate exact limit: %v", err)
+			}
+		})
+		t.Run(tc.name+"-over", func(t *testing.T) {
+			if err := validateSQLiteBundleManifestSize(tc.limit+1, tc.snapshotScoped); err == nil {
+				t.Fatal("validate over limit succeeded")
+			}
+		})
+	}
+
+	app := "gitcrawl"
+	archive := "gitcrawl/openclaw__openclaw"
+	mutable := testSQLiteBundleManifest(app, archive, "", 1)
+	mutable.Privacy["padding"] = strings.Repeat("x", int(maxSQLiteSnapshotBundleManifestBytes))
+	if _, body, err := prepareSQLiteBundleManifest(app, archive, mutable); err != nil {
+		t.Fatalf("prepare mutable manifest between limits: %v", err)
+	} else if int64(len(body)) <= maxSQLiteSnapshotBundleManifestBytes ||
+		int64(len(body)) > maxSQLiteMutableBundleManifestBytes {
+		t.Fatalf("mutable manifest size = %d", len(body))
+	}
+
+	snapshot := testSQLiteBundleManifest(app, archive, strings.Repeat("a", 64), 1)
+	snapshot.Privacy["padding"] = strings.Repeat("x", int(maxSQLiteSnapshotBundleManifestBytes))
+	if _, _, err := prepareSQLiteBundleManifest(app, archive, snapshot); err == nil ||
+		!strings.Contains(err.Error(), "must not exceed 65536 bytes") {
+		t.Fatalf("snapshot manifest error = %v", err)
+	}
+
+	mutable.Privacy["padding"] = strings.Repeat("x", int(maxSQLiteMutableBundleManifestBytes))
+	if _, _, err := prepareSQLiteBundleManifest(app, archive, mutable); err == nil ||
+		!strings.Contains(err.Error(), "must not exceed 1048576 bytes") {
+		t.Fatalf("oversized mutable manifest error = %v", err)
 	}
 }
 
@@ -2202,9 +2424,13 @@ func TestClientPreflightsCompleteSQLiteBundleManifestBeforePartUploads(t *testin
 			wantErr: `compression must be "gzip"`,
 		},
 		{
-			name: "manifest-over-64-kib",
+			name:       "snapshot-manifest-over-64-kib",
+			snapshotID: strings.Repeat("c", 64),
 			mutate: func(manifest *SQLiteBundleManifest) {
-				manifest.Privacy["padding"] = strings.Repeat("x", int(maxSQLiteBundleManifestBytes))
+				manifest.Privacy["padding"] = strings.Repeat(
+					"x",
+					int(maxSQLiteSnapshotBundleManifestBytes),
+				)
 			},
 			wantErr: "must not exceed 65536 bytes",
 		},
@@ -2293,22 +2519,37 @@ func TestClientPreflightsCompleteSQLiteBundleManifestBeforePartUploads(t *testin
 	}
 }
 
-func TestClientRejectsOversizedSQLiteBundleBeforeRequest(t *testing.T) {
+func TestClientScopesSQLiteBundlePartLimitToSnapshots(t *testing.T) {
 	var requests int
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	httpClient := &http.Client{Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
 		requests++
-		t.Fatalf("unexpected request")
-	}))
-	defer server.Close()
-	client, err := NewClient(Options{Endpoint: server.URL, TokenProvider: StaticToken("secret")})
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"complete":true}`)),
+			Request:    r,
+		}, nil
+	})}
+	client, err := NewClient(Options{
+		Endpoint:      "https://remote.test",
+		HTTPClient:    httpClient,
+		TokenProvider: StaticToken("secret"),
+	})
 	if err != nil {
 		t.Fatalf("client: %v", err)
 	}
 	if _, err := client.UploadSQLiteBundlePart(context.Background(), "gitcrawl", "archive", SQLiteBundlePartUpload{
 		Body: strings.NewReader("x"),
 		Size: DefaultSQLiteBundleChunkSize + 1,
-	}); err == nil || !strings.Contains(err.Error(), "part 0 size") {
-		t.Fatalf("mutable part upload err = %v", err)
+	}); err != nil {
+		t.Fatalf("legacy mutable part upload: %v", err)
+	}
+	if _, err := client.UploadSQLiteBundlePart(context.Background(), "gitcrawl", "archive", SQLiteBundlePartUpload{
+		Body:       strings.NewReader("x"),
+		Size:       DefaultSQLiteBundleChunkSize,
+		SnapshotID: strings.Repeat("a", 64),
+	}); err != nil {
+		t.Fatalf("snapshot part at limit: %v", err)
 	}
 	if _, err := client.UploadSQLiteBundlePart(context.Background(), "gitcrawl", "archive", SQLiteBundlePartUpload{
 		Body:       strings.NewReader("x"),
@@ -2317,8 +2558,8 @@ func TestClientRejectsOversizedSQLiteBundleBeforeRequest(t *testing.T) {
 	}); err == nil || !strings.Contains(err.Error(), "part 0 size") {
 		t.Fatalf("snapshot part upload err = %v", err)
 	}
-	if requests != 0 {
-		t.Fatalf("requests = %d", requests)
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2 accepted boundaries", requests)
 	}
 }
 

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -669,6 +670,136 @@ func TestValidateSQLiteBundleSourceSizeBounds(t *testing.T) {
 		if err := validateSQLiteBundleSourceSize(size); err != nil {
 			t.Fatalf("validate size %d: %v", size, err)
 		}
+	}
+}
+
+func TestBuildGzipSQLiteBundleRejectsSourceDriftAndCleansArtifacts(t *testing.T) {
+	payload := bytes.Repeat([]byte("sqlite-source-block-"), 512)
+	for _, tc := range []struct {
+		name          string
+		skipOnWindows bool
+		mutate        func(path string) error
+	}{
+		{
+			name: "truncate",
+			mutate: func(path string) error {
+				return os.Truncate(path, int64(len(payload)/2))
+			},
+		},
+		{
+			name: "append",
+			mutate: func(path string) error {
+				file, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0)
+				if err != nil {
+					return err
+				}
+				if _, err := file.Write([]byte("appended")); err != nil {
+					_ = file.Close()
+					return err
+				}
+				return file.Close()
+			},
+		},
+		{
+			name: "same-size-rewrite",
+			mutate: func(path string) error {
+				return os.WriteFile(path, bytes.Repeat([]byte("x"), len(payload)), 0o600)
+			},
+		},
+		{
+			name:          "replacement",
+			skipOnWindows: true,
+			mutate: func(path string) error {
+				replacement := path + ".replacement"
+				if err := os.WriteFile(
+					replacement,
+					bytes.Repeat([]byte("r"), len(payload)),
+					0o600,
+				); err != nil {
+					return err
+				}
+				if err := os.Remove(path); err != nil {
+					return err
+				}
+				return os.Rename(replacement, path)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.skipOnWindows && runtime.GOOS == "windows" {
+				t.Skip("Windows does not atomically replace an open file path")
+			}
+			sourceDir := t.TempDir()
+			sourcePath := filepath.Join(sourceDir, "archive.db")
+			if err := os.WriteFile(sourcePath, payload, 0o600); err != nil {
+				t.Fatalf("write source: %v", err)
+			}
+			workDir := t.TempDir()
+			mutated := false
+			copySource := func(
+				ctx context.Context,
+				dst io.Writer,
+				src io.Reader,
+			) (int64, error) {
+				first := make([]byte, 64)
+				n, readErr := src.Read(first)
+				var written int64
+				if n > 0 {
+					count, err := dst.Write(first[:n])
+					written += int64(count)
+					if err != nil {
+						return written, err
+					}
+					if count != n {
+						return written, io.ErrShortWrite
+					}
+				}
+				if !mutated {
+					mutated = true
+					if err := tc.mutate(sourcePath); err != nil {
+						return written, fmt.Errorf("mutate source: %w", err)
+					}
+				}
+				if readErr == io.EOF {
+					return written, nil
+				}
+				if readErr != nil {
+					return written, readErr
+				}
+				rest, err := copyWithContext(ctx, dst, src)
+				return written + rest, err
+			}
+			_, err := buildGzipSQLiteBundleWithSourceCopy(
+				context.Background(),
+				SQLiteBundleBuildOptions{
+					App:              "gitcrawl",
+					Archive:          "gitcrawl/openclaw__openclaw",
+					SourcePath:       sourcePath,
+					WorkDir:          workDir,
+					ChunkSize:        64 * 1024,
+					CompressionLevel: gzip.NoCompression,
+				},
+				true,
+				sqliteBundleBuildLimits{
+					maxCompressedSize: maxSQLiteBundleCompressedSize,
+					maxParts:          maxSQLiteBundleParts,
+				},
+				copySource,
+			)
+			if err == nil || !strings.Contains(err.Error(), "source changed during bundle construction") {
+				t.Fatalf("build error = %v", err)
+			}
+			entries, readErr := os.ReadDir(workDir)
+			if readErr != nil {
+				t.Fatalf("read work dir: %v", readErr)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("partial bundle artifacts remain: %#v", entries)
+			}
+			if err := os.Rename(sourcePath, sourcePath+".closed"); err != nil {
+				t.Fatalf("source remained open after failed build: %v", err)
+			}
+		})
 	}
 }
 

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -1667,6 +1667,19 @@ func TestOpenValidatedSQLiteBundleFilesRetainsValidatedHandles(t *testing.T) {
 	if err := os.WriteFile(replacementPath, replacement, 0o600); err != nil {
 		t.Fatalf("write replacement: %v", err)
 	}
+	if runtime.GOOS == "windows" {
+		if err := os.Remove(partPath); err == nil {
+			t.Fatal("Windows replaced a part while its validated handle was retained")
+		}
+		body, err := io.ReadAll(parts[0].file)
+		if err != nil {
+			t.Fatalf("read retained part: %v", err)
+		}
+		if !bytes.Equal(body, original) {
+			t.Fatalf("retained part = %q, want %q", body, original)
+		}
+		return
+	}
 	if err := os.Remove(partPath); err != nil {
 		t.Fatalf("remove original path: %v", err)
 	}

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -480,6 +480,77 @@ func TestDefaultSQLiteBundleChunkSizeMatchesRemoteUploadLimit(t *testing.T) {
 	if got, want := DefaultSQLiteBundleChunkSize, int64(64*1024*1024); got != want {
 		t.Fatalf("default sqlite bundle chunk size = %d, want %d", got, want)
 	}
+	if got, want := sqliteBundleChunkSize(0, false), int64(64*1024*1024); got != want {
+		t.Fatalf("implicit mutable sqlite bundle chunk size = %d, want %d", got, want)
+	}
+	if got, want := sqliteBundleChunkSize(0, true), int64(256*1024*1024); got != want {
+		t.Fatalf("implicit snapshot sqlite bundle chunk size = %d, want released %d", got, want)
+	}
+	if got, want := sqliteBundleChunkSize(32*1024*1024, true), int64(32*1024*1024); got != want {
+		t.Fatalf("explicit snapshot sqlite bundle chunk size = %d, want %d", got, want)
+	}
+}
+
+func TestBuildSnapshotGzipSQLiteBundlePreservesReleasedImplicitRepresentation(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "archive.db")
+	payload := make([]byte, 1024*1024)
+	for i := range payload {
+		payload[i] = byte((i*31 + i/7) % 251)
+	}
+	if err := os.WriteFile(source, payload, 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	build := func(t *testing.T, chunkSize int64) SQLiteBundleBuild {
+		t.Helper()
+		bundle, err := BuildSnapshotGzipSQLiteBundle(context.Background(), SQLiteBundleBuildOptions{
+			App:         "gitcrawl",
+			Archive:     "gitcrawl/openclaw__openclaw",
+			SourcePath:  source,
+			WorkDir:     dir,
+			ChunkSize:   chunkSize,
+			ContentType: "application/vnd.sqlite3",
+		})
+		if err != nil {
+			t.Fatalf("build snapshot bundle: %v", err)
+		}
+		t.Cleanup(bundle.Cleanup)
+		return bundle
+	}
+	implicit := build(t, 0)
+	released := build(t, 256*1024*1024)
+	implicitManifest, err := json.Marshal(implicit.Manifest)
+	if err != nil {
+		t.Fatalf("marshal implicit manifest: %v", err)
+	}
+	releasedManifest, err := json.Marshal(released.Manifest)
+	if err != nil {
+		t.Fatalf("marshal released manifest: %v", err)
+	}
+	if !bytes.Equal(implicitManifest, releasedManifest) {
+		t.Fatalf(
+			"implicit snapshot representation changed:\nimplicit: %s\nreleased: %s",
+			implicitManifest,
+			releasedManifest,
+		)
+	}
+	if len(implicit.Parts) != len(released.Parts) {
+		t.Fatalf("part counts differ: implicit=%d released=%d", len(implicit.Parts), len(released.Parts))
+	}
+	for index := range implicit.Parts {
+		implicitPart, err := os.ReadFile(implicit.Parts[index].Path)
+		if err != nil {
+			t.Fatalf("read implicit part %d: %v", index, err)
+		}
+		releasedPart, err := os.ReadFile(released.Parts[index].Path)
+		if err != nil {
+			t.Fatalf("read released part %d: %v", index, err)
+		}
+		if implicit.Parts[index].SQLiteBundlePart != released.Parts[index].SQLiteBundlePart ||
+			!bytes.Equal(implicitPart, releasedPart) {
+			t.Fatalf("snapshot part %d changed across the default upgrade", index)
+		}
+	}
 }
 
 func TestBuildSnapshotGzipSQLiteBundleUsesSnapshotKeyLayout(t *testing.T) {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -124,6 +124,101 @@ func TestClientRejectsBearerTokenOverRemoteHTTP(t *testing.T) {
 	}
 }
 
+func TestClientPublishStatusForSnapshotUsesEncodedQuery(t *testing.T) {
+	const snapshotID = "immutable id/+?&"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.EscapedPath(), "/v1/apps/gitcrawl/archives/gitcrawl%2Fopenclaw/publish-status"; got != want {
+			t.Fatalf("path = %q, want %q", got, want)
+		}
+		if got, want := r.URL.RawQuery, "snapshot_id=immutable+id%2F%2B%3F%26"; got != want {
+			t.Fatalf("query = %q, want %q", got, want)
+		}
+		if got := r.URL.Query().Get("snapshot_id"); got != snapshotID {
+			t.Fatalf("snapshot id = %q, want %q", got, snapshotID)
+		}
+		_ = json.NewEncoder(w).Encode(PublisherStatus{
+			App:      "gitcrawl",
+			Archive:  "gitcrawl/openclaw",
+			Snapshot: &ArchiveSnapshot{ID: snapshotID},
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Options{Endpoint: server.URL, TokenProvider: StaticToken("secret")})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	status, err := client.PublishStatusForSnapshot(
+		context.Background(),
+		"gitcrawl",
+		"gitcrawl/openclaw",
+		" "+snapshotID+" ",
+	)
+	if err != nil {
+		t.Fatalf("publish status for snapshot: %v", err)
+	}
+	if status.Snapshot == nil || status.Snapshot.ID != snapshotID {
+		t.Fatalf("publish status = %#v", status)
+	}
+}
+
+func TestClientPublishStatusForSnapshotRejectsBlankIDBeforeRequest(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Options{Endpoint: server.URL, TokenProvider: StaticToken("secret")})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	_, err = client.PublishStatusForSnapshot(
+		context.Background(),
+		"gitcrawl",
+		"gitcrawl/openclaw",
+		" \t\n",
+	)
+	if err == nil || !strings.Contains(err.Error(), "snapshot id is required") {
+		t.Fatalf("publish status error = %v", err)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d", requests)
+	}
+}
+
+func TestClientPublishStatusForSnapshotReturnsRemoteError(t *testing.T) {
+	const snapshotID = "missing/snapshot"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("snapshot_id"); got != snapshotID {
+			t.Fatalf("snapshot id = %q, want %q", got, snapshotID)
+		}
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"code":    "snapshot_mismatch",
+			"message": "requested snapshot is not complete",
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Options{Endpoint: server.URL, TokenProvider: StaticToken("secret")})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	_, err = client.PublishStatusForSnapshot(
+		context.Background(),
+		"gitcrawl",
+		"gitcrawl/openclaw",
+		snapshotID,
+	)
+	var remoteErr *Error
+	if !errors.As(err, &remoteErr) ||
+		remoteErr.Status != http.StatusConflict ||
+		remoteErr.Code != "snapshot_mismatch" {
+		t.Fatalf("publish status error = %#v", err)
+	}
+}
+
 func TestClientArchiveOperations(t *testing.T) {
 	var requests []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1344,9 +1439,10 @@ func TestClientPreflightsCompleteSQLiteBundleManifestBeforePartUploads(t *testin
 	}
 
 	for _, tc := range []struct {
-		name    string
-		mutate  func(*SQLiteBundleManifest)
-		wantErr string
+		name       string
+		snapshotID string
+		mutate     func(*SQLiteBundleManifest)
+		wantErr    string
 	}{
 		{
 			name: "invalid-privacy-json",
@@ -1369,12 +1465,60 @@ func TestClientPreflightsCompleteSQLiteBundleManifestBeforePartUploads(t *testin
 			},
 			wantErr: "must not exceed 65536 bytes",
 		},
+		{
+			name:       "invalid-snapshot-reconstruct",
+			snapshotID: strings.Repeat("c", 64),
+			mutate: func(manifest *SQLiteBundleManifest) {
+				manifest.Reconstruct = "concatenate the parts somehow"
+			},
+			wantErr: "sqlite bundle reconstruct must be",
+		},
+		{
+			name:       "empty-snapshot-privacy-key",
+			snapshotID: strings.Repeat("c", 64),
+			mutate: func(manifest *SQLiteBundleManifest) {
+				manifest.Privacy[""] = true
+			},
+			wantErr: "sqlite bundle privacy key must not be empty",
+		},
+		{
+			name:       "oversized-snapshot-privacy-key",
+			snapshotID: strings.Repeat("c", 64),
+			mutate: func(manifest *SQLiteBundleManifest) {
+				manifest.Privacy[strings.Repeat("\u00e9", maxSQLiteBundleMetadataBytes/2+1)] = true
+			},
+			wantErr: "sqlite bundle privacy key must not exceed 1024 UTF-8 bytes",
+		},
+		{
+			name:       "invalid-utf8-snapshot-privacy-key",
+			snapshotID: strings.Repeat("c", 64),
+			mutate: func(manifest *SQLiteBundleManifest) {
+				manifest.Privacy[string([]byte{0xff})] = true
+			},
+			wantErr: "sqlite bundle privacy key must be valid UTF-8",
+		},
+		{
+			name:       "oversized-snapshot-count-name",
+			snapshotID: strings.Repeat("c", 64),
+			mutate: func(manifest *SQLiteBundleManifest) {
+				manifest.Counts[strings.Repeat("\u00e9", maxSQLiteBundleMetadataBytes/2+1)] = 1
+			},
+			wantErr: "sqlite bundle count name must not exceed 1024 UTF-8 bytes",
+		},
+		{
+			name:       "unsafe-snapshot-count",
+			snapshotID: strings.Repeat("c", 64),
+			mutate: func(manifest *SQLiteBundleManifest) {
+				manifest.Counts["rows"] = maxSQLiteBundleSafeInteger + 1
+			},
+			wantErr: `sqlite bundle count "rows" must be a non-negative safe integer`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			manifest := testSQLiteBundleManifest(
 				"gitcrawl",
 				"gitcrawl/openclaw__openclaw",
-				"",
+				tc.snapshotID,
 				int64(len("compressed")),
 			)
 			tc.mutate(&manifest)

--- a/remote/sqlite_bundle.go
+++ b/remote/sqlite_bundle.go
@@ -96,6 +96,8 @@ type sqliteBundleBuildLimits struct {
 	maxParts          int
 }
 
+type sqliteBundleSourceCopy func(context.Context, io.Writer, io.Reader) (int64, error)
+
 func BuildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions) (SQLiteBundleBuild, error) {
 	return buildGzipSQLiteBundle(ctx, opts, false)
 }
@@ -121,11 +123,30 @@ func buildGzipSQLiteBundleWithLimits(
 	snapshotScoped bool,
 	limits sqliteBundleBuildLimits,
 ) (SQLiteBundleBuild, error) {
+	return buildGzipSQLiteBundleWithSourceCopy(
+		ctx,
+		opts,
+		snapshotScoped,
+		limits,
+		copyWithContext,
+	)
+}
+
+func buildGzipSQLiteBundleWithSourceCopy(
+	ctx context.Context,
+	opts SQLiteBundleBuildOptions,
+	snapshotScoped bool,
+	limits sqliteBundleBuildLimits,
+	copySource sqliteBundleSourceCopy,
+) (SQLiteBundleBuild, error) {
 	if opts.SourcePath == "" {
 		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle source path is required")
 	}
 	if limits.maxCompressedSize <= 0 || limits.maxParts <= 0 {
 		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle build limits must be positive")
+	}
+	if copySource == nil {
+		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle source copier is required")
 	}
 	chunkSize := sqliteBundleChunkSize(opts.ChunkSize, snapshotScoped)
 	if chunkSize > DefaultSQLiteBundleChunkSize {
@@ -134,9 +155,24 @@ func buildGzipSQLiteBundleWithLimits(
 			DefaultSQLiteBundleChunkSize,
 		)
 	}
-	sourceInfo, err := os.Stat(opts.SourcePath)
+	source, err := os.Open(opts.SourcePath)
+	if err != nil {
+		return SQLiteBundleBuild{}, fmt.Errorf("open sqlite bundle source: %w", err)
+	}
+	defer func() { _ = source.Close() }()
+	sourceInfo, err := source.Stat()
 	if err != nil {
 		return SQLiteBundleBuild{}, fmt.Errorf("stat sqlite bundle source: %w", err)
+	}
+	if !sourceInfo.Mode().IsRegular() {
+		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle source must be a regular file")
+	}
+	pathInfo, err := os.Stat(opts.SourcePath)
+	if err != nil {
+		return SQLiteBundleBuild{}, fmt.Errorf("stat sqlite bundle source path: %w", err)
+	}
+	if !os.SameFile(sourceInfo, pathInfo) {
+		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle source changed before compression")
 	}
 	if err := validateSQLiteBundleSourceSize(sourceInfo.Size()); err != nil {
 		return SQLiteBundleBuild{}, err
@@ -179,17 +215,25 @@ func buildGzipSQLiteBundleWithLimits(
 	}
 	sourceSHA, sourceSize, err := gzipFile(
 		ctx,
-		opts.SourcePath,
+		source,
 		compressedPath,
 		level,
 		compressedLimit,
 		compressedLimitErr,
+		copySource,
 	)
 	if err != nil {
 		cleanup()
 		return SQLiteBundleBuild{}, err
 	}
-	if err := validateSQLiteBundleSourceSize(sourceSize); err != nil {
+	if err := validateSQLiteBundleSourceStable(
+		ctx,
+		source,
+		opts.SourcePath,
+		sourceInfo,
+		sourceSize,
+		sourceSHA,
+	); err != nil {
 		cleanup()
 		return SQLiteBundleBuild{}, err
 	}
@@ -408,17 +452,13 @@ func (w *sqliteBundleBoundedWriter) Write(p []byte) (int, error) {
 
 func gzipFile(
 	ctx context.Context,
-	sourcePath,
+	source io.Reader,
 	targetPath string,
 	level int,
 	maxCompressedSize int64,
 	limitErr error,
+	copySource sqliteBundleSourceCopy,
 ) (string, int64, error) {
-	source, err := os.Open(sourcePath)
-	if err != nil {
-		return "", 0, fmt.Errorf("open sqlite bundle source: %w", err)
-	}
-	defer func() { _ = source.Close() }()
 	target, err := os.OpenFile(targetPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
 	if err != nil {
 		return "", 0, fmt.Errorf("create compressed sqlite bundle: %w", err)
@@ -434,7 +474,7 @@ func gzipFile(
 		return "", 0, fmt.Errorf("create gzip writer: %w", err)
 	}
 	hash := sha256.New()
-	sourceSize, err := copyWithContext(ctx, io.MultiWriter(gzw, hash), source)
+	sourceSize, err := copySource(ctx, io.MultiWriter(gzw, hash), source)
 	if err != nil {
 		_ = gzw.Close()
 		return "", 0, fmt.Errorf("compress sqlite bundle: %w", err)
@@ -443,6 +483,64 @@ func gzipFile(
 		return "", 0, fmt.Errorf("finish compressed sqlite bundle: %w", err)
 	}
 	return fmt.Sprintf("%x", hash.Sum(nil)), sourceSize, nil
+}
+
+func validateSQLiteBundleSourceStable(
+	ctx context.Context,
+	source *os.File,
+	sourcePath string,
+	initialInfo os.FileInfo,
+	sourceSize int64,
+	sourceSHA256 string,
+) error {
+	if err := validateSQLiteBundleSourceState(source, sourcePath, initialInfo, sourceSize); err != nil {
+		return err
+	}
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rewind sqlite bundle source: %w", err)
+	}
+	hash := sha256.New()
+	verifiedSize, err := copyWithContext(ctx, hash, source)
+	if err != nil {
+		return fmt.Errorf("verify sqlite bundle source: %w", err)
+	}
+	if verifiedSize != sourceSize ||
+		fmt.Sprintf("%x", hash.Sum(nil)) != sourceSHA256 {
+		return fmt.Errorf("sqlite bundle source changed during bundle construction")
+	}
+	return validateSQLiteBundleSourceState(
+		source,
+		sourcePath,
+		initialInfo,
+		verifiedSize,
+	)
+}
+
+func validateSQLiteBundleSourceState(
+	source *os.File,
+	sourcePath string,
+	initialInfo os.FileInfo,
+	readSize int64,
+) error {
+	currentInfo, err := source.Stat()
+	if err != nil {
+		return fmt.Errorf("restat sqlite bundle source: %w", err)
+	}
+	pathInfo, err := os.Stat(sourcePath)
+	if err != nil {
+		return fmt.Errorf("restat sqlite bundle source path: %w", err)
+	}
+	if !os.SameFile(initialInfo, currentInfo) ||
+		!os.SameFile(initialInfo, pathInfo) ||
+		!currentInfo.Mode().IsRegular() ||
+		initialInfo.Size() != currentInfo.Size() ||
+		initialInfo.Size() != pathInfo.Size() ||
+		initialInfo.Size() != readSize ||
+		!initialInfo.ModTime().Equal(currentInfo.ModTime()) ||
+		!initialInfo.ModTime().Equal(pathInfo.ModTime()) {
+		return fmt.Errorf("sqlite bundle source changed during bundle construction")
+	}
+	return nil
 }
 
 func splitBundleParts(

--- a/remote/sqlite_bundle.go
+++ b/remote/sqlite_bundle.go
@@ -15,7 +15,7 @@ import (
 const (
 	SQLiteGzipChunkedBundleFormat = "sqlite-gzip-chunked-v1"
 	SQLiteGzipCompression         = "gzip"
-	DefaultSQLiteBundleChunkSize  = int64(256 * 1024 * 1024)
+	DefaultSQLiteBundleChunkSize  = int64(64 * 1024 * 1024)
 )
 
 type SQLiteBundleObject struct {

--- a/remote/sqlite_bundle.go
+++ b/remote/sqlite_bundle.go
@@ -138,11 +138,8 @@ func buildGzipSQLiteBundleWithLimits(
 	if err != nil {
 		return SQLiteBundleBuild{}, fmt.Errorf("stat sqlite bundle source: %w", err)
 	}
-	if sourceInfo.Size() <= 0 || sourceInfo.Size() > maxSQLiteBundleObjectSize {
-		return SQLiteBundleBuild{}, fmt.Errorf(
-			"sqlite bundle object size must be between 1 and %d bytes",
-			maxSQLiteBundleObjectSize,
-		)
+	if err := validateSQLiteBundleSourceSize(sourceInfo.Size()); err != nil {
+		return SQLiteBundleBuild{}, err
 	}
 	level := opts.CompressionLevel
 	if level == 0 {
@@ -192,12 +189,9 @@ func buildGzipSQLiteBundleWithLimits(
 		cleanup()
 		return SQLiteBundleBuild{}, err
 	}
-	if sourceSize > maxSQLiteBundleObjectSize {
+	if err := validateSQLiteBundleSourceSize(sourceSize); err != nil {
 		cleanup()
-		return SQLiteBundleBuild{}, fmt.Errorf(
-			"sqlite bundle object size must not exceed %d bytes",
-			maxSQLiteBundleObjectSize,
-		)
+		return SQLiteBundleBuild{}, err
 	}
 	compressedInfo, err := os.Stat(compressedPath)
 	if err != nil {
@@ -268,6 +262,16 @@ func buildGzipSQLiteBundleWithLimits(
 		Parts:          parts,
 		Cleanup:        cleanup,
 	}, nil
+}
+
+func validateSQLiteBundleSourceSize(size int64) error {
+	if size <= 0 || size > maxSQLiteBundleObjectSize {
+		return fmt.Errorf(
+			"sqlite bundle object size must be between 1 and %d bytes",
+			maxSQLiteBundleObjectSize,
+		)
+	}
+	return nil
 }
 
 func sqliteBundleChunkSize(requested int64, snapshotScoped bool) int64 {

--- a/remote/sqlite_bundle.go
+++ b/remote/sqlite_bundle.go
@@ -18,6 +18,7 @@ const (
 	DefaultSQLiteBundleChunkSize        = int64(256 * 1024 * 1024)
 	DefaultMutableSQLiteBundleChunkSize = int64(64 * 1024 * 1024)
 
+	maxSQLiteBundleManifestBytes  = int64(64 * 1024)
 	maxSQLiteBundleCompressedSize = int64(512 * 1024 * 1024)
 	maxSQLiteBundleObjectSize     = int64(4 * 1024 * 1024 * 1024)
 	maxSQLiteBundleParts          = 8
@@ -90,6 +91,11 @@ type SQLiteBundlePartUpload struct {
 	SnapshotID  string
 }
 
+type sqliteBundleBuildLimits struct {
+	maxCompressedSize int64
+	maxParts          int
+}
+
 func BuildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions) (SQLiteBundleBuild, error) {
 	return buildGzipSQLiteBundle(ctx, opts, false)
 }
@@ -103,10 +109,45 @@ func BuildSnapshotGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOp
 }
 
 func buildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions, snapshotScoped bool) (SQLiteBundleBuild, error) {
+	return buildGzipSQLiteBundleWithLimits(ctx, opts, snapshotScoped, sqliteBundleBuildLimits{
+		maxCompressedSize: maxSQLiteBundleCompressedSize,
+		maxParts:          maxSQLiteBundleParts,
+	})
+}
+
+func buildGzipSQLiteBundleWithLimits(
+	ctx context.Context,
+	opts SQLiteBundleBuildOptions,
+	snapshotScoped bool,
+	limits sqliteBundleBuildLimits,
+) (SQLiteBundleBuild, error) {
 	if opts.SourcePath == "" {
 		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle source path is required")
 	}
+	if limits.maxCompressedSize <= 0 || limits.maxParts <= 0 {
+		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle build limits must be positive")
+	}
 	chunkSize := sqliteBundleChunkSize(opts.ChunkSize, snapshotScoped)
+	maxPartSize := DefaultMutableSQLiteBundleChunkSize
+	if snapshotScoped {
+		maxPartSize = DefaultSQLiteBundleChunkSize
+	}
+	if chunkSize > maxPartSize {
+		return SQLiteBundleBuild{}, fmt.Errorf(
+			"sqlite bundle chunk size must not exceed %d bytes",
+			maxPartSize,
+		)
+	}
+	sourceInfo, err := os.Stat(opts.SourcePath)
+	if err != nil {
+		return SQLiteBundleBuild{}, fmt.Errorf("stat sqlite bundle source: %w", err)
+	}
+	if sourceInfo.Size() > maxSQLiteBundleObjectSize {
+		return SQLiteBundleBuild{}, fmt.Errorf(
+			"sqlite bundle object size must not exceed %d bytes",
+			maxSQLiteBundleObjectSize,
+		)
+	}
 	level := opts.CompressionLevel
 	if level == 0 {
 		level = gzip.DefaultCompression
@@ -129,10 +170,38 @@ func buildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions, s
 	}
 	cleanup := func() { _ = os.RemoveAll(tmpDir) }
 	compressedPath := filepath.Join(tmpDir, "current.db.gz")
-	sourceSHA, sourceSize, err := gzipFile(ctx, opts.SourcePath, compressedPath, level)
+	compressedLimit := limits.maxCompressedSize
+	compressedLimitErr := fmt.Errorf(
+		"compressed sqlite bundle exceeds %d bytes",
+		limits.maxCompressedSize,
+	)
+	partCapacity := chunkSize * int64(limits.maxParts)
+	if partCapacity < compressedLimit {
+		compressedLimit = partCapacity
+		compressedLimitErr = fmt.Errorf(
+			"compressed sqlite bundle requires more than %d parts at %d bytes each",
+			limits.maxParts,
+			chunkSize,
+		)
+	}
+	sourceSHA, sourceSize, err := gzipFile(
+		ctx,
+		opts.SourcePath,
+		compressedPath,
+		level,
+		compressedLimit,
+		compressedLimitErr,
+	)
 	if err != nil {
 		cleanup()
 		return SQLiteBundleBuild{}, err
+	}
+	if sourceSize > maxSQLiteBundleObjectSize {
+		cleanup()
+		return SQLiteBundleBuild{}, fmt.Errorf(
+			"sqlite bundle object size must not exceed %d bytes",
+			maxSQLiteBundleObjectSize,
+		)
 	}
 	compressedInfo, err := os.Stat(compressedPath)
 	if err != nil {
@@ -154,7 +223,16 @@ func buildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions, s
 		compressedObjectKey = SQLiteSnapshotCompressedObjectKey(opts.App, opts.Archive, snapshotID, compressedSHA)
 		reconstruct = "concatenate parts in index order to archive.db.gz, then gzip-decompress to archive.db"
 	}
-	parts, err := splitBundleParts(ctx, compressedPath, tmpDir, opts.App, opts.Archive, snapshotID, chunkSize)
+	parts, err := splitBundleParts(
+		ctx,
+		compressedPath,
+		tmpDir,
+		opts.App,
+		opts.Archive,
+		snapshotID,
+		chunkSize,
+		limits,
+	)
 	if err != nil {
 		cleanup()
 		return SQLiteBundleBuild{}, err
@@ -297,7 +375,45 @@ func validSQLiteSnapshotID(snapshotID string) bool {
 	return true
 }
 
-func gzipFile(ctx context.Context, sourcePath, targetPath string, level int) (string, int64, error) {
+type sqliteBundleBoundedWriter struct {
+	writer   io.Writer
+	limit    int64
+	written  int64
+	limitErr error
+}
+
+func (w *sqliteBundleBoundedWriter) Write(p []byte) (int, error) {
+	remaining := w.limit - w.written
+	if remaining <= 0 {
+		return 0, w.limitErr
+	}
+	if int64(len(p)) > remaining {
+		n, err := w.writer.Write(p[:remaining])
+		w.written += int64(n)
+		if err != nil {
+			return n, err
+		}
+		if int64(n) != remaining {
+			return n, io.ErrShortWrite
+		}
+		return n, w.limitErr
+	}
+	n, err := w.writer.Write(p)
+	w.written += int64(n)
+	if err == nil && n != len(p) {
+		err = io.ErrShortWrite
+	}
+	return n, err
+}
+
+func gzipFile(
+	ctx context.Context,
+	sourcePath,
+	targetPath string,
+	level int,
+	maxCompressedSize int64,
+	limitErr error,
+) (string, int64, error) {
 	source, err := os.Open(sourcePath)
 	if err != nil {
 		return "", 0, fmt.Errorf("open sqlite bundle source: %w", err)
@@ -308,7 +424,12 @@ func gzipFile(ctx context.Context, sourcePath, targetPath string, level int) (st
 		return "", 0, fmt.Errorf("create compressed sqlite bundle: %w", err)
 	}
 	defer func() { _ = target.Close() }()
-	gzw, err := gzip.NewWriterLevel(target, level)
+	boundedTarget := &sqliteBundleBoundedWriter{
+		writer:   target,
+		limit:    maxCompressedSize,
+		limitErr: limitErr,
+	}
+	gzw, err := gzip.NewWriterLevel(boundedTarget, level)
 	if err != nil {
 		return "", 0, fmt.Errorf("create gzip writer: %w", err)
 	}
@@ -324,14 +445,44 @@ func gzipFile(ctx context.Context, sourcePath, targetPath string, level int) (st
 	return fmt.Sprintf("%x", hash.Sum(nil)), sourceSize, nil
 }
 
-func splitBundleParts(ctx context.Context, sourcePath, dir, app, archive, snapshotID string, chunkSize int64) ([]SQLiteBundlePartFile, error) {
+func splitBundleParts(
+	ctx context.Context,
+	sourcePath,
+	dir,
+	app,
+	archive,
+	snapshotID string,
+	chunkSize int64,
+	limits sqliteBundleBuildLimits,
+) ([]SQLiteBundlePartFile, error) {
 	source, err := os.Open(sourcePath)
 	if err != nil {
 		return nil, fmt.Errorf("open compressed sqlite bundle: %w", err)
 	}
 	defer func() { _ = source.Close() }()
-	var parts []SQLiteBundlePartFile
-	for index := 0; ; index++ {
+	info, err := source.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat compressed sqlite bundle: %w", err)
+	}
+	if info.Size() <= 0 {
+		return nil, fmt.Errorf("compressed sqlite bundle is empty")
+	}
+	if info.Size() > limits.maxCompressedSize {
+		return nil, fmt.Errorf(
+			"compressed sqlite bundle exceeds %d bytes",
+			limits.maxCompressedSize,
+		)
+	}
+	partCount := int((info.Size()-1)/chunkSize) + 1
+	if partCount > limits.maxParts {
+		return nil, fmt.Errorf(
+			"compressed sqlite bundle requires %d parts, maximum is %d",
+			partCount,
+			limits.maxParts,
+		)
+	}
+	parts := make([]SQLiteBundlePartFile, 0, partCount)
+	for index := 0; index < partCount; index++ {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
@@ -341,17 +492,22 @@ func splitBundleParts(ctx context.Context, sourcePath, dir, app, archive, snapsh
 			return nil, fmt.Errorf("create sqlite bundle part: %w", err)
 		}
 		hash := sha256.New()
-		written, copyErr := io.CopyN(io.MultiWriter(partFile, hash), source, chunkSize)
+		partSize := min(chunkSize, info.Size()-int64(index)*chunkSize)
+		written, copyErr := io.CopyN(io.MultiWriter(partFile, hash), source, partSize)
 		closeErr := partFile.Close()
-		if copyErr != nil && copyErr != io.EOF {
+		if copyErr != nil {
 			return nil, fmt.Errorf("write sqlite bundle part: %w", copyErr)
 		}
 		if closeErr != nil {
 			return nil, fmt.Errorf("close sqlite bundle part: %w", closeErr)
 		}
-		if written == 0 && copyErr == io.EOF {
-			_ = os.Remove(partPath)
-			break
+		if written != partSize {
+			return nil, fmt.Errorf(
+				"write sqlite bundle part %d: wrote %d bytes, want %d",
+				index,
+				written,
+				partSize,
+			)
 		}
 		partSHA := fmt.Sprintf("%x", hash.Sum(nil))
 		parts = append(parts, SQLiteBundlePartFile{
@@ -363,12 +519,6 @@ func splitBundleParts(ctx context.Context, sourcePath, dir, app, archive, snapsh
 			},
 			Path: partPath,
 		})
-		if copyErr == io.EOF {
-			break
-		}
-	}
-	if len(parts) == 0 {
-		return nil, fmt.Errorf("compressed sqlite bundle is empty")
 	}
 	return parts, nil
 }

--- a/remote/sqlite_bundle.go
+++ b/remote/sqlite_bundle.go
@@ -24,6 +24,7 @@ const (
 	maxSQLiteBundleCompressedSize        = int64(512 * 1024 * 1024)
 	maxSQLiteBundleObjectSize            = int64(4 * 1024 * 1024 * 1024)
 	maxSQLiteBundleParts                 = 8
+	maxSQLiteBundleInitialPartsCapacity  = 64
 )
 
 type SQLiteBundleObject struct {
@@ -222,9 +223,14 @@ func buildGzipSQLiteBundleWithSourceCopy(
 			)
 		}
 	}
+	boundedSource, err := sqliteBundleDeclaredSizeReader(source, sourceInfo.Size())
+	if err != nil {
+		cleanup()
+		return SQLiteBundleBuild{}, err
+	}
 	sourceSHA, sourceSize, err := gzipFile(
 		ctx,
-		source,
+		boundedSource,
 		compressedPath,
 		level,
 		compressedLimit,
@@ -234,6 +240,10 @@ func buildGzipSQLiteBundleWithSourceCopy(
 	if err != nil {
 		cleanup()
 		return SQLiteBundleBuild{}, err
+	}
+	if sourceSize != sourceInfo.Size() {
+		cleanup()
+		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle source changed during bundle construction")
 	}
 	if err := validateSQLiteBundleSourceStable(
 		ctx,
@@ -251,7 +261,7 @@ func buildGzipSQLiteBundleWithSourceCopy(
 		cleanup()
 		return SQLiteBundleBuild{}, fmt.Errorf("stat compressed sqlite bundle: %w", err)
 	}
-	compressedSHA, err := fileSHA256(ctx, compressedPath)
+	compressedSHA, err := fileSHA256(ctx, compressedPath, compressedInfo.Size())
 	if err != nil {
 		cleanup()
 		return SQLiteBundleBuild{}, err
@@ -512,7 +522,12 @@ func validateSQLiteBundleSourceStable(
 		return fmt.Errorf("rewind sqlite bundle source: %w", err)
 	}
 	hash := sha256.New()
-	verifiedSize, err := copyWithContext(ctx, hash, source)
+	verifiedSize, err := copySQLiteBundleDeclaredSize(
+		ctx,
+		hash,
+		source,
+		initialInfo.Size(),
+	)
 	if err != nil {
 		return fmt.Errorf("verify sqlite bundle source: %w", err)
 	}
@@ -577,33 +592,52 @@ func splitBundleParts(
 	if info.Size() <= 0 {
 		return nil, fmt.Errorf("compressed sqlite bundle is empty")
 	}
+	if chunkSize <= 0 {
+		return nil, fmt.Errorf("sqlite bundle chunk size must be positive")
+	}
 	if limits.maxCompressedSize > 0 && info.Size() > limits.maxCompressedSize {
 		return nil, fmt.Errorf(
 			"compressed sqlite bundle exceeds %d bytes",
 			limits.maxCompressedSize,
 		)
 	}
-	partCount := int((info.Size()-1)/chunkSize) + 1
-	if limits.maxParts > 0 && partCount > limits.maxParts {
+	partCount := (info.Size()-1)/chunkSize + 1
+	if limits.maxParts > 0 && partCount > int64(limits.maxParts) {
 		return nil, fmt.Errorf(
 			"compressed sqlite bundle requires %d parts, maximum is %d",
 			partCount,
 			limits.maxParts,
 		)
 	}
-	parts := make([]SQLiteBundlePartFile, 0, partCount)
-	for index := 0; index < partCount; index++ {
+	if partCount > int64(^uint(0)>>1) {
+		return nil, fmt.Errorf("compressed sqlite bundle requires too many parts")
+	}
+	boundedSource, err := sqliteBundleDeclaredSizeReader(source, info.Size())
+	if err != nil {
+		return nil, err
+	}
+	parts := make(
+		[]SQLiteBundlePartFile,
+		0,
+		sqliteBundleInitialPartsCapacity(partCount),
+	)
+	for partNumber := int64(0); partNumber < partCount; partNumber++ {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
+		index := int(partNumber)
 		partPath := filepath.Join(dir, fmt.Sprintf("current.db.gz.part-%04d", index))
 		partFile, err := os.OpenFile(partPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
 		if err != nil {
 			return nil, fmt.Errorf("create sqlite bundle part: %w", err)
 		}
 		hash := sha256.New()
-		partSize := min(chunkSize, info.Size()-int64(index)*chunkSize)
-		written, copyErr := io.CopyN(io.MultiWriter(partFile, hash), source, partSize)
+		partSize := min(chunkSize, info.Size()-partNumber*chunkSize)
+		written, copyErr := io.CopyN(
+			io.MultiWriter(partFile, hash),
+			boundedSource,
+			partSize,
+		)
 		closeErr := partFile.Close()
 		if copyErr != nil {
 			return nil, fmt.Errorf("write sqlite bundle part: %w", copyErr)
@@ -630,20 +664,68 @@ func splitBundleParts(
 			Path: partPath,
 		})
 	}
+	extra, err := copyWithContext(ctx, io.Discard, boundedSource)
+	if err != nil {
+		return nil, fmt.Errorf("verify compressed sqlite bundle size: %w", err)
+	}
+	infoAfter, err := source.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("restat compressed sqlite bundle: %w", err)
+	}
+	if extra != 0 ||
+		!os.SameFile(info, infoAfter) ||
+		infoAfter.Size() != info.Size() ||
+		!infoAfter.ModTime().Equal(info.ModTime()) {
+		return nil, fmt.Errorf("compressed sqlite bundle changed while splitting")
+	}
 	return parts, nil
 }
 
-func fileSHA256(ctx context.Context, path string) (string, error) {
+func sqliteBundleInitialPartsCapacity(partCount int64) int {
+	if partCount <= 0 {
+		return 0
+	}
+	return int(min(partCount, maxSQLiteBundleInitialPartsCapacity))
+}
+
+func fileSHA256(ctx context.Context, path string, expectedSize int64) (string, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return "", fmt.Errorf("open file for sha256: %w", err)
 	}
 	defer func() { _ = file.Close() }()
 	hash := sha256.New()
-	if _, err := copyWithContext(ctx, hash, file); err != nil {
+	size, err := copySQLiteBundleDeclaredSize(ctx, hash, file, expectedSize)
+	if err != nil {
 		return "", fmt.Errorf("hash file: %w", err)
 	}
+	if size != expectedSize {
+		return "", fmt.Errorf("file changed while hashing")
+	}
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
+func sqliteBundleDeclaredSizeReader(src io.Reader, declaredSize int64) (*io.LimitedReader, error) {
+	if declaredSize < 0 {
+		return nil, fmt.Errorf("sqlite bundle declared size must not be negative")
+	}
+	if declaredSize == math.MaxInt64 {
+		return nil, fmt.Errorf("sqlite bundle declared size is too large to bound")
+	}
+	return &io.LimitedReader{R: src, N: declaredSize + 1}, nil
+}
+
+func copySQLiteBundleDeclaredSize(
+	ctx context.Context,
+	dst io.Writer,
+	src io.Reader,
+	declaredSize int64,
+) (int64, error) {
+	bounded, err := sqliteBundleDeclaredSizeReader(src, declaredSize)
+	if err != nil {
+		return 0, err
+	}
+	return copyWithContext(ctx, dst, bounded)
 }
 
 func copyWithContext(ctx context.Context, dst io.Writer, src io.Reader) (int64, error) {

--- a/remote/sqlite_bundle.go
+++ b/remote/sqlite_bundle.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"math"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -111,10 +112,12 @@ func BuildSnapshotGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOp
 }
 
 func buildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions, snapshotScoped bool) (SQLiteBundleBuild, error) {
-	return buildGzipSQLiteBundleWithLimits(ctx, opts, snapshotScoped, sqliteBundleBuildLimits{
-		maxCompressedSize: maxSQLiteBundleCompressedSize,
-		maxParts:          maxSQLiteBundleParts,
-	})
+	limits := sqliteBundleBuildLimits{}
+	if snapshotScoped {
+		limits.maxCompressedSize = maxSQLiteBundleCompressedSize
+		limits.maxParts = maxSQLiteBundleParts
+	}
+	return buildGzipSQLiteBundleWithLimits(ctx, opts, snapshotScoped, limits)
 }
 
 func buildGzipSQLiteBundleWithLimits(
@@ -142,8 +145,9 @@ func buildGzipSQLiteBundleWithSourceCopy(
 	if opts.SourcePath == "" {
 		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle source path is required")
 	}
-	if limits.maxCompressedSize <= 0 || limits.maxParts <= 0 {
-		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle build limits must be positive")
+	if limits.maxCompressedSize < 0 || limits.maxParts < 0 ||
+		(limits.maxCompressedSize == 0) != (limits.maxParts == 0) {
+		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle build limits must both be zero or positive")
 	}
 	if copySource == nil {
 		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle source copier is required")
@@ -199,19 +203,23 @@ func buildGzipSQLiteBundleWithSourceCopy(
 	}
 	cleanup := func() { _ = os.RemoveAll(tmpDir) }
 	compressedPath := filepath.Join(tmpDir, "current.db.gz")
-	compressedLimit := limits.maxCompressedSize
-	compressedLimitErr := fmt.Errorf(
-		"compressed sqlite bundle exceeds %d bytes",
-		limits.maxCompressedSize,
-	)
-	partCapacity := chunkSize * int64(limits.maxParts)
-	if partCapacity < compressedLimit {
-		compressedLimit = partCapacity
+	compressedLimit := int64(math.MaxInt64)
+	compressedLimitErr := fmt.Errorf("compressed sqlite bundle exceeds the supported size")
+	if limits.maxCompressedSize > 0 {
+		compressedLimit = limits.maxCompressedSize
 		compressedLimitErr = fmt.Errorf(
-			"compressed sqlite bundle requires more than %d parts at %d bytes each",
-			limits.maxParts,
-			chunkSize,
+			"compressed sqlite bundle exceeds %d bytes",
+			limits.maxCompressedSize,
 		)
+		partCapacity := chunkSize * int64(limits.maxParts)
+		if partCapacity < compressedLimit {
+			compressedLimit = partCapacity
+			compressedLimitErr = fmt.Errorf(
+				"compressed sqlite bundle requires more than %d parts at %d bytes each",
+				limits.maxParts,
+				chunkSize,
+			)
+		}
 	}
 	sourceSHA, sourceSize, err := gzipFile(
 		ctx,
@@ -565,14 +573,14 @@ func splitBundleParts(
 	if info.Size() <= 0 {
 		return nil, fmt.Errorf("compressed sqlite bundle is empty")
 	}
-	if info.Size() > limits.maxCompressedSize {
+	if limits.maxCompressedSize > 0 && info.Size() > limits.maxCompressedSize {
 		return nil, fmt.Errorf(
 			"compressed sqlite bundle exceeds %d bytes",
 			limits.maxCompressedSize,
 		)
 	}
 	partCount := int((info.Size()-1)/chunkSize) + 1
-	if partCount > limits.maxParts {
+	if limits.maxParts > 0 && partCount > limits.maxParts {
 		return nil, fmt.Errorf(
 			"compressed sqlite bundle requires %d parts, maximum is %d",
 			partCount,

--- a/remote/sqlite_bundle.go
+++ b/remote/sqlite_bundle.go
@@ -13,11 +13,10 @@ import (
 )
 
 const (
-	SQLiteGzipChunkedBundleFormat = "sqlite-gzip-chunked-v1"
-	SQLiteGzipCompression         = "gzip"
-	DefaultSQLiteBundleChunkSize  = int64(64 * 1024 * 1024)
-
-	releasedSnapshotSQLiteBundleChunkSize = int64(256 * 1024 * 1024)
+	SQLiteGzipChunkedBundleFormat       = "sqlite-gzip-chunked-v1"
+	SQLiteGzipCompression               = "gzip"
+	DefaultSQLiteBundleChunkSize        = int64(256 * 1024 * 1024)
+	DefaultMutableSQLiteBundleChunkSize = int64(64 * 1024 * 1024)
 )
 
 type SQLiteBundleObject struct {
@@ -198,9 +197,9 @@ func sqliteBundleChunkSize(requested int64, snapshotScoped bool) int64 {
 		return requested
 	}
 	if snapshotScoped {
-		return releasedSnapshotSQLiteBundleChunkSize
+		return DefaultSQLiteBundleChunkSize
 	}
-	return DefaultSQLiteBundleChunkSize
+	return DefaultMutableSQLiteBundleChunkSize
 }
 
 func SQLiteObjectKey(app, archive string) string {

--- a/remote/sqlite_bundle.go
+++ b/remote/sqlite_bundle.go
@@ -16,6 +16,8 @@ const (
 	SQLiteGzipChunkedBundleFormat = "sqlite-gzip-chunked-v1"
 	SQLiteGzipCompression         = "gzip"
 	DefaultSQLiteBundleChunkSize  = int64(64 * 1024 * 1024)
+
+	releasedSnapshotSQLiteBundleChunkSize = int64(256 * 1024 * 1024)
 )
 
 type SQLiteBundleObject struct {
@@ -101,10 +103,7 @@ func buildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions, s
 	if opts.SourcePath == "" {
 		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle source path is required")
 	}
-	chunkSize := opts.ChunkSize
-	if chunkSize <= 0 {
-		chunkSize = DefaultSQLiteBundleChunkSize
-	}
+	chunkSize := sqliteBundleChunkSize(opts.ChunkSize, snapshotScoped)
 	level := opts.CompressionLevel
 	if level == 0 {
 		level = gzip.DefaultCompression
@@ -192,6 +191,16 @@ func buildGzipSQLiteBundle(ctx context.Context, opts SQLiteBundleBuildOptions, s
 		Parts:          parts,
 		Cleanup:        cleanup,
 	}, nil
+}
+
+func sqliteBundleChunkSize(requested int64, snapshotScoped bool) int64 {
+	if requested > 0 {
+		return requested
+	}
+	if snapshotScoped {
+		return releasedSnapshotSQLiteBundleChunkSize
+	}
+	return DefaultSQLiteBundleChunkSize
 }
 
 func SQLiteObjectKey(app, archive string) string {

--- a/remote/sqlite_bundle.go
+++ b/remote/sqlite_bundle.go
@@ -19,10 +19,11 @@ const (
 	DefaultSQLiteBundleChunkSize        = int64(256 * 1024 * 1024)
 	DefaultMutableSQLiteBundleChunkSize = int64(64 * 1024 * 1024)
 
-	maxSQLiteBundleManifestBytes  = int64(64 * 1024)
-	maxSQLiteBundleCompressedSize = int64(512 * 1024 * 1024)
-	maxSQLiteBundleObjectSize     = int64(4 * 1024 * 1024 * 1024)
-	maxSQLiteBundleParts          = 8
+	maxSQLiteSnapshotBundleManifestBytes = int64(64 * 1024)
+	maxSQLiteMutableBundleManifestBytes  = int64(1024 * 1024)
+	maxSQLiteBundleCompressedSize        = int64(512 * 1024 * 1024)
+	maxSQLiteBundleObjectSize            = int64(4 * 1024 * 1024 * 1024)
+	maxSQLiteBundleParts                 = 8
 )
 
 type SQLiteBundleObject struct {
@@ -153,7 +154,7 @@ func buildGzipSQLiteBundleWithSourceCopy(
 		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle source copier is required")
 	}
 	chunkSize := sqliteBundleChunkSize(opts.ChunkSize, snapshotScoped)
-	if chunkSize > DefaultSQLiteBundleChunkSize {
+	if snapshotScoped && chunkSize > DefaultSQLiteBundleChunkSize {
 		return SQLiteBundleBuild{}, fmt.Errorf(
 			"sqlite bundle chunk size must not exceed %d bytes",
 			DefaultSQLiteBundleChunkSize,
@@ -178,7 +179,7 @@ func buildGzipSQLiteBundleWithSourceCopy(
 	if !os.SameFile(sourceInfo, pathInfo) {
 		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle source changed before compression")
 	}
-	if err := validateSQLiteBundleSourceSize(sourceInfo.Size()); err != nil {
+	if err := validateSQLiteBundleSourceSize(sourceInfo.Size(), snapshotScoped); err != nil {
 		return SQLiteBundleBuild{}, err
 	}
 	level := opts.CompressionLevel
@@ -316,8 +317,11 @@ func buildGzipSQLiteBundleWithSourceCopy(
 	}, nil
 }
 
-func validateSQLiteBundleSourceSize(size int64) error {
-	if size <= 0 || size > maxSQLiteBundleObjectSize {
+func validateSQLiteBundleSourceSize(size int64, snapshotScoped bool) error {
+	if size <= 0 {
+		return fmt.Errorf("sqlite bundle object size must be positive")
+	}
+	if snapshotScoped && size > maxSQLiteBundleObjectSize {
 		return fmt.Errorf(
 			"sqlite bundle object size must be between 1 and %d bytes",
 			maxSQLiteBundleObjectSize,

--- a/remote/sqlite_bundle.go
+++ b/remote/sqlite_bundle.go
@@ -17,6 +17,10 @@ const (
 	SQLiteGzipCompression               = "gzip"
 	DefaultSQLiteBundleChunkSize        = int64(256 * 1024 * 1024)
 	DefaultMutableSQLiteBundleChunkSize = int64(64 * 1024 * 1024)
+
+	maxSQLiteBundleCompressedSize = int64(512 * 1024 * 1024)
+	maxSQLiteBundleObjectSize     = int64(4 * 1024 * 1024 * 1024)
+	maxSQLiteBundleParts          = 8
 )
 
 type SQLiteBundleObject struct {

--- a/remote/sqlite_bundle.go
+++ b/remote/sqlite_bundle.go
@@ -128,23 +128,19 @@ func buildGzipSQLiteBundleWithLimits(
 		return SQLiteBundleBuild{}, fmt.Errorf("sqlite bundle build limits must be positive")
 	}
 	chunkSize := sqliteBundleChunkSize(opts.ChunkSize, snapshotScoped)
-	maxPartSize := DefaultMutableSQLiteBundleChunkSize
-	if snapshotScoped {
-		maxPartSize = DefaultSQLiteBundleChunkSize
-	}
-	if chunkSize > maxPartSize {
+	if chunkSize > DefaultSQLiteBundleChunkSize {
 		return SQLiteBundleBuild{}, fmt.Errorf(
 			"sqlite bundle chunk size must not exceed %d bytes",
-			maxPartSize,
+			DefaultSQLiteBundleChunkSize,
 		)
 	}
 	sourceInfo, err := os.Stat(opts.SourcePath)
 	if err != nil {
 		return SQLiteBundleBuild{}, fmt.Errorf("stat sqlite bundle source: %w", err)
 	}
-	if sourceInfo.Size() > maxSQLiteBundleObjectSize {
+	if sourceInfo.Size() <= 0 || sourceInfo.Size() > maxSQLiteBundleObjectSize {
 		return SQLiteBundleBuild{}, fmt.Errorf(
-			"sqlite bundle object size must not exceed %d bytes",
+			"sqlite bundle object size must be between 1 and %d bytes",
 			maxSQLiteBundleObjectSize,
 		)
 	}


### PR DESCRIPTION
## Summary

- preserve the shipped 256 MiB `DefaultSQLiteBundleChunkSize`, immutable snapshot representation, and 64 MiB mutable producer default
- retain legacy mutable compatibility for explicitly configured large chunks/objects/part counts, minimal manifests, and file-backed `Size: -1` unknown-length part transport
- preserve optional mutable part digests while verifying any supplied digest; immutable snapshot sizes and digests remain strict
- enforce the negotiated 256 MiB part, 4 GiB object, 512 MiB compressed, eight-part, and 64 KiB manifest bounds only for immutable snapshots
- cap every immutable or file-backed source/part/hash/compression read at the declared or statted size plus one byte, detecting same-inode growth without consuming an unbounded appended tail
- encode manifests in the deterministic two-space JSON representation crawl-remote persists, with allocation-bounded structural size preflight before full encoding; compact input that expands beyond the persisted ceiling is rejected before any request
- keep mutable file handling sequential and staging-free, match files to manifest entries by declared part index, reject duplicate indexes, and bound initial split capacity for caller-controlled tiny chunk sizes
- bind snapshot-scoped publish status to the normalized requested app, archive, and snapshot ID

## Review blockers closed

1. Immutable/file-backed reads and compression are bounded to declared size plus one byte, with growing source, part-validation, and upload regressions.
2. Manifest preflight is allocation-bounded and validates the same pretty-printed persisted representation and byte ceiling used by crawl-remote, including compact-input expansion and custom-marshaler adversarial coverage.
3. Legacy mutable `Size: -1` keeps unknown-length/chunked transport; snapshot-scoped parts require an exact nonnegative size.
4. Mutable `splitBundleParts` uses bounded initial capacity instead of preallocating caller-controlled `partCount`.
5. Strict complete-manifest validation is snapshot-only, preserving v0.14.1 minimal mutable manifest inputs.
6. Mutable part files match manifest entries by declared `Index`, with reordered and duplicate-index coverage.
7. `PublishStatusForSnapshot` rejects same-digest responses for the wrong normalized app or archive.
8. `UploadSQLiteBundleFiles` resolves mutable `Size: -1` to the statted file size only for bounded local validation and streaming, while retaining `ContentLength: -1` and chunked HTTP transport.
9. Mutable file uploads allow an omitted `SHA256` header but still reject mismatched supplied digests; snapshot-scoped manifests and files retain mandatory exact sizes and digests.
10. Unknown-length mutable uploads expose exactly the statted bytes to HTTP and perform the one-byte growth probe locally after the request, so concurrent appends cannot corrupt the remote part before rejection.

## Compatibility and wire contract

- legacy/exported `DefaultSQLiteBundleChunkSize`: 256 MiB
- mutable producer default: 64 MiB
- mutable manifest maximum: 1 MiB persisted representation
- immutable snapshot maximum part size: 256 MiB
- immutable snapshot maximum object size: 4 GiB
- immutable snapshot maximum compressed total: 512 MiB
- immutable snapshot maximum part count: 8
- immutable snapshot manifest maximum: 64 KiB persisted representation
- snapshot metadata map keys: at most 1 KiB of valid UTF-8
- snapshot count values: non-negative JavaScript-safe integers
- immutable manifests omit `generated_at`; retries keep deterministic field order and two-space JSON

The crawlkit fixture and manifest representation coordinate with https://github.com/openclaw/crawl-remote/pull/36 at current head `d2a3134cab45e78f59787c27aa41857d229320c1`. Snapshot manifests also send `x-crawl-snapshot-id` so crawl-remote can enforce the immutable ceiling from byte zero.

## Validation

Exact pushed head: `e1103dcb919b404c0f3a85dece5575ebd3607ad7`

- focused remote suite: `GOWORK=off go test -count=1 ./remote`
- repeated compatibility regressions: `GOWORK=off go test -count=5 ./remote -run 'TestClient(PreservesUnknownLengthMutableBundleFileTransport|AllowsMutableBundleFileWithoutSHA256|KeepsUnknownLengthGrowthProbeOutOfMutableBundleUpload|BoundsMutablePartGrowthDuringUpload|RejectsChangedSQLiteBundlePartContentBeforeRequest|PreservesUnknownLengthMutablePartTransport)'`
- full suite: `GOWORK=off go test -count=1 ./...`
- vet: `GOWORK=off go vet ./...`
- module hygiene: `GOWORK=off go mod tidy` and `git diff --exit-code -- go.mod go.sum`
- repository-wide `gofmt -l` check
- `git diff --check`
- Windows amd64 cross-build: `CGO_ENABLED=0 GOOS=windows GOARCH=amd64 GOWORK=off go test -exec=true -run '^$' -count=1 ./...`
- Windows arm64 cross-build: `CGO_ENABLED=0 GOOS=windows GOARCH=arm64 GOWORK=off go test -exec=true -run '^$' -count=1 ./...`
- hosted checks at the exact pushed head: 6 successful, 0 pending, 0 failing (`CI/test`, `CI/windows-test`, `CodeQL/analyze`, `CodeQL`, and two secret scans)
- read-only local ClawSweeper range review of `e3fce078b7dee2cf4b597ee0dab3b97083301cc6..e1103dcb919b404c0f3a85dece5575ebd3607ad7`: patch correct, no actionable code or security findings

## Latest commits

- `e1103dc` `fix(remote): keep mutable growth probes local`
- `e3fce07` `fix(remote): preserve mutable file upload compatibility`
- `4521264` `docs(changelog): document bounded bundle guarantees`
- `4e2b34c` `fix(remote): close bounded bundle review gaps`

