### PR TITLE
build(deps): bump go-isatty to 0.0.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/charmbracelet/x/term v0.2.2
-	github.com/mattn/go-isatty v0.0.22
+	github.com/mattn/go-isatty v0.0.23
 	github.com/pelletier/go-toml/v2 v2.4.3
 	modernc.org/sqlite v1.53.0
 )

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/lucasb-eyer/go-colorful v1.4.0 h1:UtrWVfLdarDgc44HcS7pYloGHJUjHV/4FwW4TvVgFr4=
 github.com/lucasb-eyer/go-colorful v1.4.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
-github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
+github.com/mattn/go-isatty v0.0.23 h1:cYwCQTQf3HB6xUC+BtyCLZNr7IzbOmoZbmssVNzSyiQ=
+github.com/mattn/go-isatty v0.0.23/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
 github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/ay2DU=


### PR DESCRIPTION
## Summary

- update direct dependency `github.com/mattn/go-isatty` from `v0.0.22` to `v0.0.23`
- retain existing terminal detection behavior on supported crawlkit targets

Upstream delta: Haiku gets a non-terminal stub; the dependency Go directive moves down to 1.20. No exported API change.

## Proof

- upstream tag `v0.0.23` points to `4bc9b75fc8738b40f30b420ad17c00e8a151c3bf`
- `GOWORK=off go mod verify`
- `GOWORK=off go mod tidy`
- `git diff --exit-code -- go.mod go.sum` after commit
- `GOWORK=off go vet ./...`
- `GOWORK=off go test -count=1 ./...` (18 packages passed)
- `GOWORK=off go test -race -count=1 ./...` (18 packages passed)
- `GOWORK=off go run golang.org/x/vuln/cmd/govulncheck@v1.4.0 ./...` (0 reachable vulnerabilities)
- external consumer of `releasecheck.StderrIsTerminal`: `false` through pipes, `true` under a PTY
- built `crawlctl`: `--version` returned `dev`; `--help` listed all commands
- AutoReview clean: no accepted/actionable findings; confidence 0.99
