### PR TITLE
docs(changelog): restore v0.14 release sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Add a publisher-authenticated archive status route and client helper so
-  interrupted snapshot publication can resume without reader credentials.
+## v0.14.2 - 2026-07-12
+
 - Add a snapshot-scoped publisher status client helper so resumable publishers
   verify the exact immutable candidate instead of trusting an unrelated
   completed candidate from the unscoped status route, and reject successful
@@ -31,6 +31,11 @@
   deterministic two-space persisted JSON representation and are size-preflighted
   before full encoding: snapshots are capped at 64 KiB while legacy mutable
   manifests retain the service-compatible 1 MiB ceiling.
+
+## v0.14.1 - 2026-07-12
+
+- Add a publisher-authenticated archive status route and client helper so
+  interrupted snapshot publication can resume without reader credentials.
 
 ## v0.14.0 - 2026-07-12
 


### PR DESCRIPTION
## Summary

- restore version sections for signed tags `v0.14.1` and `v0.14.2`
- keep each existing changelog entry with the tag whose commit range introduced it
- restore an empty `Unreleased` section for future work

## Proof

- compared `v0.14.0..v0.14.1` and `v0.14.1..v0.14.2` commit ranges
- compared `CHANGELOG.md` at both signed tags
- `git diff --check`
- `GOWORK=off go mod tidy`
- `git diff --exit-code -- go.mod go.sum`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test -count=1 ./...` (18 packages passed)
- AutoReview clean: no accepted/actionable findings; confidence 0.98

This repairs current-main release notes only. It does not create the missing GitHub Releases or macOS assets for `v0.14.0`, `v0.14.1`, or `v0.14.2`.
