### PR TITLE
fix(ci): restore crawlkit AWS provisioning

### DIFF
--- a/.crabbox.yaml
+++ b/.crabbox.yaml
@@ -24,7 +24,7 @@ actions:
   ephemeral: true
 aws:
   region: eu-west-1
-  rootGB: 160
+  rootGB: 400
 sync:
   delete: true
   checksum: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Update Go dependencies and validation tools, including SQLite v1.55.0, `modernc.org/libc` v1.74.4, deadcode v0.48.0, and govulncheck v1.6.0; document caller-provided `file:` URI parameter pass-through.
 - Refresh the pinned TruffleHog and CodeQL security actions to v3.96.0 and v4.37.4.
 - Update the stale repository automation to the immutable v11.0.0 action revision.
+- Raise the brokered AWS Crabbox root volume to 400 GB to match the current developer snapshot minimum.
 
 ## v0.14.4 - 2026-07-26
 


### PR DESCRIPTION
## What Problem This Solves

Fixes crawlkit's brokered AWS Crabbox provisioning, which failed because the
configured 160 GB root volume was smaller than the current 400 GB developer
snapshot.

## Why This Change Was Made

Raise the repository's AWS root volume to the snapshot minimum while leaving
provider, instance, region, hydration, and sync policy unchanged.

## User Impact

Maintainers can run the repository's configured AWS Crabbox validation without
an environment override.

## Evidence

- `crabbox config show` resolves `provider=aws`, `profile=crawlkit-check`, and
  `root_gb=400`.
- AWS proof with the same 400 GB setting: lease `cbx_d47f5c023c3d`, run
  `run_1ec0e1464022`; exact-head assertion, tidy, module diff, vet, full tests,
  and race tests passed. The lease was released.
- `make check`
- `GOWORK=off go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `git diff --check`
