### PR TITLE
build(release): prepare v0.14.3

### DIFF
--- a/.github/release-allowed-signers
+++ b/.github/release-allowed-signers
@@ -1,1 +1,1 @@
-steipete@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII9XsaCcr8TInPnHcuTVfvXXcsoUFrOE7menfbEIHFW9
+steipete@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA6rFpd7CodTF6fy60LZTriTeiGAJ7haIBWD4hrdxmDB

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## v0.14.3 - 2026-07-17
+
+### Highlights
+
+- Restore release readiness with Peter's current repository-pinned SSH signing key and a supported pre-tag macOS notarization preflight that rechecks online tickets and build provenance after managed keychain cleanup.
+- Update the bundled SQLite engine to v3.53.3 through `modernc.org/sqlite` v1.54.0.
+
+### Maintenance
+
+- Update terminal detection to `go-isatty` v0.0.23, CodeQL Action to v4.37.0, and TruffleHog to v3.95.9.
+
 ## v0.14.2 - 2026-07-12
 
 - Add a snapshot-scoped publisher status client helper so resumable publishers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Maintenance
 
-- Update terminal detection to `go-isatty` v0.0.23, CodeQL Action to v4.37.0, and TruffleHog to v3.95.9.
+- Update terminal detection to `go-isatty` v0.0.23 and refresh CI security tooling.
 
 ## v0.14.2 - 2026-07-12
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -20,16 +20,27 @@ GOWORK=off go test -count=1 ./...
 3. Update docs and changelogs in `crawlkit` plus every downstream app branch
    that consumes the release.
 4. Test downstream apps against the local checkout through a temporary Go workspace.
-5. Merge `crawlkit` to `main`.
-6. Tag the next semver release from `main`:
+5. Before merging, run a complete notarization preflight from the clean release
+   candidate with the approved private signing environment. This does not
+   inspect or create a tag. It produces disposable candidates, restores the
+   managed keychain, then runs the credential-free online-ticket and build
+   provenance verifier:
 
 ```bash
-git tag -s v0.14.0
-git push origin main
-git push origin v0.14.0
+preflight_dir=$(mktemp -d /private/tmp/crawlkit-v0.14.3-preflight.XXXXXX)
+scripts/preflight-crawlctl-release.sh v0.14.3 "$preflight_dir"
 ```
 
-7. From the clean checkout whose `HEAD` exactly matches the signed release tag,
+6. Merge `crawlkit` to `main`.
+7. Tag the next semver release from `main`:
+
+```bash
+git tag -s v0.14.3
+git push origin main
+git push origin v0.14.3
+```
+
+8. From the clean checkout whose `HEAD` exactly matches the signed release tag,
 build the signed macOS artifacts. The package entrypoint fetches the remote tag
 and protected `main` head into temporary refs, verifies the annotated tag against
 the repository-pinned SSH signer principal and key, requires the signed tag
@@ -39,11 +50,11 @@ or renamed tag is not releasable. It then uses the shared secret-safe release
 keychain helper and fails closed if any provenance or signing check differs:
 
 ```bash
-make release-artifacts VERSION=v0.14.0
-release_commit=$(scripts/verify-crawlctl-release-provenance.sh v0.14.0)
-scripts/verify-crawlctl-release.sh v0.14.0 "$release_commit" \
-  dist/crawlctl-v0.14.0-macos-arm64.tar.gz \
-  dist/crawlctl-v0.14.0-macos-x86_64.tar.gz
+make release-artifacts VERSION=v0.14.3
+release_commit=$(scripts/verify-crawlctl-release-provenance.sh v0.14.3)
+scripts/verify-crawlctl-release.sh v0.14.3 "$release_commit" \
+  dist/crawlctl-v0.14.3-macos-arm64.tar.gz \
+  dist/crawlctl-v0.14.3-macos-x86_64.tar.gz
 ```
 
 The fixed code identifier is `org.openclaw.crawlctl`. The required signing
@@ -80,7 +91,7 @@ Apple. Do not use
 standalone executables can exit with “the code is valid but does not seem to be
 an app.”
 
-8. Create the GitHub release as a draft, attach both archives and their
+9. Create the GitHub release as a draft, attach both archives and their
 `.sha256` files, then run the `Release Assets` workflow manually from the
 default branch with the tag to verify the uploaded draft assets. Publish only
 after that check succeeds. A crawlkit release without both verified signed
@@ -107,17 +118,17 @@ separately:
   action succeeds without a second alert. Do not claim first-install prompt
   suppression.
 
-9. Prime and verify module proxy visibility:
+10. Prime and verify module proxy visibility:
 
 ```bash
-GOPROXY=https://proxy.golang.org GONOSUMDB= go list -m github.com/openclaw/crawlkit@v0.14.0
-GOPROXY=https://proxy.golang.org go list -m github.com/openclaw/crawlkit@v0.14.0
+GOPROXY=https://proxy.golang.org GONOSUMDB= go list -m github.com/openclaw/crawlkit@v0.14.3
+GOPROXY=https://proxy.golang.org go list -m github.com/openclaw/crawlkit@v0.14.3
 ```
 
-10. Bump downstream apps to the new tag and commit their `go.mod`/`go.sum` updates:
+11. Bump downstream apps to the new tag and commit their `go.mod`/`go.sum` updates:
 
 ```bash
-go get github.com/openclaw/crawlkit@v0.14.0
+go get github.com/openclaw/crawlkit@v0.14.3
 GOWORK=off go mod tidy
 ```
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -20,8 +20,17 @@ GOWORK=off go test -count=1 ./...
 3. Update docs and changelogs in `crawlkit` plus every downstream app branch
    that consumes the release.
 4. Test downstream apps against the local checkout through a temporary Go workspace.
-5. Before merging, run a complete notarization preflight from the clean release
-   candidate with the approved private signing environment. This does not
+5. Merge `crawlkit` to `main`.
+6. Pull the final protected `main` commit into a clean checkout.
+
+```bash
+git switch main
+git pull --ff-only
+git status --short --branch
+```
+
+7. Run a complete notarization preflight from that exact release candidate with
+   the approved private signing environment. This does not
    inspect or create a tag. It produces disposable candidates, restores the
    managed keychain, then runs the credential-free online-ticket and build
    provenance verifier:
@@ -31,8 +40,7 @@ preflight_dir=$(mktemp -d /private/tmp/crawlkit-v0.14.3-preflight.XXXXXX)
 scripts/preflight-crawlctl-release.sh v0.14.3 "$preflight_dir"
 ```
 
-6. Merge `crawlkit` to `main`.
-7. Tag the next semver release from `main`:
+8. Tag the next semver release from `main`:
 
 ```bash
 git tag -s v0.14.3
@@ -40,7 +48,7 @@ git push origin main
 git push origin v0.14.3
 ```
 
-8. From the clean checkout whose `HEAD` exactly matches the signed release tag,
+9. From the clean checkout whose `HEAD` exactly matches the signed release tag,
 build the signed macOS artifacts. The package entrypoint fetches the remote tag
 and protected `main` head into temporary refs, verifies the annotated tag against
 the repository-pinned SSH signer principal and key, requires the signed tag
@@ -91,7 +99,7 @@ Apple. Do not use
 standalone executables can exit with “the code is valid but does not seem to be
 an app.”
 
-9. Create the GitHub release as a draft, attach both archives and their
+10. Create the GitHub release as a draft, attach both archives and their
 `.sha256` files, then run the `Release Assets` workflow manually from the
 default branch with the tag to verify the uploaded draft assets. Publish only
 after that check succeeds. A crawlkit release without both verified signed
@@ -118,14 +126,14 @@ separately:
   action succeeds without a second alert. Do not claim first-install prompt
   suppression.
 
-10. Prime and verify module proxy visibility:
+11. Prime and verify module proxy visibility:
 
 ```bash
 GOPROXY=https://proxy.golang.org GONOSUMDB= go list -m github.com/openclaw/crawlkit@v0.14.3
 GOPROXY=https://proxy.golang.org go list -m github.com/openclaw/crawlkit@v0.14.3
 ```
 
-11. Bump downstream apps to the new tag and commit their `go.mod`/`go.sum` updates:
+12. Bump downstream apps to the new tag and commit their `go.mod`/`go.sum` updates:
 
 ```bash
 go get github.com/openclaw/crawlkit@v0.14.3

--- a/scripts/preflight-crawlctl-release.sh
+++ b/scripts/preflight-crawlctl-release.sh
@@ -4,11 +4,25 @@ set -euo pipefail
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 VERSION=${1:-}
 OUT_DIR=${2:-}
+REMOTE=origin
+DEFAULT_BRANCH=main
 
 if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ || -z "$OUT_DIR" ]]; then
   echo "usage: $0 vX.Y.Z output-directory" >&2
   exit 2
 fi
+for tool in awk git; do
+  command -v "$tool" >/dev/null || {
+    echo "missing required tool: $tool" >&2
+    exit 1
+  }
+done
+export GIT_NO_REPLACE_OBJECTS=1
+replacement_refs=$(git -C "$ROOT" for-each-ref --format='%(refname)' refs/replace/)
+[[ -z "$replacement_refs" ]] || {
+  echo "release preflight rejects Git replacement refs" >&2
+  exit 1
+}
 if ! worktree_state=$(git -C "$ROOT" status --porcelain --untracked-files=normal); then
   echo "could not inspect release preflight checkout" >&2
   exit 1
@@ -18,7 +32,40 @@ fi
   exit 1
 }
 
-EXPECTED_COMMIT=$(git -C "$ROOT" rev-parse HEAD)
+remote_url=$(git -C "$ROOT" remote get-url "$REMOTE")
+case "$remote_url" in
+  https://github.com/openclaw/crawlkit | https://github.com/openclaw/crawlkit.git | \
+    git@github.com:openclaw/crawlkit | git@github.com:openclaw/crawlkit.git | \
+    ssh://git@github.com/openclaw/crawlkit | ssh://git@github.com/openclaw/crawlkit.git) ;;
+  *)
+    echo "release preflight requires the official openclaw/crawlkit origin" >&2
+    exit 1
+    ;;
+esac
+remote_default_ref=$(git -C "$ROOT" ls-remote --symref "$REMOTE" HEAD |
+  awk '$1 == "ref:" && $3 == "HEAD" { print $2 }')
+[[ "$remote_default_ref" == "refs/heads/$DEFAULT_BRANCH" ]] || {
+  echo "official release origin default branch is not $DEFAULT_BRANCH" >&2
+  exit 1
+}
+
+ref_namespace="refs/crawlctl-release-preflight/$$-$RANDOM"
+branch_ref="$ref_namespace/branch"
+cleanup() {
+  git -C "$ROOT" update-ref -d "$branch_ref" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+git -C "$ROOT" \
+  -c fetch.prune=false -c fetch.pruneTags=false \
+  -c remote.origin.prune=false -c remote.origin.pruneTags=false \
+  fetch --force --no-tags --no-write-fetch-head "$REMOTE" \
+  "+refs/heads/$DEFAULT_BRANCH:$branch_ref" >/dev/null
+EXPECTED_COMMIT=$(git -C "$ROOT" rev-parse "$branch_ref^{commit}")
+[[ "$(git -C "$ROOT" rev-parse HEAD)" == "$EXPECTED_COMMIT" ]] || {
+  echo "release preflight HEAD does not match protected $DEFAULT_BRANCH" >&2
+  exit 1
+}
+
 helper=${MAC_RELEASE_HELPER:-"$HOME/Projects/agent-scripts/skills/release-mac-app/scripts/mac-release"}
 [[ -x "$helper" ]] || {
   echo "mac-release helper is not executable: $helper" >&2

--- a/scripts/preflight-crawlctl-release.sh
+++ b/scripts/preflight-crawlctl-release.sh
@@ -9,7 +9,11 @@ if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ || -z "$OUT
   echo "usage: $0 vX.Y.Z output-directory" >&2
   exit 2
 fi
-[[ -z "$(git -C "$ROOT" status --porcelain --untracked-files=normal)" ]] || {
+if ! worktree_state=$(git -C "$ROOT" status --porcelain --untracked-files=normal); then
+  echo "could not inspect release preflight checkout" >&2
+  exit 1
+fi
+[[ -z "$worktree_state" ]] || {
   echo "release preflight checkout is not clean" >&2
   exit 1
 }

--- a/scripts/preflight-crawlctl-release.sh
+++ b/scripts/preflight-crawlctl-release.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+VERSION=${1:-}
+OUT_DIR=${2:-}
+
+if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ || -z "$OUT_DIR" ]]; then
+  echo "usage: $0 vX.Y.Z output-directory" >&2
+  exit 2
+fi
+[[ -z "$(git -C "$ROOT" status --porcelain --untracked-files=normal)" ]] || {
+  echo "release preflight checkout is not clean" >&2
+  exit 1
+}
+
+EXPECTED_COMMIT=$(git -C "$ROOT" rev-parse HEAD)
+helper=${MAC_RELEASE_HELPER:-"$HOME/Projects/agent-scripts/skills/release-mac-app/scripts/mac-release"}
+[[ -x "$helper" ]] || {
+  echo "mac-release helper is not executable: $helper" >&2
+  exit 1
+}
+
+CRAWLCTL_EXPECTED_COMMIT="$EXPECTED_COMMIT" \
+  "$helper" codesign-run --with-package-secrets -- \
+  "$ROOT/scripts/package-crawlctl-release.sh" --produce "$VERSION" "$OUT_DIR"
+
+"$ROOT/scripts/verify-crawlctl-release.sh" "$VERSION" "$EXPECTED_COMMIT" \
+  "$OUT_DIR/crawlctl-${VERSION}-macos-arm64.tar.gz" \
+  "$OUT_DIR/crawlctl-${VERSION}-macos-x86_64.tar.gz"
+
+printf '%s\n' "$EXPECTED_COMMIT"

--- a/scripts/test-crawlctl-release.sh
+++ b/scripts/test-crawlctl-release.sh
@@ -12,9 +12,15 @@ fail() {
 }
 
 for script in download-crawlctl-release-assets.sh install-crawlctl.sh package-crawlctl-release.sh \
-  verify-crawlctl-release-provenance.sh verify-crawlctl-release.sh; do
+  preflight-crawlctl-release.sh verify-crawlctl-release-provenance.sh \
+  verify-crawlctl-release.sh; do
   bash -n "$ROOT/scripts/$script"
 done
+grep -Fx \
+  'steipete@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA6rFpd7CodTF6fy60LZTriTeiGAJ7haIBWD4hrdxmDB' \
+  "$ROOT/.github/release-allowed-signers" >/dev/null
+[[ "$(wc -l < "$ROOT/.github/release-allowed-signers" | tr -d ' ')" == 1 ]] ||
+  fail "release signer policy must contain exactly one reviewed signer"
 grep -F "github.event_name == 'release' ||" \
   "$ROOT/.github/workflows/release-assets.yml" >/dev/null
 grep -F "ref: \${{ github.event_name == 'release' && github.event.repository.default_branch || github.workflow_sha }}" \
@@ -443,6 +449,15 @@ for version in v0.13.4 v0.14.0; do
   [[ "$(find "$WORK_DIR/$version" -maxdepth 1 -type f | wc -l | tr -d ' ')" == 4 ]] ||
     fail "unexpected release artifact inventory for $version"
 done
+preflight_commit=$(bash "$ROOT/scripts/preflight-crawlctl-release.sh" \
+  v0.14.3 "$WORK_DIR/preflight")
+[[ "$preflight_commit" == "$MOCK_COMMIT" ]] || fail "preflight reported the wrong commit"
+for arch in arm64 x86_64; do
+  archive="$WORK_DIR/preflight/crawlctl-v0.14.3-macos-${arch}.tar.gz"
+  [[ -f "$archive" && -f "$archive.sha256" ]] || fail "missing preflight $arch artifact"
+done
+[[ "$(find "$WORK_DIR/preflight" -maxdepth 1 -type f | wc -l | tr -d ' ')" == 4 ]] ||
+  fail "unexpected preflight artifact inventory"
 grep -F 'codesign-run --with-package-secrets --' "$MOCK_HELPER_LOG" >/dev/null ||
   fail "package producer did not use the managed release helper"
 awk '

--- a/scripts/test-crawlctl-release.sh
+++ b/scripts/test-crawlctl-release.sh
@@ -41,6 +41,12 @@ grep -F '"$RELEASE_TAG" "$RELEASE_COMMIT" "$archive"' \
   "$ROOT/.github/workflows/release-assets.yml" >/dev/null
 grep -F 'gpg.ssh.allowedSignersFile=' \
   "$ROOT/scripts/verify-crawlctl-release-provenance.sh" >/dev/null
+grep -F 'export GIT_NO_REPLACE_OBJECTS=1' \
+  "$ROOT/scripts/preflight-crawlctl-release.sh" >/dev/null
+grep -F -- '-c fetch.prune=false -c fetch.pruneTags=false' \
+  "$ROOT/scripts/preflight-crawlctl-release.sh" >/dev/null
+grep -F -- '-c remote.origin.prune=false -c remote.origin.pruneTags=false' \
+  "$ROOT/scripts/preflight-crawlctl-release.sh" >/dev/null
 # shellcheck disable=SC2016
 grep -F '+refs/heads/$DEFAULT_BRANCH:$branch_ref' \
   "$ROOT/scripts/verify-crawlctl-release-provenance.sh" >/dev/null
@@ -157,6 +163,9 @@ TAG
     esac
     ;;
   status) [[ "${MOCK_STATUS_RESULT:-ok}" == ok ]] ;;
+  for-each-ref)
+    [[ -z "${MOCK_REPLACE_REF:-}" ]] || echo "$MOCK_REPLACE_REF"
+    ;;
   update-ref) exit 0 ;;
   *) exit 2 ;;
 esac
@@ -456,6 +465,26 @@ if MOCK_STATUS_RESULT=fail bash "$ROOT/scripts/preflight-crawlctl-release.sh" \
 fi
 [[ ! -e "$WORK_DIR/preflight-status-error" ]] ||
   fail "failed checkout probe mutated the preflight artifact destination"
+if MOCK_REPLACE_REF=refs/replace/$MOCK_COMMIT \
+  bash "$ROOT/scripts/preflight-crawlctl-release.sh" \
+    v0.14.3 "$WORK_DIR/preflight-replace-ref" >/dev/null 2>&1; then
+  fail "preflight accepted a Git replacement ref"
+fi
+[[ ! -e "$WORK_DIR/preflight-replace-ref" ]] ||
+  fail "replacement ref mutated the preflight artifact destination"
+if MOCK_REMOTE_URL=https://github.com/steipete/crawlkit.git \
+  bash "$ROOT/scripts/preflight-crawlctl-release.sh" \
+    v0.14.3 "$WORK_DIR/preflight-wrong-origin" >/dev/null 2>&1; then
+  fail "preflight accepted a non-official origin"
+fi
+[[ ! -e "$WORK_DIR/preflight-wrong-origin" ]] ||
+  fail "non-official origin mutated the preflight artifact destination"
+if MOCK_LOCAL_HEAD="$MOCK_SIDE_COMMIT" bash "$ROOT/scripts/preflight-crawlctl-release.sh" \
+  v0.14.3 "$WORK_DIR/preflight-side-commit" >/dev/null 2>&1; then
+  fail "preflight accepted a checkout outside protected main"
+fi
+[[ ! -e "$WORK_DIR/preflight-side-commit" ]] ||
+  fail "side-commit preflight mutated the artifact destination"
 preflight_commit=$(bash "$ROOT/scripts/preflight-crawlctl-release.sh" \
   v0.14.3 "$WORK_DIR/preflight")
 [[ "$preflight_commit" == "$MOCK_COMMIT" ]] || fail "preflight reported the wrong commit"

--- a/scripts/test-crawlctl-release.sh
+++ b/scripts/test-crawlctl-release.sh
@@ -156,7 +156,8 @@ TAG
       *) exit 2 ;;
     esac
     ;;
-  status|update-ref) exit 0 ;;
+  status) [[ "${MOCK_STATUS_RESULT:-ok}" == ok ]] ;;
+  update-ref) exit 0 ;;
   *) exit 2 ;;
 esac
 EOF
@@ -449,6 +450,12 @@ for version in v0.13.4 v0.14.0; do
   [[ "$(find "$WORK_DIR/$version" -maxdepth 1 -type f | wc -l | tr -d ' ')" == 4 ]] ||
     fail "unexpected release artifact inventory for $version"
 done
+if MOCK_STATUS_RESULT=fail bash "$ROOT/scripts/preflight-crawlctl-release.sh" \
+  v0.14.3 "$WORK_DIR/preflight-status-error" >/dev/null 2>&1; then
+  fail "preflight accepted a failed checkout cleanliness probe"
+fi
+[[ ! -e "$WORK_DIR/preflight-status-error" ]] ||
+  fail "failed checkout probe mutated the preflight artifact destination"
 preflight_commit=$(bash "$ROOT/scripts/preflight-crawlctl-release.sh" \
   v0.14.3 "$WORK_DIR/preflight")
 [[ "$preflight_commit" == "$MOCK_COMMIT" ]] || fail "preflight reported the wrong commit"


### PR DESCRIPTION
## Summary

- rotate the repository-pinned release signer to Peter's current SSH signing key
- add a supported pre-tag macOS release preflight that authenticates fresh protected `origin/main`, signs and notarizes, restores the managed keychain, then runs the credential-free online-ticket and build-provenance verifier
- fail closed when checkout cleanliness cannot be inspected, with regression coverage
- finalize the v0.14.3 changelog and update publishing commands

## Backfill decision

No GitHub Releases were created for v0.14.0, v0.14.1, or v0.14.2. The repository contract requires every release to carry both signed/notarized architecture archives and checksums, and its protected verifier also requires the signed tag to equal current protected `main`. These historical tags have no release assets and no longer equal current `main`; tag-only backfills would violate the release contract.

## Proof

- `GOWORK=off go mod tidy && git diff --exit-code -- go.mod go.sum`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test -count=1 ./...` — all 17 package suites pass
- `GOWORK=off go test -race -count=1 ./...` — pass
- `GOWORK=off go run golang.org/x/tools/cmd/deadcode@v0.46.0 -test ./...` — no output
- `GOWORK=off go run golang.org/x/vuln/cmd/govulncheck@v1.4.0 ./...` — zero reachable vulnerabilities
- `bash scripts/test-crawlctl-release.sh` — pass
- live signing/notarization path proof on `d4da06c5c2030d3e3ecb170810b457ddc9025e73` with the approved managed Developer ID and notary environment — both thin architectures accepted by Apple; signature, designated-requirement, online-ticket, build-provenance, and post-cleanup checks pass
- protected-main gate head `e2df402` pre-merge preflight — fails closed before helper access because the branch does not equal freshly fetched protected `main`; temporary proof ref is removed and no artifact destination is created. Final head `1b80e1f` changes only durable changelog wording. Successful exact-head preflight is intentionally a post-merge release gate.
- real notarized candidate: `crawlctl --version` returns `0.14.3`; `crawlctl --help` returns the expected command surface
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean

No tag, release, artifact upload, or publication performed.
