### PR TITLE
fix(snapshot): reject manifest path traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## v0.14.9 - Unreleased
 
+**Highlights:** Safer snapshot shard paths and recovery from interrupted scheduler-history writes.
+
+- Reject absolute and parent-traversing snapshot shard paths in full and incremental imports while preserving current-directory roots and literal filesystem names. Thanks @SebTardif.
 - Recover truncated scheduler history tails after interrupted writes while preserving valid final records without a newline and reporting write or cleanup failures. Thanks @SebTardif.
 - Update SQLite to v1.58.0 with its required libc v1.75.6 runtime, refresh x/crypto and go-runewidth, and prefer Go 1.27.1 while retaining the Go 1.27.0 minimum.
-- Refresh the pinned TruffleHog secret-scanning action to v3.97.4. Thanks @dependabot.
+- Refresh the pinned TruffleHog secret-scanning action to v3.97.4 and GitHub Script to v9.0.0. Thanks @dependabot.
 
 ## v0.14.8 - 2026-08-30
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ The `remote` package owns the Go client and v1 wire contract for hosted archives
 
 Tests and examples use temporary or in-memory data. They do not access app runtime stores such as `~/.config/gitcrawl`, `~/.slacrawl`, `~/.discrawl`, or `~/.notcrawl`.
 
+Snapshot imports reject absolute and parent-traversing shard paths while preserving literal root and shard names, including current-directory roots. This is a lexical check: snapshots must still come from a trusted filesystem tree because shard reads follow symlinks.
+
 Pass a plain filesystem path to `store.Open` unless SQLite driver parameters are intentional. A caller-supplied `file:` URI keeps its query parameters, which can override crawlkit's default pragmas or fail connection validation.
 
 ## Development

--- a/snapshot/import_paths_test.go
+++ b/snapshot/import_paths_test.go
@@ -1,0 +1,87 @@
+package snapshot
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/openclaw/crawlkit/store"
+)
+
+func TestImportPreservesLiteralPaths(t *testing.T) {
+	for _, incremental := range []bool{false, true} {
+		mode := "full"
+		if incremental {
+			mode = "incremental"
+		}
+		t.Run(mode, func(t *testing.T) {
+			for _, name := range []string{"nested", "dot", "dot-slash", "empty-root", "root-space", "shard-space", "legacy-shard-space"} {
+				t.Run(name, func(t *testing.T) {
+					if runtime.GOOS == "windows" && (name == "root-space" || name == "shard-space" || name == "legacy-shard-space") {
+						t.Skip("Windows normalizes trailing spaces in filesystem names")
+					}
+					ctx := context.Background()
+					base := t.TempDir()
+					root := filepath.Join(base, "archive")
+					rel := "tables/things/000001.jsonl.gz"
+					if name == "root-space" {
+						root += " "
+					}
+					if name == "shard-space" || name == "legacy-shard-space" {
+						rel = " tables/things/000001.jsonl.gz "
+					}
+					write := func(path, id string) {
+						t.Helper()
+						if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+							t.Fatal(err)
+						}
+						writeGzipJSONL(t, path, map[string]any{"id": id})
+					}
+					write(filepath.Join(root, rel), "intended")
+					if name == "root-space" {
+						write(filepath.Join(base, "archive", rel), "foreign")
+					}
+					if name == "shard-space" || name == "legacy-shard-space" {
+						write(filepath.Join(root, "tables/things/000001.jsonl.gz"), "foreign")
+					}
+					table := TableManifest{Name: "things", Files: []string{rel}, Columns: []string{"id"}, Rows: 1}
+					if name == "legacy-shard-space" {
+						table.Files = nil
+						table.File = rel
+					}
+					current := Manifest{Version: 1, Tables: []TableManifest{table}}
+					if err := WriteManifest(root, current); err != nil {
+						t.Fatal(err)
+					}
+					switch name {
+					case "dot", "dot-slash", "empty-root":
+						t.Chdir(root)
+						root = map[string]string{"dot": ".", "dot-slash": "./", "empty-root": ""}[name]
+					}
+					dst, err := store.Open(ctx, store.Options{Path: ":memory:", Schema: "create table things(id text primary key)"})
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer dst.Close()
+					if incremental {
+						_, _, err = ImportIncremental(ctx, IncrementalImportOptions{DB: dst.DB(), RootDir: root, Previous: Manifest{Version: 1}, Current: current})
+					} else {
+						_, err = Import(ctx, ImportOptions{DB: dst.DB(), RootDir: root})
+					}
+					if err != nil {
+						t.Fatal(err)
+					}
+					var id string
+					if err := dst.DB().QueryRowContext(ctx, "select id from things").Scan(&id); err != nil {
+						t.Fatal(err)
+					}
+					if id != "intended" {
+						t.Fatalf("imported %q, want intended root and shard", id)
+					}
+				})
+			}
+		})
+	}
+}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -512,7 +512,10 @@ func importTable(ctx context.Context, tx *sql.Tx, rootDir string, table TableMan
 	reportImportProgress(progress, ImportProgress{Phase: "table_start", Table: table.Name, FileCount: len(files), TotalRows: table.Rows})
 	totalRows := 0
 	for index, rel := range files {
-		path := filepath.Join(rootDir, filepath.FromSlash(rel))
+		path, err := confinedSnapshotFile(rootDir, rel)
+		if err != nil {
+			return totalRows, err
+		}
 		file, err := os.Open(path)
 		if err != nil {
 			return totalRows, fmt.Errorf("open %s: %w", rel, err)
@@ -801,6 +804,28 @@ func planTableMerge(previousFiles, currentFiles []FileManifest, current TableMan
 		return TableImportPlan{Table: current, Mode: TableImportSkip, Reason: "unchanged"}
 	}
 	return TableImportPlan{Table: current, Mode: TableImportFiles, Files: changed, Reason: "merge changed files"}
+}
+
+func confinedSnapshotFile(rootDir, rel string) (string, error) {
+	rel = strings.TrimSpace(rel)
+	if rel == "" || strings.Contains(rel, "\x00") {
+		return "", fmt.Errorf("snapshot file path %q is not under the snapshot root", rel)
+	}
+	clean := filepath.ToSlash(filepath.Clean(rel))
+	local := filepath.FromSlash(clean)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || filepath.IsAbs(clean) || filepath.IsAbs(local) || filepath.VolumeName(local) != "" {
+		return "", fmt.Errorf("snapshot file path %q is not under the snapshot root", rel)
+	}
+	root := filepath.Clean(strings.TrimSpace(rootDir))
+	if root == "" || root == "." {
+		return "", errors.New("root dir is required")
+	}
+	path := filepath.Join(root, local)
+	inside, err := filepath.Rel(root, path)
+	if err != nil || inside == ".." || strings.HasPrefix(inside, ".."+string(filepath.Separator)) || filepath.IsAbs(inside) {
+		return "", fmt.Errorf("snapshot file path %q is not under the snapshot root", rel)
+	}
+	return path, nil
 }
 
 func tableShardDir(table string) (string, error) {

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -807,25 +807,12 @@ func planTableMerge(previousFiles, currentFiles []FileManifest, current TableMan
 }
 
 func confinedSnapshotFile(rootDir, rel string) (string, error) {
-	rel = strings.TrimSpace(rel)
-	if rel == "" || strings.Contains(rel, "\x00") {
+	local := filepath.FromSlash(rel)
+	// Keep literal filesystem names; this checks traversal, not symlink targets.
+	if !filepath.IsLocal(local) || filepath.Clean(local) == "." || strings.ContainsRune(local, 0) {
 		return "", fmt.Errorf("snapshot file path %q is not under the snapshot root", rel)
 	}
-	clean := filepath.ToSlash(filepath.Clean(rel))
-	local := filepath.FromSlash(clean)
-	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || filepath.IsAbs(clean) || filepath.IsAbs(local) || filepath.VolumeName(local) != "" {
-		return "", fmt.Errorf("snapshot file path %q is not under the snapshot root", rel)
-	}
-	root := filepath.Clean(strings.TrimSpace(rootDir))
-	if root == "" || root == "." {
-		return "", errors.New("root dir is required")
-	}
-	path := filepath.Join(root, local)
-	inside, err := filepath.Rel(root, path)
-	if err != nil || inside == ".." || strings.HasPrefix(inside, ".."+string(filepath.Separator)) || filepath.IsAbs(inside) {
-		return "", fmt.Errorf("snapshot file path %q is not under the snapshot root", rel)
-	}
-	return path, nil
+	return filepath.Join(rootDir, local), nil
 }
 
 func tableShardDir(table string) (string, error) {

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -130,6 +130,115 @@ func TestExportRejectsUnsafeTablePath(t *testing.T) {
 	}
 }
 
+func TestImportRejectsUnsafeFilePath(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name   string
+		path   func(outside string) string
+		legacy bool
+	}{
+		{name: "parent directory", path: func(string) string { return "../secret.jsonl.gz" }},
+		{name: "absolute path", path: func(outside string) string { return outside }},
+		{name: "legacy file field", path: func(string) string { return "../secret.jsonl.gz" }, legacy: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			base := t.TempDir()
+			root := filepath.Join(base, "snapshot")
+			if err := os.MkdirAll(root, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			outside := filepath.Join(base, "secret.jsonl.gz")
+			writeGzipJSONL(t, outside, map[string]any{"id": "leaked", "body": "outside"})
+			rel := tc.path(outside)
+			table := TableManifest{
+				Name:    "things",
+				Columns: []string{"id", "body"},
+				Rows:    1,
+			}
+			if tc.legacy {
+				table.File = rel
+			} else {
+				table.Files = []string{rel}
+			}
+			if err := WriteManifest(root, Manifest{
+				Version:     1,
+				GeneratedAt: time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC),
+				Tables:      []TableManifest{table},
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			dst, err := store.Open(ctx, store.Options{
+				Path:   filepath.Join(t.TempDir(), "dst.db"),
+				Schema: `create table things(id text primary key, body text not null);`,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer dst.Close()
+			_, err = Import(ctx, ImportOptions{DB: dst.DB(), RootDir: root})
+			if err == nil || !strings.Contains(err.Error(), "not under the snapshot root") {
+				t.Fatalf("expected confined import path error, got %v", err)
+			}
+			var count int
+			if err := dst.DB().QueryRowContext(ctx, `select count(*) from things`).Scan(&count); err != nil {
+				t.Fatal(err)
+			}
+			if count != 0 {
+				t.Fatalf("escaped rows imported = %d", count)
+			}
+		})
+	}
+}
+
+func TestImportIncrementalRejectsUnsafeFilePath(t *testing.T) {
+	ctx := context.Background()
+	base := t.TempDir()
+	root := filepath.Join(base, "snapshot")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(base, "secret.jsonl.gz")
+	writeGzipJSONL(t, outside, map[string]any{"id": "leaked", "body": "outside"})
+	current := Manifest{
+		Version:     1,
+		GeneratedAt: time.Date(2026, 5, 2, 10, 5, 0, 0, time.UTC),
+		Tables: []TableManifest{{
+			Name:    "things",
+			Files:   []string{"../secret.jsonl.gz"},
+			Columns: []string{"id", "body"},
+			Rows:    1,
+		}},
+	}
+	if err := WriteManifest(root, current); err != nil {
+		t.Fatal(err)
+	}
+
+	dst, err := store.Open(ctx, store.Options{
+		Path:   filepath.Join(t.TempDir(), "dst.db"),
+		Schema: `create table things(id text primary key, body text not null);`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dst.Close()
+	if _, _, err := ImportIncremental(ctx, IncrementalImportOptions{
+		DB:       dst.DB(),
+		RootDir:  root,
+		Previous: Manifest{Version: 1},
+		Current:  current,
+	}); err == nil || !strings.Contains(err.Error(), "not under the snapshot root") {
+		t.Fatalf("expected confined incremental import path error, got %v", err)
+	}
+	var count int
+	if err := dst.DB().QueryRowContext(ctx, `select count(*) from things`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("escaped rows imported = %d", count)
+	}
+}
+
 func TestSyncSidecarTreeCopiesFingerprintsAndPrunes(t *testing.T) {
 	ctx := context.Background()
 	source := t.TempDir()


### PR DESCRIPTION
## What Problem This Solves

A snapshot manifest can list `../outside.jsonl.gz` in `Files` or legacy `File`, causing full and incremental imports to read a gzip JSONL shard outside the caller-selected root and insert its rows into SQLite.

## What Changed

Validate manifest shard paths with Go's platform-aware `filepath.IsLocal` before opening them. Preserve literal root and shard names, including whitespace and current-directory roots (`.`, `./`, and the existing empty-root behavior). This repairs the original patch's root/shard trimming and current-directory regressions while retaining its shared import guard and regression coverage.

The check is lexical. Existing symlink following remains unchanged and is documented in the README; callers must supply a trusted filesystem tree. This PR does not claim symlink-safe confinement.

The unreleased notes credit @SebTardif and include all user-visible changes since v0.14.8, including the already-merged GitHub Script refresh.

## Validation

- Real public `snapshot.Import` and `snapshot.ImportIncremental` calls against temporary gzip JSONL fixtures and SQLite databases, on macOS arm64 with Go 1.27.1.
- Baseline main accepted parent traversal and imported the synthetic `foreign` row. The repaired code rejects parent, absolute, and legacy-parent paths, leaving the preexisting destination row intact.
- Both APIs import the `intended` row for nested shards, `.`, `./`, empty roots, whitespace-bearing roots, and whitespace-bearing shard names; sibling/trimmed-name decoys never supply rows.
- Regression coverage for both APIs and legacy filenames; Windows skips only trailing-whitespace filename cases that its filesystem normalizes.
- `GOMAXPROCS=2 make check`, `actionlint`, independent Codex review, and exact-head CI are recorded in the proof comment.

Contributor: Sebastien Tardif <SebTardif@ncf.ca>.
