### PR TITLE
ci(release): allow current tag signer

### DIFF
--- a/.github/release-allowed-signers
+++ b/.github/release-allowed-signers
@@ -1,2 +1,3 @@
 steipete@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA6rFpd7CodTF6fy60LZTriTeiGAJ7haIBWD4hrdxmDB
 steipete@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII9XsaCcr8TInPnHcuTVfvXXcsoUFrOE7menfbEIHFW9
+25068+vincentkoc@users.noreply.github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMYJHwFnesHbwtPLErQBRMffbET0Wrbzh+PjkndZRNyy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Refresh the pinned TruffleHog and CodeQL security actions to v3.96.0 and v4.37.4.
 - Update the stale repository automation to the immutable v11.0.0 action revision.
 - Raise the brokered AWS Crabbox root volume to 400 GB to match the current developer snapshot minimum.
+- Allow the current maintainer SSH signing key to create repository-verified release tags.
 
 ## v0.14.4 - 2026-07-26
 


### PR DESCRIPTION
## What Problem This Solves

The current maintainer SSH key can sign commits and tags, but crawlkit's release
allowlist only contains Peter's signer identities. That prevents the mandatory
pre-push verification for v0.14.5.

## Why This Change Was Made

Add the current key under the public GitHub noreply principal. Keep both
historical Peter keys so existing release tags continue to verify.

## User Impact

The v0.14.5 tag can be created and verified with the repository's documented
SSH-signed release process.

## Evidence

- Created an unpushed test tag with
  `25068+vincentkoc@users.noreply.github.com`.
- `git verify-tag` accepted the signature against
  `.github/release-allowed-signers`.
- Deleted the test tag after verification.
- `make check`
- `GOWORK=off go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `git diff --check`
