### PR TITLE
fix(snapshot): reject corrupt snapshot imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.14.10 - Unreleased
 
+- Verify compressed shard hashes, sizes, and decoded row counts before committing full or incremental snapshot imports; bind supplied plans to current manifest metadata, reject inconsistent file paths and modern table row totals, and roll back corrupt imports. Preserve legacy manifests without per-file metadata; their nonnegative table row totals remain advisory, including positive values.
+
 ## v0.14.9 - 2026-09-05
 
 **Highlights:** Safer snapshot shard paths and recovery from interrupted scheduler-history writes.

--- a/snapshot/integrity_test.go
+++ b/snapshot/integrity_test.go
@@ -1,0 +1,752 @@
+package snapshot
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/crawlkit/store"
+)
+
+func TestImportIntegrityValidMetadata(t *testing.T) {
+	for _, mode := range []string{"full", "replace", "merge"} {
+		for _, metadata := range []string{"complete", "hash only", "size only", "rows only", "metadata only", "reordered", "aliased Files", "aliased File", "legacy Files", "legacy File"} {
+			t.Run(mode+"/"+metadata, func(t *testing.T) {
+				root, manifest := integritySnapshot(t,
+					[]map[string]any{{"id": "one", "body": "first"}},
+					[]map[string]any{{"id": "two", "body": "second"}},
+				)
+				table := &manifest.Tables[0]
+				wantRows := 2
+				switch metadata {
+				case "hash only":
+					for i := range table.FileManifests {
+						table.FileManifests[i].Size = 0
+					}
+				case "size only":
+					for i := range table.FileManifests {
+						table.FileManifests[i].SHA256 = ""
+					}
+				case "rows only":
+					for i := range table.FileManifests {
+						table.FileManifests[i].Size = 0
+						table.FileManifests[i].SHA256 = ""
+					}
+				case "metadata only":
+					table.Files = nil
+				case "reordered":
+					table.FileManifests[0], table.FileManifests[1] = table.FileManifests[1], table.FileManifests[0]
+				case "aliased Files":
+					table.Files[0] = "tables/things/x/../000000.jsonl.gz"
+				case "aliased File":
+					table.File = "tables/things/x/../000000.jsonl.gz"
+					table.Files = table.Files[:1]
+					table.FileManifests = table.FileManifests[:1]
+					table.Rows = 1
+					wantRows = 1
+				case "legacy Files":
+					table.FileManifests = nil
+					table.Rows = 0
+				case "legacy File":
+					table.File = table.Files[1]
+					table.Files = nil
+					table.FileManifests = nil
+					table.Rows = 0
+					wantRows = 1
+				}
+				db := integrityDB(t)
+				if err := runIntegrityImport(t, mode, manifest, ImportOptions{DB: db, RootDir: root}); err != nil {
+					t.Fatal(err)
+				}
+				assertIntegrityCount(t, db, `select count(*) from things where id != 'old'`, wantRows)
+				wantOld := 0
+				if mode == "merge" {
+					wantOld = 1
+				}
+				assertIntegrityCount(t, db, `select count(*) from things where id = 'old'`, wantOld)
+			})
+		}
+	}
+}
+
+func TestImportIntegrityCountsDecodedRowsBeforeCallbacks(t *testing.T) {
+	for _, mode := range []string{"full", "replace", "merge"} {
+		t.Run(mode, func(t *testing.T) {
+			root, manifest := integritySnapshot(t, []map[string]any{
+				{"id": "one", "body": "keep"},
+				{},
+				nil,
+				{"id": "filtered", "body": "skip"},
+				{"id": "ignored", "body": "skip"},
+			}, nil)
+			db := integrityDB(t)
+			filterCalls, importCalls := 0, 0
+			var progress []ImportProgress
+			err := runIntegrityImport(t, mode, manifest, ImportOptions{
+				DB: db, RootDir: root,
+				Filter: func(_ string, row map[string]any) (bool, error) {
+					filterCalls++
+					return row["id"] != "filtered", nil
+				},
+				ImportRow: func(ctx context.Context, tx *sql.Tx, table string, row map[string]any) error {
+					importCalls++
+					if row["id"] == "ignored" {
+						return nil
+					}
+					return insertRow(ctx, tx, table, row)
+				},
+				Progress: func(event ImportProgress) { progress = append(progress, event) },
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if filterCalls != 3 || importCalls != 2 {
+				t.Fatalf("filter calls = %d, import calls = %d", filterCalls, importCalls)
+			}
+			assertIntegrityCount(t, db, `select count(*) from things where id != 'old'`, 1)
+			if got := progress[len(progress)-1]; got.Phase != "table_done" || got.Rows != 2 || got.TotalRows != 5 {
+				t.Fatalf("table progress = %+v", got)
+			}
+		})
+	}
+}
+
+func TestImportIntegrityRollsBackBadLaterFile(t *testing.T) {
+	for _, mode := range []string{"full", "replace", "merge"} {
+		for _, corruption := range []struct {
+			name string
+			want string
+		}{
+			{"hash", "compressed SHA256 mismatch"},
+			{"size small", "compressed size mismatch"},
+			{"size large", "compressed size mismatch"},
+			{"negative size", "compressed size mismatch"},
+			{"rows zero", "row count mismatch"},
+			{"rows large", "row count mismatch"},
+			{"truncated gzip", "unexpected EOF"},
+			{"gzip checksum", "invalid checksum"},
+			{"legacy truncated gzip", "unexpected EOF"},
+		} {
+			t.Run(mode+"/"+corruption.name, func(t *testing.T) {
+				root, manifest := integritySnapshot(t,
+					[]map[string]any{{"id": "one", "body": "first"}},
+					[]map[string]any{{"id": "two", "body": "second"}},
+				)
+				bad := &manifest.Tables[0].FileManifests[1]
+				switch corruption.name {
+				case "hash":
+					bad.SHA256 = strings.Repeat("0", 64)
+				case "size small":
+					bad.Size--
+				case "size large":
+					bad.Size++
+				case "negative size":
+					bad.Size = -1
+				case "rows zero":
+					bad.Rows = 0
+					manifest.Tables[0].Rows = 1
+				case "rows large":
+					bad.Rows = 2
+					manifest.Tables[0].Rows = 3
+				default:
+					path := filepath.Join(root, filepath.FromSlash(bad.Path))
+					data, err := os.ReadFile(path)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if corruption.name == "gzip checksum" {
+						data[len(data)-8] ^= 1
+					} else {
+						data = data[:len(data)-1]
+					}
+					if err := os.WriteFile(path, data, 0o600); err != nil {
+						t.Fatal(err)
+					}
+					if corruption.name == "legacy truncated gzip" {
+						manifest.Tables[0].FileManifests = nil
+					}
+				}
+				db := integrityDB(t)
+				beforeCalled, deleteCalled, afterCalled := false, false, false
+				var imported []string
+				var progress []ImportProgress
+				err := runIntegrityImport(t, mode, manifest, ImportOptions{
+					DB: db, RootDir: root,
+					BeforeImport: func(ctx context.Context, tx *sql.Tx) error {
+						beforeCalled = true
+						_, err := tx.ExecContext(ctx, `insert into audit values ('before')`)
+						return err
+					},
+					DeleteTable: func(ctx context.Context, tx *sql.Tx, table string) error {
+						deleteCalled = true
+						if _, err := tx.ExecContext(ctx, `insert into audit values ('delete')`); err != nil {
+							return err
+						}
+						return deleteImportTable(ctx, tx, table, nil)
+					},
+					ImportRow: func(ctx context.Context, tx *sql.Tx, table string, row map[string]any) error {
+						imported = append(imported, row["id"].(string))
+						if _, err := tx.ExecContext(ctx, `insert into audit values ('row')`); err != nil {
+							return err
+						}
+						return insertRow(ctx, tx, table, row)
+					},
+					AfterImport: func(ctx context.Context, tx *sql.Tx) error {
+						afterCalled = true
+						_, err := tx.ExecContext(ctx, `insert into audit values ('after')`)
+						return err
+					},
+					Progress: func(event ImportProgress) { progress = append(progress, event) },
+				})
+				if err == nil || !strings.Contains(err.Error(), corruption.want) {
+					t.Fatalf("error = %v, want %q", err, corruption.want)
+				}
+				if !strings.Contains(err.Error(), manifest.Tables[0].Files[1]) {
+					t.Fatalf("error does not identify bad shard: %v", err)
+				}
+				if !beforeCalled || deleteCalled != (mode != "merge") || afterCalled {
+					t.Fatalf("hooks: before=%t delete=%t after=%t", beforeCalled, deleteCalled, afterCalled)
+				}
+				if len(imported) == 0 || imported[0] != "one" {
+					t.Fatalf("first file was not imported before failure: %v", imported)
+				}
+				done := 0
+				for _, event := range progress {
+					if event.Phase == "file_done" {
+						done++
+						if event.File != manifest.Tables[0].Files[0] {
+							t.Fatalf("corrupt file reported done: %+v", event)
+						}
+					}
+					if event.Phase == "table_done" {
+						t.Fatalf("failed table reported done: %+v", event)
+					}
+				}
+				if done != 1 {
+					t.Fatalf("completed files = %d", done)
+				}
+				assertIntegrityCount(t, db, `select count(*) from things`, 1)
+				assertIntegrityCount(t, db, `select count(*) from things where id = 'old' and body = 'original'`, 1)
+				assertIntegrityCount(t, db, `select count(*) from audit`, 0)
+			})
+		}
+	}
+}
+
+func TestImportIntegrityRejectsInconsistentPaths(t *testing.T) {
+	for _, mode := range []string{"full", "replace", "merge", "skip"} {
+		for _, mismatch := range []string{"missing entry", "extra entry", "missing path", "wrong path", "duplicate metadata", "duplicate file", "conflicting File"} {
+			t.Run(mode+"/"+mismatch, func(t *testing.T) {
+				root, manifest := integritySnapshot(t,
+					[]map[string]any{{"id": "one", "body": "first"}},
+					[]map[string]any{{"id": "two", "body": "second"}},
+				)
+				table := &manifest.Tables[0]
+				switch mismatch {
+				case "missing entry":
+					table.FileManifests = table.FileManifests[:1]
+				case "extra entry":
+					table.Files = table.Files[:1]
+				case "missing path":
+					table.FileManifests[1].Path = ""
+				case "wrong path":
+					table.FileManifests[1].Path = "other.jsonl.gz"
+				case "duplicate metadata":
+					table.FileManifests[1] = table.FileManifests[0]
+				case "duplicate file":
+					table.Files[1] = table.Files[0]
+				case "conflicting File":
+					table.File = "other.jsonl.gz"
+				}
+				db := integrityDB(t)
+				err := runIntegrityImport(t, mode, manifest, ImportOptions{DB: db, RootDir: root})
+				if err == nil || !strings.Contains(err.Error(), "table things:") {
+					t.Fatalf("expected manifest metadata error, got %v", err)
+				}
+				assertIntegrityCount(t, db, `select count(*) from things`, 1)
+				assertIntegrityCount(t, db, `select count(*) from things where id = 'old'`, 1)
+			})
+		}
+	}
+}
+
+func TestImportIntegrityLegacyPartialPlan(t *testing.T) {
+	for _, field := range []string{"File", "Files"} {
+		t.Run(field, func(t *testing.T) {
+			root, manifest := integritySnapshot(t,
+				[]map[string]any{{"id": "one", "body": "first"}},
+				[]map[string]any{{"id": "two", "body": "second"}},
+			)
+			table := &manifest.Tables[0]
+			table.FileManifests = nil
+			table.Rows = 0
+			if field == "File" {
+				table.File = table.Files[1]
+				table.Files = nil
+			}
+			files := tableFileManifests(*table)
+			plan := ImportPlan{Tables: []TableImportPlan{{
+				Table: *table,
+				Mode:  TableImportFiles,
+				Files: files[len(files)-1:],
+			}}}
+			db := integrityDB(t)
+			if _, _, err := ImportIncremental(context.Background(), IncrementalImportOptions{
+				DB: db, RootDir: root, Current: manifest, Plan: plan,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			assertIntegrityCount(t, db, `select count(*) from things`, 2)
+			assertIntegrityCount(t, db, `select count(*) from things where id in ('old', 'two')`, 2)
+		})
+	}
+}
+
+func TestImportIntegrityRejectsInconsistentRows(t *testing.T) {
+	for _, mode := range []string{"full", "replace", "merge", "skip"} {
+		for _, mismatch := range []string{"missing last shard", "zero total", "small total", "large total", "negative total", "negative file rows", "overflow"} {
+			t.Run(mode+"/"+mismatch, func(t *testing.T) {
+				root, manifest := integritySnapshot(t,
+					[]map[string]any{{"id": "one", "body": "first"}},
+					[]map[string]any{{"id": "two", "body": "second"}},
+				)
+				table := &manifest.Tables[0]
+				switch mismatch {
+				case "missing last shard":
+					table.Files = table.Files[:1]
+					table.FileManifests = table.FileManifests[:1]
+				case "zero total":
+					table.Rows = 0
+				case "small total":
+					table.Rows = 1
+				case "large total":
+					table.Rows = 3
+				case "negative total":
+					table.Rows = -1
+				case "negative file rows":
+					table.FileManifests[1].Rows = -1
+				case "overflow":
+					table.Rows = int(^uint(0) >> 1)
+					table.FileManifests[0].Rows = table.Rows
+				}
+				db := integrityDB(t)
+				afterCalled := false
+				err := runIntegrityImport(t, mode, manifest, ImportOptions{
+					DB: db, RootDir: root,
+					BeforeImport: func(ctx context.Context, tx *sql.Tx) error {
+						_, err := tx.ExecContext(ctx, `insert into audit values ('before')`)
+						return err
+					},
+					AfterImport: func(context.Context, *sql.Tx) error {
+						afterCalled = true
+						return nil
+					},
+				})
+				if err == nil || !strings.Contains(err.Error(), "table things:") || !strings.Contains(err.Error(), "row count") {
+					t.Fatalf("expected table row count error, got %v", err)
+				}
+				if afterCalled {
+					t.Fatal("AfterImport called with invalid table row count")
+				}
+				assertIntegrityCount(t, db, `select count(*) from things`, 1)
+				assertIntegrityCount(t, db, `select count(*) from things where id = 'old' and body = 'original'`, 1)
+				assertIntegrityCount(t, db, `select count(*) from audit`, 0)
+			})
+		}
+	}
+}
+
+func TestImportIntegrityRejectsStrippedPlannedMetadata(t *testing.T) {
+	root, manifest := integritySnapshot(t, []map[string]any{{"id": "one", "body": "first"}})
+	table := manifest.Tables[0]
+	plan := ImportPlan{Tables: []TableImportPlan{{
+		Table: table,
+		Mode:  TableImportFiles,
+		Files: []FileManifest{{Path: table.Files[0]}},
+	}}}
+	db := integrityDB(t)
+	_, _, err := ImportIncremental(context.Background(), IncrementalImportOptions{
+		DB: db, RootDir: root, Current: manifest, Plan: plan,
+	})
+	if err == nil || !strings.Contains(err.Error(), "inconsistent planned file manifest") {
+		t.Fatalf("expected planned metadata error, got %v", err)
+	}
+	assertIntegrityCount(t, db, `select count(*) from things where id = 'old'`, 1)
+}
+
+func TestImportIntegrityBindsSuppliedPlanToCurrentManifest(t *testing.T) {
+	for _, mode := range []TableImportMode{TableImportReplace, TableImportFiles} {
+		for _, metadata := range []string{"stripped", "forged"} {
+			t.Run(string(mode)+"/"+metadata, func(t *testing.T) {
+				root, current := integritySnapshot(t, []map[string]any{{"id": "one", "body": "first"}})
+				table := current.Tables[0]
+				path := filepath.Join(root, filepath.FromSlash(table.Files[0]))
+				data, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				// Changing the gzip mtime preserves rows and size but changes its hash.
+				data[4] ^= 1
+				if err := os.WriteFile(path, data, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				files := []FileManifest{{Path: table.Files[0]}}
+				table.FileManifests = nil
+				table.Rows = 0
+				if metadata == "forged" {
+					files[0] = current.Tables[0].FileManifests[0]
+					files[0].SHA256 = fmt.Sprintf("%x", sha256.Sum256(data))
+					table.FileManifests = files
+					table.Rows = files[0].Rows
+				}
+				plan := ImportPlan{Tables: []TableImportPlan{{Table: table, Mode: mode, Files: files}}}
+				db := integrityDB(t)
+				afterCalled := false
+				_, _, err = ImportIncremental(context.Background(), IncrementalImportOptions{
+					DB: db, RootDir: root, Current: current, Plan: plan,
+					BeforeImport: func(ctx context.Context, tx *sql.Tx) error {
+						_, err := tx.ExecContext(ctx, `insert into audit values ('before')`)
+						return err
+					},
+					AfterImport: func(context.Context, *sql.Tx) error {
+						afterCalled = true
+						return nil
+					},
+				})
+				want := "compressed SHA256 mismatch"
+				if mode == TableImportFiles {
+					want = "inconsistent planned file manifest"
+				}
+				if err == nil || !strings.Contains(err.Error(), want) {
+					t.Fatalf("error = %v, want %q", err, want)
+				}
+				if afterCalled {
+					t.Fatal("AfterImport called for a corrupt supplied plan")
+				}
+				assertIntegrityCount(t, db, `select count(*) from things`, 1)
+				assertIntegrityCount(t, db, `select count(*) from things where id = 'old' and body = 'original'`, 1)
+				assertIntegrityCount(t, db, `select count(*) from audit`, 0)
+				if metadata == "stripped" && len(plan.Tables[0].Table.FileManifests) != 0 {
+					t.Fatal("import mutated the caller's plan metadata")
+				}
+			})
+		}
+	}
+}
+
+func TestImportIntegrityRejectsPlanTableAbsentFromCurrent(t *testing.T) {
+	root, current := integritySnapshot(t, []map[string]any{{"id": "one", "body": "first"}})
+	plan := PlanMergeImport(Manifest{Version: current.Version}, current)
+	plan.Tables[0].Table.Name = "missing"
+	db := integrityDB(t)
+	_, _, err := ImportIncremental(context.Background(), IncrementalImportOptions{
+		DB: db, RootDir: root, Current: current, Plan: plan,
+	})
+	if err == nil || !strings.Contains(err.Error(), `planned table "missing" is not in the current manifest`) {
+		t.Fatalf("expected missing plan table error, got %v", err)
+	}
+	assertIntegrityCount(t, db, `select count(*) from things where id = 'old'`, 1)
+}
+
+func TestImportIntegrityRejectsShadowedCurrentTable(t *testing.T) {
+	root, current := integritySnapshot(t, []map[string]any{{"id": "one", "body": "first"}})
+	legacy := current.Tables[0]
+	legacy.FileManifests = nil
+	current.Tables = append(current.Tables, legacy)
+	db := integrityDB(t)
+	_, _, err := ImportIncremental(context.Background(), IncrementalImportOptions{
+		DB: db, RootDir: root, Current: current, Previous: Manifest{Version: current.Version},
+	})
+	if err == nil || !strings.Contains(err.Error(), `duplicate table "things" in the current manifest`) {
+		t.Fatalf("expected duplicate current table error, got %v", err)
+	}
+	assertIntegrityCount(t, db, `select count(*) from things where id = 'old'`, 1)
+}
+
+func TestImportIntegrityRejectsInvalidLegacyPlanPaths(t *testing.T) {
+	for _, field := range []string{"File", "Files"} {
+		for _, invalid := range []string{"undeclared", "duplicate"} {
+			t.Run(field+"/"+invalid, func(t *testing.T) {
+				root, current := integritySnapshot(t,
+					[]map[string]any{{"id": "one", "body": "first"}},
+					[]map[string]any{{"id": "two", "body": "second"}},
+				)
+				table := &current.Tables[0]
+				knownPath := table.Files[0]
+				table.FileManifests = nil
+				table.Rows = 0
+				if field == "File" {
+					table.File = knownPath
+					table.Files = nil
+				}
+				selected := []FileManifest{{Path: knownPath}}
+				if invalid == "undeclared" {
+					rel := "tables/things/undeclared.jsonl.gz"
+					writeGzipJSONL(t, filepath.Join(root, filepath.FromSlash(rel)), map[string]any{"id": "rogue", "body": "undeclared"})
+					selected = append(selected, FileManifest{Path: rel})
+				} else {
+					selected = append(selected, selected[0])
+				}
+				plan := ImportPlan{Tables: []TableImportPlan{{
+					Table: *table, Mode: TableImportFiles, Files: selected,
+				}}}
+				db := integrityDB(t)
+				afterCalled := false
+				_, _, err := ImportIncremental(context.Background(), IncrementalImportOptions{
+					DB: db, RootDir: root, Current: current, Plan: plan,
+					BeforeImport: func(ctx context.Context, tx *sql.Tx) error {
+						_, err := tx.ExecContext(ctx, `insert into audit values ('before')`)
+						return err
+					},
+					AfterImport: func(context.Context, *sql.Tx) error {
+						afterCalled = true
+						return nil
+					},
+				})
+				if err == nil || !strings.Contains(err.Error(), "inconsistent planned file manifest") {
+					t.Fatalf("expected invalid legacy plan path error, got %v", err)
+				}
+				if afterCalled {
+					t.Fatal("AfterImport called with invalid legacy plan paths")
+				}
+				assertIntegrityCount(t, db, `select count(*) from things`, 1)
+				assertIntegrityCount(t, db, `select count(*) from things where id = 'old' and body = 'original'`, 1)
+				assertIntegrityCount(t, db, `select count(*) from audit`, 0)
+			})
+		}
+	}
+}
+
+func TestImportIntegrityRejectsNegativeLegacyRows(t *testing.T) {
+	for _, mode := range []string{"full", "replace", "merge", "skip"} {
+		for _, field := range []string{"File", "Files", "no files"} {
+			t.Run(mode+"/"+field, func(t *testing.T) {
+				root, current := integritySnapshot(t, []map[string]any{{"id": "one", "body": "first"}})
+				table := &current.Tables[0]
+				table.FileManifests = nil
+				table.Rows = -1
+				if field == "File" {
+					table.File = table.Files[0]
+					table.Files = nil
+				} else if field == "no files" {
+					table.Files = nil
+				}
+				db := integrityDB(t)
+				err := runIntegrityImport(t, mode, current, ImportOptions{DB: db, RootDir: root})
+				if err == nil || !strings.Contains(err.Error(), "negative row count") {
+					t.Fatalf("expected negative legacy row count error, got %v", err)
+				}
+				assertIntegrityCount(t, db, `select count(*) from things`, 1)
+				assertIntegrityCount(t, db, `select count(*) from things where id = 'old' and body = 'original'`, 1)
+			})
+		}
+	}
+}
+
+func TestImportIntegrityRejectsDuplicateActivePlans(t *testing.T) {
+	for _, legacy := range []bool{false, true} {
+		for _, first := range []TableImportMode{TableImportFiles, TableImportReplace} {
+			for _, second := range []TableImportMode{TableImportFiles, TableImportReplace} {
+				t.Run(fmt.Sprintf("legacy=%t/%s/%s", legacy, first, second), func(t *testing.T) {
+					root, current := integritySnapshot(t, []map[string]any{{"id": "one", "body": "first"}})
+					if legacy {
+						current.Tables[0].FileManifests = nil
+						current.Tables[0].Rows = 0
+					}
+					table := current.Tables[0]
+					files := tableFileManifests(table)
+					plan := ImportPlan{Tables: []TableImportPlan{
+						{Table: table, Mode: first, Files: files},
+						{Table: table, Mode: second, Files: files},
+					}}
+					db := integrityDB(t)
+					beforeCalled := false
+					_, _, err := ImportIncremental(context.Background(), IncrementalImportOptions{
+						DB: db, RootDir: root, Current: current, Plan: plan,
+						BeforeImport: func(context.Context, *sql.Tx) error {
+							beforeCalled = true
+							return nil
+						},
+					})
+					if err == nil || !strings.Contains(err.Error(), `duplicate active plan for table "things"`) {
+						t.Fatalf("expected duplicate active plan error, got %v", err)
+					}
+					if beforeCalled {
+						t.Fatal("BeforeImport called before rejecting duplicate active plans")
+					}
+					assertIntegrityCount(t, db, `select count(*) from things`, 1)
+					assertIntegrityCount(t, db, `select count(*) from things where id = 'old' and body = 'original'`, 1)
+				})
+			}
+		}
+	}
+}
+
+func TestImportIntegrityRejectsAliasedManifestPaths(t *testing.T) {
+	for _, mode := range []string{"full", "replace", "merge", "skip"} {
+		for _, metadata := range []string{"modern", "legacy", "Files only"} {
+			t.Run(mode+"/"+metadata, func(t *testing.T) {
+				root, current := integritySnapshot(t, []map[string]any{{"id": "one", "body": "first"}})
+				table := &current.Tables[0]
+				alias := table.FileManifests[0]
+				alias.Path = "tables/things/x/../000000.jsonl.gz"
+				table.Files = append(table.Files, alias.Path)
+				if metadata == "legacy" {
+					table.FileManifests = nil
+					table.Rows = 0
+				} else if metadata == "modern" {
+					table.FileManifests = append(table.FileManifests, alias)
+					table.Rows += alias.Rows
+				}
+				db := integrityDB(t)
+				afterCalled := false
+				err := runIntegrityImport(t, mode, current, ImportOptions{
+					DB: db, RootDir: root,
+					BeforeImport: func(ctx context.Context, tx *sql.Tx) error {
+						_, err := tx.ExecContext(ctx, `insert into audit values ('before')`)
+						return err
+					},
+					AfterImport: func(context.Context, *sql.Tx) error {
+						afterCalled = true
+						return nil
+					},
+				})
+				if err == nil || !strings.Contains(err.Error(), "table things:") {
+					t.Fatalf("expected duplicate shard path error, got %v", err)
+				}
+				if afterCalled {
+					t.Fatal("AfterImport called for duplicate shard paths")
+				}
+				assertIntegrityCount(t, db, `select count(*) from things`, 1)
+				assertIntegrityCount(t, db, `select count(*) from things where id = 'old' and body = 'original'`, 1)
+				assertIntegrityCount(t, db, `select count(*) from audit`, 0)
+			})
+		}
+	}
+}
+
+func TestImportIntegrityAliasedPlanPaths(t *testing.T) {
+	for _, metadata := range []string{"modern", "legacy File", "legacy Files"} {
+		for _, duplicate := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/duplicate=%t", metadata, duplicate), func(t *testing.T) {
+				root, current := integritySnapshot(t, []map[string]any{{"id": "one", "body": "first"}})
+				table := &current.Tables[0]
+				if metadata != "modern" {
+					table.FileManifests = nil
+					table.Rows = 0
+				}
+				if metadata == "legacy File" {
+					table.File = table.Files[0]
+					table.Files = nil
+				}
+				original := tableFileManifests(*table)[0]
+				alias := original
+				alias.Path = "tables/things/x/../000000.jsonl.gz"
+				selected := []FileManifest{alias}
+				if duplicate {
+					selected = append(selected, original)
+				}
+				plan := ImportPlan{Tables: []TableImportPlan{{
+					Table: *table, Mode: TableImportFiles, Files: selected,
+				}}}
+				db := integrityDB(t)
+				_, _, err := ImportIncremental(context.Background(), IncrementalImportOptions{
+					DB: db, RootDir: root, Current: current, Plan: plan,
+					ImportRow: func(ctx context.Context, tx *sql.Tx, table string, row map[string]any) error {
+						_, err := tx.ExecContext(ctx, `insert into audit values ('row')`)
+						return err
+					},
+				})
+				wantRows := 1
+				if duplicate {
+					wantRows = 0
+					if err == nil || !strings.Contains(err.Error(), "inconsistent planned file manifest") {
+						t.Fatalf("expected duplicate planned shard error, got %v", err)
+					}
+				} else if err != nil {
+					t.Fatal(err)
+				}
+				assertIntegrityCount(t, db, `select count(*) from audit`, wantRows)
+				assertIntegrityCount(t, db, `select count(*) from things where id = 'old' and body = 'original'`, 1)
+			})
+		}
+	}
+}
+
+func integritySnapshot(t *testing.T, shards ...[]map[string]any) (string, Manifest) {
+	t.Helper()
+	root := t.TempDir()
+	table := TableManifest{Name: "things", Columns: []string{"id", "body"}}
+	for i, rows := range shards {
+		rel := fmt.Sprintf("tables/things/%06d.jsonl.gz", i)
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		writeGzipJSONL(t, path, rows...)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		table.Files = append(table.Files, rel)
+		table.FileManifests = append(table.FileManifests, FileManifest{
+			Path: rel, Rows: len(rows), Size: int64(len(data)), SHA256: fmt.Sprintf("%x", sha256.Sum256(data)),
+		})
+		table.Rows += len(rows)
+	}
+	return root, Manifest{Version: 1, Tables: []TableManifest{table}}
+}
+
+func integrityDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := store.Open(context.Background(), store.Options{
+		Path: filepath.Join(t.TempDir(), "dst.db"),
+		Schema: `create table things(id text primary key, body text not null);
+create table audit(event text not null);`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	mustExec(t, db.DB(), `insert into things values ('old', 'original')`)
+	return db.DB()
+}
+
+func runIntegrityImport(t *testing.T, mode string, manifest Manifest, opts ImportOptions) error {
+	t.Helper()
+	ctx := context.Background()
+	if mode == "full" {
+		if err := WriteManifest(opts.RootDir, manifest); err != nil {
+			t.Fatal(err)
+		}
+		_, err := Import(ctx, opts)
+		return err
+	}
+	previous := Manifest{Version: manifest.Version}
+	plan := PlanIncrementalImport(previous, manifest)
+	if mode == "merge" {
+		plan = PlanMergeImport(previous, manifest)
+	} else if mode == "skip" {
+		previous = manifest
+		plan = PlanIncrementalImport(previous, manifest)
+	}
+	_, _, err := ImportIncremental(ctx, IncrementalImportOptions{
+		DB: opts.DB, RootDir: opts.RootDir, Previous: previous, Current: manifest, Plan: plan,
+		DeleteTable: opts.DeleteTable, Filter: opts.Filter, ImportRow: opts.ImportRow, Progress: opts.Progress,
+		BeforeImport: opts.BeforeImport, AfterImport: opts.AfterImport,
+	})
+	return err
+}
+
+func assertIntegrityCount(t *testing.T, db *sql.DB, query string, want int) {
+	t.Helper()
+	var got int
+	if err := db.QueryRow(query).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("%s: got %d, want %d", query, got, want)
+	}
+}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -339,6 +339,16 @@ func ImportIncremental(ctx context.Context, opts IncrementalImportOptions) (Mani
 			return Manifest{}, ImportPlan{}, err
 		}
 	}
+	currentTables := make(map[string]TableManifest, len(current.Tables))
+	for _, table := range current.Tables {
+		if _, exists := currentTables[table.Name]; exists {
+			return Manifest{}, ImportPlan{}, fmt.Errorf("duplicate table %q in the current manifest", table.Name)
+		}
+		if _, err := importFileManifests(table); err != nil {
+			return Manifest{}, ImportPlan{}, err
+		}
+		currentTables[table.Name] = table
+	}
 	plan := opts.Plan
 	if len(plan.Tables) == 0 && !plan.Full && plan.Reason == "" {
 		plan = PlanIncrementalImport(opts.Previous, current)
@@ -348,6 +358,16 @@ func ImportIncremental(ctx context.Context, opts IncrementalImportOptions) (Mani
 	}
 	if !plan.Changed() {
 		return current, plan, nil
+	}
+	activeTables := make(map[string]bool, len(plan.Tables))
+	for _, tablePlan := range plan.Tables {
+		if tablePlan.Mode == TableImportSkip {
+			continue
+		}
+		if activeTables[tablePlan.Table.Name] {
+			return Manifest{}, plan, fmt.Errorf("duplicate active plan for table %q", tablePlan.Table.Name)
+		}
+		activeTables[tablePlan.Table.Name] = true
 	}
 	tx, err := opts.DB.BeginTx(ctx, nil)
 	if err != nil {
@@ -365,6 +385,14 @@ func ImportIncremental(ctx context.Context, opts IncrementalImportOptions) (Mani
 		}
 	}
 	for _, tablePlan := range plan.Tables {
+		if tablePlan.Mode != TableImportSkip {
+			table, ok := currentTables[tablePlan.Table.Name]
+			if !ok {
+				return Manifest{}, plan, fmt.Errorf("planned table %q is not in the current manifest", tablePlan.Table.Name)
+			}
+			// Plans select work; only the current manifest supplies integrity metadata.
+			tablePlan.Table = table
+		}
 		switch tablePlan.Mode {
 		case TableImportSkip:
 			continue
@@ -378,11 +406,10 @@ func ImportIncremental(ctx context.Context, opts IncrementalImportOptions) (Mani
 			}
 			reportImportProgress(opts.Progress, ImportProgress{Phase: "table_done", Table: tablePlan.Table.Name, Rows: rows, TotalRows: tablePlan.Table.Rows})
 		case TableImportFiles:
-			table := tablePlan.Table
-			table.File = ""
-			table.Files = fileManifestPaths(tablePlan.Files)
-			table.FileManifests = tablePlan.Files
-			table.Rows = fileManifestRows(tablePlan.Files)
+			table, err := selectImportFiles(tablePlan)
+			if err != nil {
+				return Manifest{}, plan, err
+			}
 			rows, err := importTable(ctx, tx, opts.RootDir, table, opts.Filter, opts.ImportRow, opts.Progress)
 			if err != nil {
 				return Manifest{}, plan, err
@@ -502,16 +529,17 @@ func exportTable(ctx context.Context, db *sql.DB, rootDir, table string, maxShar
 }
 
 func importTable(ctx context.Context, tx *sql.Tx, rootDir string, table TableManifest, filter RowFilter, importRow RowImportFunc, progress func(ImportProgress)) (int, error) {
-	files := table.Files
-	if len(files) == 0 && strings.TrimSpace(table.File) != "" {
-		files = []string{table.File}
+	files, err := importFileManifests(table)
+	if err != nil {
+		return 0, err
 	}
 	if len(files) == 0 {
 		return 0, nil
 	}
 	reportImportProgress(progress, ImportProgress{Phase: "table_start", Table: table.Name, FileCount: len(files), TotalRows: table.Rows})
 	totalRows := 0
-	for index, rel := range files {
+	for index, entry := range files {
+		rel := entry.Path
 		path, err := confinedSnapshotFile(rootDir, rel)
 		if err != nil {
 			return totalRows, err
@@ -522,10 +550,14 @@ func importTable(ctx context.Context, tx *sql.Tx, rootDir string, table TableMan
 		}
 		fileProgress := ImportProgress{Phase: "file_start", Table: table.Name, File: rel, FileIndex: index + 1, FileCount: len(files), TotalRows: table.Rows}
 		reportImportProgress(progress, fileProgress)
-		rows, err := importJSONLGzip(ctx, tx, file, table.Name, filter, importRow)
+		var expected *FileManifest
+		if len(table.FileManifests) > 0 {
+			expected = &entry
+		}
+		rows, err := importJSONLGzip(ctx, tx, file, table.Name, filter, importRow, expected)
 		if err != nil {
 			_ = file.Close()
-			return totalRows, err
+			return totalRows, fmt.Errorf("import %s: %w", rel, err)
 		}
 		if err := file.Close(); err != nil {
 			return totalRows, fmt.Errorf("close %s: %w", rel, err)
@@ -538,7 +570,12 @@ func importTable(ctx context.Context, tx *sql.Tx, rootDir string, table TableMan
 	return totalRows, nil
 }
 
-func importJSONLGzip(ctx context.Context, tx *sql.Tx, reader io.Reader, table string, filter RowFilter, importRow RowImportFunc) (int, error) {
+func importJSONLGzip(ctx context.Context, tx *sql.Tx, reader io.Reader, table string, filter RowFilter, importRow RowImportFunc, expected *FileManifest) (int, error) {
+	hasher := sha256.New()
+	counter := &countingWriter{w: hasher}
+	if expected != nil {
+		reader = io.TeeReader(reader, counter)
+	}
 	gz, err := gzip.NewReader(reader)
 	if err != nil {
 		return 0, fmt.Errorf("open gzip for %s: %w", table, err)
@@ -547,11 +584,13 @@ func importJSONLGzip(ctx context.Context, tx *sql.Tx, reader io.Reader, table st
 	scanner := bufio.NewScanner(gz)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)
 	rows := 0
+	decodedRows := 0
 	for scanner.Scan() {
 		var row map[string]any
 		if err := json.Unmarshal(scanner.Bytes(), &row); err != nil {
 			return rows, fmt.Errorf("decode %s row: %w", table, err)
 		}
+		decodedRows++
 		if len(row) == 0 {
 			continue
 		}
@@ -573,8 +612,20 @@ func importJSONLGzip(ctx context.Context, tx *sql.Tx, reader io.Reader, table st
 		}
 		rows++
 	}
+	// Scan through gzip EOF: Close alone does not verify the gzip checksum.
 	if err := scanner.Err(); err != nil {
 		return rows, fmt.Errorf("scan %s rows: %w", table, err)
+	}
+	if expected != nil {
+		if expected.Size != 0 && counter.n != expected.Size {
+			return rows, fmt.Errorf("compressed size mismatch: got %d, want %d", counter.n, expected.Size)
+		}
+		if expected.SHA256 != "" && !strings.EqualFold(hex.EncodeToString(hasher.Sum(nil)), expected.SHA256) {
+			return rows, errors.New("compressed SHA256 mismatch")
+		}
+		if decodedRows != expected.Rows {
+			return rows, fmt.Errorf("row count mismatch: got %d, want %d", decodedRows, expected.Rows)
+		}
 	}
 	return rows, nil
 }
@@ -841,6 +892,113 @@ func tableFileManifests(table TableManifest) []FileManifest {
 		out = append(out, FileManifest{Path: file})
 	}
 	return out
+}
+
+func importFileManifests(table TableManifest) ([]FileManifest, error) {
+	if table.Rows < 0 {
+		return nil, fmt.Errorf("table %s: negative row count", table.Name)
+	}
+	entries := tableFileManifests(table)
+	modern := len(table.FileManifests) > 0
+	remainingRows := table.Rows
+	byPath := make(map[string]FileManifest, len(entries))
+	for _, file := range entries {
+		// Use the same lexical path identity as opening the shard.
+		key, err := confinedSnapshotFile(".", file.Path)
+		if err != nil {
+			return nil, fmt.Errorf("table %s: %w", table.Name, err)
+		}
+		if _, exists := byPath[key]; exists {
+			return nil, fmt.Errorf("table %s: duplicate file manifest path %q", table.Name, file.Path)
+		}
+		byPath[key] = file
+		if modern {
+			if file.Rows < 0 {
+				return nil, fmt.Errorf("table %s: negative row count for %q", table.Name, file.Path)
+			}
+			// Subtract from the declared total to avoid overflowing a sum of rows.
+			if file.Rows > remainingRows {
+				return nil, fmt.Errorf("table %s: row count does not match file manifests", table.Name)
+			}
+			remainingRows -= file.Rows
+		}
+	}
+	if !modern {
+		// Legacy table totals remain advisory, including positive values.
+		return entries, nil
+	}
+	if remainingRows != 0 {
+		return nil, fmt.Errorf("table %s: row count does not match file manifests", table.Name)
+	}
+	paths := table.Files
+	if table.File != "" {
+		key, err := confinedSnapshotFile(".", table.File)
+		if err != nil {
+			return nil, fmt.Errorf("table %s: %w", table.Name, err)
+		}
+		if len(paths) == 0 {
+			paths = []string{table.File}
+		} else if len(paths) != 1 {
+			return nil, fmt.Errorf("table %s: inconsistent file paths", table.Name)
+		} else if listedKey, err := confinedSnapshotFile(".", paths[0]); err != nil || listedKey != key {
+			return nil, fmt.Errorf("table %s: inconsistent file paths", table.Name)
+		}
+	}
+	if len(paths) == 0 {
+		paths = fileManifestPaths(table.FileManifests)
+	}
+	files := make([]FileManifest, 0, len(paths))
+	for _, path := range paths {
+		key, err := confinedSnapshotFile(".", path)
+		if err != nil {
+			return nil, fmt.Errorf("table %s: %w", table.Name, err)
+		}
+		file, ok := byPath[key]
+		if !ok {
+			return nil, fmt.Errorf("table %s: missing file manifest for %q", table.Name, path)
+		}
+		file.Path = path
+		files = append(files, file)
+		delete(byPath, key)
+	}
+	if len(byPath) != 0 {
+		return nil, fmt.Errorf("table %s: file manifests do not match file paths", table.Name)
+	}
+	return files, nil
+}
+
+func selectImportFiles(plan TableImportPlan) (TableManifest, error) {
+	table := plan.Table
+	files, err := importFileManifests(table)
+	if err != nil {
+		return TableManifest{}, err
+	}
+	modern := len(table.FileManifests) > 0
+	byPath := make(map[string]FileManifest, len(files))
+	for _, file := range files {
+		key, _ := confinedSnapshotFile(".", file.Path) // Validated above.
+		byPath[key] = file
+	}
+	for _, file := range plan.Files {
+		key, err := confinedSnapshotFile(".", file.Path)
+		if err != nil {
+			return TableManifest{}, fmt.Errorf("table %s: %w", table.Name, err)
+		}
+		expected, ok := byPath[key]
+		expected.Path = file.Path
+		if !ok || (modern && !sameFileManifest(file, expected)) {
+			return TableManifest{}, fmt.Errorf("table %s: inconsistent planned file manifest for %q", table.Name, file.Path)
+		}
+		delete(byPath, key)
+	}
+	if modern {
+		table.FileManifests = plan.Files
+	}
+	// Legacy plans synthesize zero-valued metadata; those rows are unknown.
+	table.File = ""
+	table.Files = fileManifestPaths(plan.Files)
+	table.Rows = fileManifestRows(plan.Files)
+	return table, nil
 }
 
 func allFilesHaveFingerprints(files []FileManifest) bool {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users importing a damaged snapshot could commit rows despite mismatched shard metadata. Full and incremental imports now reject corrupt compressed content and inconsistent modern metadata without retaining partial database changes.

## Why This Change Was Made

Verify supplied compressed SHA256 and nonzero size, decoded row counts before filtering, gzip EOF/checksum, and modern aggregate table totals. Incremental plans select work but cannot replace the current manifest's integrity metadata; duplicate active plans and undeclared or duplicate normalized paths are rejected.

This stays inside the shared snapshot importer. No public API, wire format, dependency, provider schema, mirror, release, symlink-resolution, or case-folding change. Legacy manifests without per-file metadata retain unknown per-file counts and advisory nonnegative table totals; negative totals are invalid.

## User Impact

Damaged imports fail with the affected shard identified, and transactional database changes roll back. Valid modern exports, filtered imports, and supported legacy snapshots continue working. Existing callbacks remain responsible for any non-transactional external side effects.

## Evidence

Candidate: `3148669e82de2dbf5b487ce7436024ae4983843b`, based on `5a7655645cc6b626738df2b6ed024c04314099ce`.

Completed on September 8, 2026, with `GOWORK=off GOMAXPROCS=2 GOFLAGS=-p=2`:

- `go mod tidy` and `git diff --exit-code -- go.mod go.sum`: pass, no module drift.
- `go vet ./...`: pass.
- `go test -count=1 ./...`: all 17 packages pass.
- `go test -race -count=1 ./snapshot`: pass.
- `gofmt` and `git diff --check`: pass.
- Final structured source review of the complete patch: no actionable findings. This supports, but does not replace, the executed API proof below.

Those earlier test gates used temporary SQLite fixtures with inherited HOME/XDG/cache; they were not offline isolated-HOME runs. The runtime proof below is a separate execution, not a relabeled unit test.

The committed regression suite additionally covers supplied-plan authority, modern aggregate omissions, negative counts, duplicate active plans, path aliases, truncated gzip, optional metadata, and callback rollback.

## Real Behavior Proof

**Claim and surface:** The actual `snapshot.Export`, `snapshot.Import`, and `snapshot.ImportIncremental` APIs reject corrupt later shards atomically, preserve valid imports, count decoded rows before filters, and accept legacy advisory totals.

**Fixture:** A standalone Go executable creates real temporary source and destination SQLite databases. It exports two rows into two gzip shards. The destination starts with an `old/unchanged` row, and `BeforeImport` inserts an audit row inside the import transaction. Each full, replacement, and merge run receives either valid data, bad SHA256, bad size, bad declared rows, a damaged gzip CRC, legacy metadata with advisory `Rows=99`, or a filter rejecting the second row.

**Command and environment:** Executed on Linux/amd64 with Go 1.27.1 against the candidate above. Build used the existing dependency cache with `GOPROXY=off GOSUMDB=off`; runtime HOME/XDG paths were temporary. Paths below use `$PROOF` instead of machine-specific locations. From the candidate checkout, place the complete driver below at `$PROOF/proof.go`, then run:

```sh
PROOF=$(mktemp -d)
# Write the driver shown below to "$PROOF/proof.go".
GOWORK=off GOMAXPROCS=2 GOFLAGS=-p=2 GOPROXY=off GOSUMDB=off \
  go build -o "$PROOF/proof" "$PROOF/proof.go"
HOME="$PROOF/home" XDG_CONFIG_HOME="$PROOF/config" \
  XDG_CACHE_HOME="$PROOF/cache" "$PROOF/proof"
```

**Observed result and trace:** Exit 0. All 21 scenarios passed. Every corruption was detected only after the first shard completed, while the final SQLite query showed the original row intact, no imported rows, and no callback audit row.

```text
full/valid: committed; old=0 new=2 audit=1
full/bad-hash: rejected; first_shard_completed=true; old=1 new=0 audit=0
full/bad-size: rejected; first_shard_completed=true; old=1 new=0 audit=0
full/bad-rows: rejected; first_shard_completed=true; old=1 new=0 audit=0
full/bad-crc: rejected; first_shard_completed=true; old=1 new=0 audit=0
full/legacy: committed; old=0 new=2 audit=1
full/filtered: committed; old=0 new=1 audit=1
replace/valid: committed; old=0 new=2 audit=1
replace/bad-hash: rejected; first_shard_completed=true; old=1 new=0 audit=0
replace/bad-size: rejected; first_shard_completed=true; old=1 new=0 audit=0
replace/bad-rows: rejected; first_shard_completed=true; old=1 new=0 audit=0
replace/bad-crc: rejected; first_shard_completed=true; old=1 new=0 audit=0
replace/legacy: committed; old=0 new=2 audit=1
replace/filtered: committed; old=0 new=1 audit=1
merge/valid: committed; old=1 new=2 audit=1
merge/bad-hash: rejected; first_shard_completed=true; old=1 new=0 audit=0
merge/bad-size: rejected; first_shard_completed=true; old=1 new=0 audit=0
merge/bad-rows: rejected; first_shard_completed=true; old=1 new=0 audit=0
merge/bad-crc: rejected; first_shard_completed=true; old=1 new=0 audit=0
merge/legacy: committed; old=1 new=2 audit=1
merge/filtered: committed; old=1 new=1 audit=1
PASS: 21 runtime scenarios; temporary SQLite databases only
```

**Limits:** Synthetic local data only; no live archives, provider APIs, release artifacts, Windows/macOS runtime, or newly published module tag were exercised. This driver proves the listed scenarios, not all possible manifest shapes. Legacy manifests without per-file integrity metadata cannot prove content identity. SQL rollback does not undo external side effects performed by caller callbacks.

<details>
<summary>Complete executed standalone driver</summary>

```go
package main

import (
	"context"
	"database/sql"
	"encoding/json"
	"fmt"
	"os"
	"path/filepath"
	"strings"

	"github.com/openclaw/crawlkit/snapshot"
	"github.com/openclaw/crawlkit/store"
)

func check(err error) {
	if err != nil {
		panic(err)
	}
}

func database(ctx context.Context, path string) *store.Store {
	s, err := store.Open(ctx, store.Options{Path: path})
	check(err)
	_, err = s.DB().ExecContext(ctx, `CREATE TABLE things (id TEXT PRIMARY KEY, body TEXT);
		CREATE TABLE audit (event TEXT);`)
	check(err)
	return s
}

func count(db *sql.DB, query string) int {
	var n int
	check(db.QueryRow(query).Scan(&n))
	return n
}

func run(mode, scenario string) {
	ctx := context.Background()
	root, err := os.MkdirTemp("", "snapshot-runtime-")
	check(err)
	defer os.RemoveAll(root)
	source := database(ctx, filepath.Join(root, "source.sqlite"))
	defer source.Close()
	_, err = source.DB().ExecContext(ctx, `INSERT INTO things VALUES ('one','first'),('two','second')`)
	check(err)
	pack := filepath.Join(root, "pack")
	manifest, err := snapshot.Export(ctx, snapshot.ExportOptions{
		DB: source.DB(), RootDir: pack, Tables: []string{"things"}, MaxShardBytes: 1,
	})
	check(err)
	if len(manifest.Tables[0].FileManifests) != 2 {
		panic("expected two exported shards")
	}
	table := &manifest.Tables[0]
	second := &table.FileManifests[1]
	expectedError := ""
	switch scenario {
	case "bad-hash":
		second.SHA256 = strings.Repeat("0", 64)
		expectedError = "compressed SHA256 mismatch"
	case "bad-size":
		second.Size++
		expectedError = "compressed size mismatch"
	case "bad-rows":
		second.Rows++
		table.Rows++
		expectedError = "row count mismatch"
	case "bad-crc":
		path := filepath.Join(pack, second.Path)
		data, err := os.ReadFile(path)
		check(err)
		data[len(data)-8] ^= 1
		check(os.WriteFile(path, data, 0600))
		expectedError = "invalid checksum"
	case "legacy":
		table.FileManifests = nil
		table.Rows = 99
	}
	data, err := json.Marshal(manifest)
	check(err)
	check(os.WriteFile(filepath.Join(pack, snapshot.ManifestName), data, 0600))
	target := database(ctx, filepath.Join(root, "target.sqlite"))
	defer target.Close()
	_, err = target.DB().ExecContext(ctx, `INSERT INTO things VALUES ('old','unchanged')`)
	check(err)
	before := func(ctx context.Context, tx *sql.Tx) error {
		_, err := tx.ExecContext(ctx, `INSERT INTO audit VALUES ('before')`)
		return err
	}
	firstShardDone := false
	progress := func(p snapshot.ImportProgress) {
		if p.Phase == "file_done" && p.FileIndex == 1 {
			firstShardDone = true
		}
	}
	filter := func(_ string, row map[string]any) (bool, error) {
		return scenario != "filtered" || row["id"] != "two", nil
	}
	if mode == "full" {
		_, err = snapshot.Import(ctx, snapshot.ImportOptions{
			DB: target.DB(), RootDir: pack, DeleteTables: []string{"things"},
			BeforeImport: before, Progress: progress, Filter: filter,
		})
	} else {
		plan := snapshot.TableImportPlan{Table: *table, Mode: snapshot.TableImportReplace}
		if mode == "merge" {
			plan.Mode = snapshot.TableImportFiles
			plan.Files = table.FileManifests
			if scenario == "legacy" {
				for _, path := range table.Files {
					plan.Files = append(plan.Files, snapshot.FileManifest{Path: path})
				}
			}
		}
		_, _, err = snapshot.ImportIncremental(ctx, snapshot.IncrementalImportOptions{
			DB: target.DB(), RootDir: pack, Current: manifest,
			Plan: snapshot.ImportPlan{Tables: []snapshot.TableImportPlan{plan}},
			BeforeImport: before, Progress: progress, Filter: filter,
		})
	}
	old := count(target.DB(), `SELECT count(*) FROM things WHERE id='old' AND body='unchanged'`)
	newRows := count(target.DB(), `SELECT count(*) FROM things WHERE id!='old'`)
	audit := count(target.DB(), `SELECT count(*) FROM audit`)
	if expectedError != "" {
		if err == nil || !strings.Contains(err.Error(), expectedError) ||
			!firstShardDone || old != 1 || newRows != 0 || audit != 0 {
			panic(fmt.Sprintf("%s/%s: err=%v first=%t old=%d new=%d audit=%d",
				mode, scenario, err, firstShardDone, old, newRows, audit))
		}
		fmt.Printf("%s/%s: rejected; first_shard_completed=true; old=1 new=0 audit=0\n", mode, scenario)
		return
	}
	check(err)
	wantOld, wantNew := 0, 2
	if mode == "merge" {
		wantOld = 1
	}
	if scenario == "filtered" {
		wantNew = 1
	}
	if old != wantOld || newRows != wantNew || audit != 1 {
		panic(fmt.Sprintf("%s/%s: old=%d new=%d audit=%d", mode, scenario, old, newRows, audit))
	}
	fmt.Printf("%s/%s: committed; old=%d new=%d audit=1\n", mode, scenario, old, newRows)
}

func main() {
	for _, mode := range []string{"full", "replace", "merge"} {
		for _, scenario := range []string{"valid", "bad-hash", "bad-size", "bad-rows", "bad-crc", "legacy", "filtered"} {
			run(mode, scenario)
		}
	}
	fmt.Println("PASS: 21 runtime scenarios; temporary SQLite databases only")
}
```

</details>

## Review Disposition

Pre-publication review corrections are included: current-manifest authority, legacy path membership, negative legacy totals, duplicate active plans, and lexical path aliases. The final source review reported no actionable findings.

**Maintainer coordination confirmation, September 8, 2026:** The coordinator independently verified all four candidate revisions and their substantive code, behavior-proof, security, and CI preconditions. The coordination hold identified in [ClawSweeper's review](https://github.com/openclaw/crawlkit/pull/110#issuecomment-5586225565) is satisfied. No code or proof decision remains outstanding.

- Crawlkit `3148669e82de2dbf5b487ce7436024ae4983843b`: hosted review found no correctness/security issues and accepted the 21-scenario runtime proof. [Linux/Windows CI, including race tests](https://github.com/openclaw/crawlkit/actions/runs/34234107592), [CodeQL](https://github.com/openclaw/crawlkit/actions/runs/34234107455), and [secret scanning](https://github.com/openclaw/crawlkit/actions/runs/34234107544) passed.
- Gitcrawl `389fda9fa34cbfd3cec0e0c38bec1a5d84a947f4`: [hosted review](https://github.com/openclaw/gitcrawl/pull/174#issuecomment-5586247444) is ready with no before-merge items; [Linux/macOS CI](https://github.com/openclaw/gitcrawl/actions/runs/34234194672), Docker, CodeQL, and secret-scanning checks passed.
- Discrawl `37e17383730786ec9fda0f749bde6a37b55b5109`: [hosted review](https://github.com/openclaw/discrawl/pull/200#issuecomment-5586269910) found no correctness/security issues; [CI](https://github.com/openclaw/discrawl/actions/runs/34234335549), Docker, CodeQL, and secret-scanning checks passed. The maintainer accepted strict malformed-vector rejection and the documented recovery behavior under the original fix-and-merge authorization.
- Companion validation was independently verified: its full local ClawSweeper review found no correctness/security issues, accepted its behavior proof, and both CI checks passed. Private identifiers and evidence are intentionally not published here.

This confirmation resolves the prior coordination checklist item. It does not claim a release, published dependency upgrade, or live-store rollout. No source changes were made for this disposition; the candidate and complete runtime proof above are unchanged.

The branch belongs to `openclaw/crawlkit`, so repository maintainers can edit it directly. GitHub's separate fork-collaboration switch is not applicable to this same-repository PR.
