### PR TITLE
build: move Go floor to 1.26.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Require Go 1.26.6 for the latest standard-library security fixes.
+
 ## v0.14.7 - 2026-08-08
 
 - Update `modernc.org/sqlite` to v1.56.0 for the SQLite 3.53.3 journal-rollback corruption fix and regenerated platform bindings.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Provider APIs, authentication, schemas, privacy filters, and user-facing command
 
 ## Install
 
-`crawlkit` requires Go 1.26.5 or newer.
+`crawlkit` requires Go 1.26.6 or newer.
 
 Add the package you need to a Go module. For the quick start below:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openclaw/crawlkit
 
-go 1.26.5
+go 1.26.6
 
 require (
 	filippo.io/age v1.3.1


### PR DESCRIPTION
## Summary

- raise the module and documented Go floor to 1.26.6
- record the security-floor update in the changelog
- clear GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218

## Verification

- `GOTOOLCHAIN=go1.26.6 GOWORK=off go build ./...`
- `GOTOOLCHAIN=go1.26.6 GOWORK=off go test ./...`
- `GOTOOLCHAIN=go1.26.6 GOWORK=off go vet ./...`
- `GOTOOLCHAIN=go1.26.6 GOWORK=off go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...` — no reachable vulnerabilities
- `GOTOOLCHAIN=go1.26.6 GOWORK=off go run ./cmd/crawlctl --help`
- autoreview clean
