### PR TITLE
docs: align release guidance with tag-only publishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,8 @@ GOWORK=off go test -count=1 ./...
 For release readiness, also verify the public module tag:
 
 ```bash
-GOPROXY=https://proxy.golang.org GONOSUMDB= go list -m github.com/openclaw/crawlkit@v0.13.4
+GOPROXY=https://proxy.golang.org GONOSUMDB= go list -m github.com/openclaw/crawlkit@vX.Y.Z
+GOPROXY=https://proxy.golang.org go list -m github.com/openclaw/crawlkit@vX.Y.Z
 ```
 
 ## Downstream Compatibility
@@ -74,11 +75,13 @@ then consume it from the app.
 
 ## Release Model
 
-Go libraries are released by signed semver git tags. Every GitHub release must
-also include Developer ID-signed `crawlctl` macOS artifacts produced through
-the repository release scripts from the clean checkout at that exact signed
-tag; never publish locally compiled or ad-hoc-signed macOS binaries. There is no
-npm, PyPI, or Homebrew publish step for `crawlkit`.
+Go libraries are released by SSH-signed semver git tags. `crawlkit` publishes no
+release binaries, and there is no release workflow to dispatch. Users install
+the optional `crawlctl` CLI from source with
+`go install github.com/openclaw/crawlkit/cmd/crawlctl@latest`. v0.14.4 was the
+last release with attached artifacts; do not delete or modify those historical
+releases or assets. There is no npm, PyPI, or Homebrew publish step for
+`crawlkit`.
 
 Use patch tags for narrow fixes and minor tags for broader shared crawler or TUI
 infrastructure. After tagging, prime/verify the Go proxy and then update


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where maintainers following `AGENTS.md` would be told to publish Developer ID-signed `crawlctl` artifacts even though crawlkit switched to tag-only releases after v0.14.4.

## Why This Change Was Made

Align the agent release model with `README.md`, `docs/publishing.md`, and the v0.14.5 Unreleased changelog direction. The release-readiness proxy commands now use a version placeholder and cover both uncached and checksum-verified module resolution.

## User Impact

Maintainers get one consistent release path: push an SSH-signed semver tag, verify it through the Go proxy, and do not dispatch a binary release workflow. Existing v0.14.4 artifacts remain historical and unchanged.

## Evidence

- `make check`
- `git diff --check`
- Cross-checked release language in `AGENTS.md`, `README.md`, `docs/publishing.md`, and `CHANGELOG.md`
