### PR TITLE
chore(release): prepare v0.14.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.14.9 - Unreleased
+## v0.14.9 - 2026-09-05
 
 **Highlights:** Safer snapshot shard paths and recovery from interrupted scheduler-history writes.
 


### PR DESCRIPTION
Prepare v0.14.9 by dating the reviewed changelog for September 5, 2026. Keep the Highlights line and user-facing order: snapshot traversal protection, scheduler history recovery, dependency refresh, and Actions updates.

The release workflow injects the CLI version; no source version constant needs changing. Publish only through the unified workflow after this PR is merged and CI succeeds on its exact main commit.

Validation: make check, actionlint, and independent Codex autoreview. This is release preparation only; it does not create a tag or publish artifacts.
