### PR TITLE
ci: allow the current release signer in crawlkit's allowlist

### DIFF
--- a/.github/release-allowed-signers
+++ b/.github/release-allowed-signers
@@ -1,1 +1,2 @@
 steipete@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA6rFpd7CodTF6fy60LZTriTeiGAJ7haIBWD4hrdxmDB
+steipete@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII9XsaCcr8TInPnHcuTVfvXXcsoUFrOE7menfbEIHFW9

--- a/scripts/test-crawlctl-release.sh
+++ b/scripts/test-crawlctl-release.sh
@@ -45,8 +45,11 @@ fi
 grep -Fx \
   'steipete@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA6rFpd7CodTF6fy60LZTriTeiGAJ7haIBWD4hrdxmDB' \
   "$ROOT/.github/release-allowed-signers" >/dev/null
-[[ "$(wc -l < "$ROOT/.github/release-allowed-signers" | tr -d ' ')" == 1 ]] ||
-  fail "release signer policy must contain exactly one reviewed signer"
+grep -Fx \
+  'steipete@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII9XsaCcr8TInPnHcuTVfvXXcsoUFrOE7menfbEIHFW9' \
+  "$ROOT/.github/release-allowed-signers" >/dev/null
+[[ "$(wc -l < "$ROOT/.github/release-allowed-signers" | tr -d ' ')" == 2 ]] ||
+  fail "release signer policy must contain exactly the historical and current reviewed signers"
 
 release_output=$(bash "$ROOT/scripts/package-crawlctl-release.sh" v0.14.4 2>&1) &&
   fail "local package script unexpectedly succeeded"


### PR DESCRIPTION
Allow the current SSH release-signing key to sign new crawlkit tags while retaining the historical v0.14.3 signer solely so previously published tags continue to verify.

This mirrors the two-key transition policy already used by `openclaw/notcrawl`. The release-contract test now requires exactly those two reviewed signers.

Proof:

- both allowlist entries resolve to the expected `buNE...` historical and `WmI...` current SHA-256 fingerprints
- `make test-release`
- Codex autoreview: clean, no accepted/actionable findings
