### PR TITLE
chore(release): fix changelog section for v0.14.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,8 @@
 
 ## v0.14.7 - 2026-08-14
 
-- Require Go 1.26.6 for the latest standard-library security fixes.
-## v0.14.7 - 2026-08-08
-
 - Update `modernc.org/sqlite` to v1.56.0 for the SQLite 3.53.3 journal-rollback corruption fix and regenerated platform bindings.
+- Require Go 1.26.6 for the latest standard-library security fixes.
 - Refresh the pinned CodeQL init and analysis actions to v4.37.6.
 
 ## v0.14.6 - 2026-08-06


### PR DESCRIPTION
Release validator requires exactly one dated level-two section matching the repo's header convention.