### PR TITLE
chore(release): open v0.14.6 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## v0.14.6 - Unreleased
+
 ## v0.14.5 - 2026-08-02
 
 - Stop publishing release binaries for this Go library. Install the optional CLI with `go install github.com/openclaw/crawlkit/cmd/crawlctl@latest`; v0.14.4 was the last release with attached artifacts.


### PR DESCRIPTION
## What Problem This Solves

Restores an Unreleased changelog target after publishing v0.14.5.

## Why This Change Was Made

Open the next patch section immediately so subsequent maintenance changes do not
accumulate under the dated v0.14.5 release.

## User Impact

No runtime behavior changes.

## Evidence

- `git diff --check`
