### PR TITLE
fix(releasecheck): default a 30s HTTP client instead of DefaultClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Default `releasecheck` to a 30s HTTP client so a hung `api.github.com` cannot stall public `check-update` CLIs.
+
 ## v0.14.7 - 2026-08-14
 
 - Update `modernc.org/sqlite` to v1.56.0 for the SQLite 3.53.3 journal-rollback corruption fix and regenerated platform bindings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- Default `releasecheck` to a 30s HTTP client so a hung `api.github.com` cannot stall public `check-update` CLIs.
-
 ## v0.14.7 - 2026-08-14
 
 - Update `modernc.org/sqlite` to v1.56.0 for the SQLite 3.53.3 journal-rollback corruption fix and regenerated platform bindings.

--- a/releasecheck/releasecheck.go
+++ b/releasecheck/releasecheck.go
@@ -214,7 +214,7 @@ func normalizeOptions(opts Options) Options {
 		opts.Interval = DefaultInterval
 	}
 	if opts.Client == nil {
-		opts.Client = http.DefaultClient
+		opts.Client = &http.Client{Timeout: 30 * time.Second}
 	}
 	if opts.Now == nil {
 		opts.Now = time.Now

--- a/releasecheck/releasecheck_test.go
+++ b/releasecheck/releasecheck_test.go
@@ -13,6 +13,28 @@ import (
 	"time"
 )
 
+func TestNormalizeOptionsDefaultsBoundedHTTPClient(t *testing.T) {
+	opts := normalizeOptions(Options{})
+	if opts.Client == nil {
+		t.Fatal("default Client is nil")
+	}
+	if opts.Client == http.DefaultClient {
+		t.Fatal("default Client is http.DefaultClient, which has no timeout")
+	}
+	if opts.Client.Timeout <= 0 {
+		t.Fatalf("default Client.Timeout = %s, want > 0 so a hung api.github.com cannot stall check-update", opts.Client.Timeout)
+	}
+	if opts.Client.Timeout != 30*time.Second {
+		t.Fatalf("default Client.Timeout = %s, want 30s to match remote.NewClient", opts.Client.Timeout)
+	}
+
+	custom := &http.Client{Timeout: time.Second}
+	got := normalizeOptions(Options{Client: custom})
+	if got.Client != custom {
+		t.Fatal("supplied Client was replaced")
+	}
+}
+
 func TestCheckReportsNewReleaseAndCaches(t *testing.T) {
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What Problem This Solves

`releasecheck.normalizeOptions` used `http.DefaultClient` when the caller did not pass a client. Public `check-update` CLIs (discrawl, gitcrawl, slacrawl, graincrawl, notcrawl) call it with `context.Background()`, so a black-holed `api.github.com` hangs forever.

## Evidence

```console
Red:  TestNormalizeOptionsDefaultsBoundedHTTPClient
      default Client is http.DefaultClient, which has no timeout
Green: GOWORK=off go test -count=1 ./...
```

Default client is now `&http.Client{Timeout: 30s}`, matching `remote.NewClient`. Caller-supplied clients are unchanged.

## Real behavior proof
Behavior addressed: Release-check HTTP now has a 30s default timeout instead of DefaultClient.
Real environment tested: macOS, Go from the worktree, crawlkit `/tmp/oc-impl-crawlkit` head `fbaa0dc`.
Exact steps or command run after this patch: `GOWORK=off go test -count=1 ./...`
Evidence after fix: red/green recorded above.
Observed result after fix: default client Timeout is 30s and is not DefaultClient.
What was not tested: A live GitHub API outage.
