### PR TITLE
chore: prepare v0.14.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.14.4 - Unreleased
+## v0.14.4 - 2026-07-26
 
 ### Breaking release asset rename
 


### PR DESCRIPTION
Dates the v0.14.4 changelog section for the signed fleet-pipeline release.

This release deliberately renames the published archives from the v0.14.3 `crawlctl-v0.14.3-macos-*` plus per-asset sidecar scheme to `crawlkit_0.14.4_{darwin,linux}_{arm64,amd64}.tar.gz` plus `checksums.txt`, as documented in the already-merged migration.

Proof:

- `make test-release`
- Codex autoreview: clean, no accepted/actionable findings
