### PR TITLE
fix(scheduler): write run history as one complete JSONL line

### DIFF
--- a/scheduler/run.go
+++ b/scheduler/run.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -283,9 +284,20 @@ func appendHistory(path string, record RunRecord) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
-	enc := json.NewEncoder(file)
-	return enc.Encode(record)
+	return writeHistoryRecord(file, record)
+}
+
+func writeHistoryRecord(file io.WriteCloser, record RunRecord) error {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(record); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if _, err := file.Write(buf.Bytes()); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
 }
 
 func ReadHistory(path string) ([]RunRecord, error) {

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -1,7 +1,10 @@
 package scheduler
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -253,5 +256,87 @@ func TestDefaultPathsCustomConfigKeepsStateNearby(t *testing.T) {
 	}
 	if filepath.Dir(paths.History) != filepath.Join(filepath.Dir(path), "state") {
 		t.Fatalf("history = %s, want state next to config", paths.History)
+	}
+}
+
+func TestAppendHistoryWritesCompleteJSONLLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "runs.jsonl")
+	record := RunRecord{
+		ID:         "rec1",
+		Job:        "ok",
+		Command:    []string{"echo", "ok"},
+		Status:     "success",
+		StartedAt:  "2026-08-29T00:00:00Z",
+		FinishedAt: "2026-08-29T00:00:01Z",
+		DurationMs: 1000,
+		LogPath:    "/tmp/ok.log",
+	}
+	if err := appendHistory(path, record); err != nil {
+		t.Fatalf("appendHistory: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Fatalf("history = %q, want one newline-terminated JSONL line", data)
+	}
+	if bytes.Count(data, []byte{'\n'}) != 1 {
+		t.Fatalf("history = %q, want exactly one line", data)
+	}
+	history, err := ReadHistory(path)
+	if err != nil {
+		t.Fatalf("ReadHistory: %v", err)
+	}
+	if len(history) != 1 || history[0].ID != record.ID || history[0].Job != record.Job {
+		t.Fatalf("history = %#v", history)
+	}
+}
+
+type historyCloseWriter struct {
+	writes   [][]byte
+	closeErr error
+}
+
+func (w *historyCloseWriter) Write(p []byte) (int, error) {
+	w.writes = append(w.writes, append([]byte(nil), p...))
+	return len(p), nil
+}
+
+func (w *historyCloseWriter) Close() error {
+	return w.closeErr
+}
+
+func TestWriteHistoryRecordWritesCompleteLine(t *testing.T) {
+	w := &historyCloseWriter{}
+	record := RunRecord{ID: "rec1", Job: "ok", Status: "success"}
+	if err := writeHistoryRecord(w, record); err != nil {
+		t.Fatalf("writeHistoryRecord: %v", err)
+	}
+	if len(w.writes) != 1 {
+		t.Fatalf("writes = %d, want 1 complete line", len(w.writes))
+	}
+	line := w.writes[0]
+	if len(line) == 0 || line[len(line)-1] != '\n' {
+		t.Fatalf("write = %q, want newline-terminated JSONL", line)
+	}
+	var got RunRecord
+	if err := json.Unmarshal(bytes.TrimSpace(line), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.ID != record.ID || got.Job != record.Job {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestWriteHistoryRecordReturnsCloseError(t *testing.T) {
+	w := &historyCloseWriter{closeErr: errors.New("flush failed")}
+	err := writeHistoryRecord(w, RunRecord{ID: "rec1", Job: "ok", Status: "success"})
+	if err == nil {
+		t.Fatal("expected close error")
+	}
+	if !strings.Contains(err.Error(), "flush failed") {
+		t.Fatalf("err = %v, want close error", err)
 	}
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who run `crawlctl run` (directly or from launchd/systemd) can get a bricked scheduler after a short write, crash, or failed close while appending `runs.jsonl`. `ReadHistory` fails closed on any unmarshal error, so `crawlctl run`, `status`, and `logs` then refuse to start until the file is hand-edited.

## Why This Change Was Made

`appendHistory` now encodes each `RunRecord` into a buffer, writes that one complete JSONL line, and returns `Close` errors instead of encoding directly onto the `O_APPEND` handle and discarding flush failures. The on-disk format and the fail-closed read contract are unchanged. Existing already-truncated files still need a manual edit.

## User Impact

A successful `crawlctl run` leaves a complete last line in `state/runs.jsonl`, so a later `run`, `status`, or `logs` command can read history again. Operators still see `error: unexpected end of JSON input` if the file is already truncated from an older build.

## Evidence

Public `crawlctl` against a temp config on the patched binary. A truncated last line still bricks `run` and `status` (fail-closed). After a successful job, history is one newline-terminated JSON object and `status` reads it.

```console
$ printf '{"id":"partial"' > state/runs.jsonl
$ crawlctl --config crawlctl.toml run
error: unexpected end of JSON input
$ crawlctl --config crawlctl.toml status
error: unexpected end of JSON input

$ rm state/runs.jsonl
$ crawlctl --config crawlctl.toml run
ok ok duration=4ms
ok: success exit=0 log=/tmp/crawlkit-F001-live/home/logs/ok-20260829T183407Z-8951d898.log
$ crawlctl --config crawlctl.toml status
ok: success 2026-08-29T18:34:07Z

$ python3 -c 'from pathlib import Path; p=Path("state/runs.jsonl"); d=p.read_bytes(); print(len(d), d.endswith(b"\n"), d.count(b"\n"), d.splitlines()[0])'
250 True 1 b'{"id":"8951d898","job":"ok","command":["true"],"started_at":"2026-08-29T18:34:07Z","finished_at":"2026-08-29T18:34:07Z","duration_ms":4,"exit_code":0,"status":"success","log_path":"/tmp/crawlkit-F001-live/home/logs/ok-20260829T183407Z-8951d898.log"}'
```

## Real behavior proof

- **Behavior or issue addressed:** `crawlctl run` can leave a truncated last `runs.jsonl` line; later `run`, `status`, and `logs` then fail closed until the file is edited.
- **Real environment tested:** macOS darwin/arm64, Go 1.27.0, crawlkit worktree `/tmp/oc-pr-crawlkit-F001` at branch `fix/f001-atomic-run-history`, public `crawlctl` built with `GOWORK=off go build -o /tmp/crawlkit-F001-live/crawlctl ./cmd/crawlctl`.
- **Exact steps or command run after this patch:** Built `crawlctl`, pointed `--config` at a temp `crawlctl.toml` with `jobs.ok.command = ["true"]`, wrote a truncated `state/runs.jsonl`, ran `crawlctl run` and `crawlctl status`, removed the bad file, ran `crawlctl run` again, then inspected the written line with `python3`.
- **Evidence after fix:** terminal output from the patched `crawlctl`:

  ```console
  $ crawlctl --config crawlctl.toml run
  ok ok duration=4ms
  ok: success exit=0 log=/tmp/crawlkit-F001-live/home/logs/ok-20260829T183407Z-8951d898.log
  $ crawlctl --config crawlctl.toml status
  ok: success 2026-08-29T18:34:07Z
  bytes 250 endswith_nl True newline_count 1 records 1
  job ok status success id 8951d898
  ```

- **Observed result after fix:** After a successful job, `runs.jsonl` is one complete JSONL line and `crawlctl status` prints `ok: success`. A truncated last line still returns `error: unexpected end of JSON input` and does not start jobs.
- **What was not tested:** A hard crash mid-`Write` on NFS, launchd/systemd scheduling, and Windows close-flush behavior.

## Summary

The hole has been present since `d41253c` (`feat: add crawlctl scheduler`, 2026-05-22, 99 days). `ReadHistory` fail-closed behavior is unchanged and is still covered by `TestRunReturnsHistoryReadErrorBeforeRunningJobs`.
