### PR TITLE
chore: reopen changelog for v0.14.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
+## v0.14.7 - Unreleased
+
 ## v0.14.6 - 2026-08-06
 
+- Publish the module as an SSH-signed tag without a GitHub Release or attached
+  `crawlctl` artifacts; the unified pipeline still needs its signing secrets
+  provisioned before it can attach binaries.
 - Fix the TUI filter so typing `q` appends to the query instead of quitting; `ctrl+c`/`ctrl+d` still quit while filtering.
 - Fix TUI filter backspace to remove one rune instead of one byte, keeping CJK and emoji queries valid UTF-8.
 - Guard `startRefresh` against overlapping runs so slow refreshes no longer stack goroutines; a manual refresh reports "Refresh already in progress".


### PR DESCRIPTION
Closeout for v0.14.6: open the v0.14.7 Unreleased section and record that v0.14.6 shipped as an SSH-signed module tag without a GitHub Release (same publication state as v0.14.5). The unified release pipeline's five signing/notarization secrets are still unprovisioned on this repo - every sibling crawl repo received them on 2026-07-27; crawlkit was skipped. Follow-up tracked separately to provision them and return to signed crawlctl artifacts.
