### PR TITLE
chore(release): prepare v0.14.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.14.7 - Unreleased
+## v0.14.7 - 2026-08-08
 
 - Update `modernc.org/sqlite` to v1.56.0 for the SQLite 3.53.3 journal-rollback corruption fix and regenerated platform bindings.
 - Refresh the pinned CodeQL init and analysis actions to v4.37.6.


### PR DESCRIPTION
## Summary

- date the v0.14.7 changelog section after the SQLite recovery fix and CodeQL refresh landed

## Verification

- `make check` — tidy, format, vet, dead-code, vulnerability, ordinary, and race suites passed
- `actionlint .github/workflows/*.yml` passed
- Codex release-freeze autoreview was clean with no accepted/actionable findings

## Blocker

Do not dispatch the unified release workflow yet. Its OpenClaw Developer ID signing secrets are unavailable; this PR only prepares the source and does not create a local tag or substitute release.
