### PR TITLE
chore(release): prepare v0.14.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## Unreleased
+## v0.14.8 - 2026-08-30
 
+- Default release checks to a 30-second HTTP timeout so unresponsive servers cannot hang checks indefinitely.
 - Reject release dispatches for existing tags or releases before rebuilding artifacts, and serialize dispatch checks through publication.
 - Require Go 1.27.0, update SQLite to v1.57.0 and supporting Go dependencies, and refresh deadcode, govulncheck, CodeQL, and TruffleHog validation tools.
 - Update age to v1.3.2 for encrypted-backup fixes and input hardening.


### PR DESCRIPTION
Dates the v0.14.8 changelog for the patch release and adds the missing entry for the merged 30-second release-check HTTP timeout fix. The existing age v1.3.2, dependency/toolchain, and release-dispatch guard entries are retained.

Validation: Codex autoreview passed with no actionable findings. `make check`, `actionlint`, and `GOWORK=off go test -count=1 ./...` passed locally. CI, CodeQL, and secret scanning passed for this PR and the exact main merge commit, 5cdee495743f06d28f865db9ac2ebc4183db3e0d.

Release workflow: https://github.com/openclaw/crawlkit/actions/runs/33364490053
