### PR TITLE
docs(release): correct v0.14.5 publication state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## v0.14.6 - Unreleased
 
+- Prepare the unified release pipeline for future Developer ID-signed and
+  notarized `crawlctl` macOS archives and static Linux archives.
+
 ## v0.14.5 - 2026-08-02
 
-- Restore the unified release pipeline for Developer ID-signed and notarized `crawlctl` macOS archives and static Linux archives; the shared workflow now owns tag creation and release publication.
+- Publish the module as an SSH-signed tag without a GitHub Release or attached
+  `crawlctl` artifacts; v0.14.4 remains the latest release with binary assets.
 - Update Go dependencies and validation tools, including SQLite v1.55.0, `modernc.org/libc` v1.74.4, `go-colorful` v1.4.1, deadcode v0.48.0, and govulncheck v1.6.0; document caller-provided `file:` URI parameter pass-through.
 - Refresh the pinned TruffleHog and CodeQL security actions to v3.96.0 and v4.37.4.
 - Update the stale repository automation to the immutable v11.0.0 action revision.

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Install the optional `crawlctl` CLI from source:
 go install github.com/openclaw/crawlkit/cmd/crawlctl@latest
 ```
 
-GitHub releases also provide Developer ID-signed and notarized `crawlctl`
-archives for macOS plus static Linux archives. Releases are created through the
-repository's unified release workflow; it owns tag creation, signing,
-notarization, verification, and publication. See `docs/publishing.md` for the
-release procedure and artifact contract.
+v0.14.5 is an SSH-signed Go module tag without a GitHub Release or attached
+artifacts. The unified release workflow is configured to publish future
+Developer ID-signed and notarized `crawlctl` archives for macOS plus static
+Linux archives. See `docs/publishing.md` for the release procedure, credential
+prerequisites, and artifact contract.
 
 See `docs/boundary.md` for the crawlkit-versus-app ownership boundary and
 `docs/remote-contract.md` for the Worker/client split.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -6,6 +6,10 @@ owns tag creation, Developer ID signing, notarization, independent artifact
 verification, and GitHub Release publication. Do not create release tags or
 handle signing credentials locally.
 
+v0.14.5 is an SSH-signed Go module tag without a GitHub Release or attached
+artifacts. v0.14.4 remains the latest historical release with binary assets.
+The unified pipeline applies to future releases.
+
 ## Release assets
 
 The archive prefix is the repository name; the executable inside every archive
@@ -28,7 +32,11 @@ Homebrew handoff.
 
 ## Release checklist
 
-1. Prepare a release PR from the current protected `main` head. Date the
+1. Confirm the repository can access all five required Actions secrets:
+   `MACOS_SIGNING_P12`, `MACOS_SIGNING_P12_PASSWORD`, `ASC_KEY_ID`,
+   `ASC_ISSUER_ID`, and `ASC_PRIVATE_KEY_P8`. The shared workflow validates
+   them before creating a tag.
+2. Prepare a release PR from the current protected `main` head. Date the
    versioned changelog section and run:
 
    ```bash
@@ -36,18 +44,18 @@ Homebrew handoff.
    actionlint
    ```
 
-2. Merge the release-preparation PR and confirm its exact merge commit is green.
-3. Dispatch the unified workflow from the current protected `main` head:
+3. Merge the release-preparation PR and confirm its exact merge commit is green.
+4. Dispatch the unified workflow from the current protected `main` head:
 
    ```bash
    gh workflow run release-unified.yml --repo openclaw/crawlkit -f version=X.Y.Z
    ```
 
-4. Watch the exact workflow run through publication. It creates or reuses an
+5. Watch the exact workflow run through publication. It creates or reuses an
    immutable annotated version tag, builds all four native archives, signs and
    notarizes the two macOS binaries, verifies the immutable draft independently
    on Apple Silicon and Intel, and publishes only the verified bytes.
-5. Confirm the GitHub Release notes match the dated changelog section. Download
+6. Confirm the GitHub Release notes match the dated changelog section. Download
    every release asset, verify `checksums.txt`, inspect both Linux binaries, and
    verify a downloaded macOS binary with:
 
@@ -55,15 +63,19 @@ Homebrew handoff.
    codesign --verify --strict --check-notarization -R=notarized ./crawlctl
    ```
 
-6. Prime and verify module proxy visibility:
+7. Prime and verify module proxy visibility:
 
    ```bash
    GOPROXY=https://proxy.golang.org GONOSUMDB= go list -m github.com/openclaw/crawlkit@vX.Y.Z
    GOPROXY=https://proxy.golang.org go list -m github.com/openclaw/crawlkit@vX.Y.Z
    ```
 
-7. Merge the workflow's closeout PR, or otherwise add the next patch-version
+8. Merge the workflow's closeout PR, or otherwise add the next patch-version
    Unreleased changelog section.
+
+Never delete or force-update a release tag. If a run fails after tag creation,
+fix the blocker and rerun the same version; the shared workflow requires the
+exact annotated tag object and target observed during validation.
 
 Use a patch version for narrow fixes on the existing API. Use a minor version
 for broad crawler infrastructure changes. If the module reaches v2, Go requires


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers and users reading the v0.14.5 release documentation would expect a GitHub Release with signed `crawlctl` artifacts even though v0.14.5 shipped only as an SSH-signed Go module tag.

## Why This Change Was Made

The v0.14.5 tag was intentionally deleted before unified release run https://github.com/openclaw/crawlkit/actions/runs/30760672990, which then recreated the tag and failed because required signing credentials were unavailable. The original signed tag has been restored.

This correction records the actual v0.14.5 publication state, moves the unified binary pipeline to v0.14.6 Unreleased, lists its credential prerequisites, and documents immutable-tag retry behavior.

## User Impact

Users can see that v0.14.5 has no attached binaries and should install `crawlctl` from source. Maintainers have an accurate checklist for future unified releases without deleting or retargeting release tags.

## Evidence

- live `v0.14.5` tag object restored at `b7ccf0332e044f7e3a147ddda0381a3b9ad4f165`, peeling to `dd7315df3f52966bcadb0ee8449df052792ee8b0`
- no GitHub Release exists for v0.14.5
- `GOWORK=off make check`
- full normal and race test suites
- govulncheck: no called vulnerabilities
- actionlint
- GoReleaser v2.17.1: configuration valid
