### PR TITLE
fix: preserve archive integrity and prepare v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Require secure, same-origin credential transport for remote redirects and
   provider-less token login and polling, preserving loopback development.
+- Redact URL userinfo from Git command failures without changing successful
+  archive output.
 - Preserve sidecars when a configured source root is a symlink, and reject
   invalid source roots before creating the destination.
 - Publish newly generated backup identities without overwriting a concurrent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.14.10 - Unreleased
 
+- Stage snapshot exports in immutable generations and publish the manifest
+  last, preserving prior packs on failure and logical incremental shard IDs.
+  Read tables in one transaction, with additive caller-owned `ReadTx` and
+  transaction-aware `FilterTx` options.
 - Publish encrypted backup rotations with unique immutable shard and index
   paths under a held writer lock. Preserve the prior pack on failure, restrict
   cleanup to its manifest-owned paths, and report post-commit cleanup errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.14.10 - Unreleased
 
+- Require secure, same-origin credential transport for remote redirects and
+  provider-less token login and polling, preserving loopback development.
 - Preserve sidecars when a configured source root is a symlink, and reject
   invalid source roots before creating the destination.
 - Publish newly generated backup identities without overwriting a concurrent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.14.10 - Unreleased
 
+- Verify compressed shard hashes, sizes, and decoded row counts before committing full or incremental snapshot imports; bind supplied plans to current manifest metadata, reject inconsistent file paths and modern table row totals, and roll back corrupt imports. Preserve legacy manifests without per-file metadata; their nonnegative table row totals remain advisory, including positive values.
+
 ## v0.14.9 - 2026-09-05
 
 **Highlights:** Safer snapshot shard paths and recovery from interrupted scheduler-history writes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.14.10 - Unreleased
 
+- Hold a persistent OS lock for the complete scheduler run; repeated cleanup
+  cannot remove another owner's lock. Legacy PID locks require stopped-runner
+  migration; mixed old/new runners are not supported.
 - Require secure, same-origin credential transport for remote redirects and
   provider-less token login and polling, preserving loopback development.
 - Redact URL userinfo from Git command failures without changing successful

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.14.10 - Unreleased
 
+- Publish newly generated backup identities without overwriting a concurrent
+  creator's key.
 - Preserve unpublished local commits when `PullCurrent` receives an explicit
   remote, and reject divergent history instead of resetting it.
 - Honor requested TOML permissions on existing files before writing replacement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.14.10 - Unreleased
 
+- Preserve exact signed integers on snapshot import while retaining ordinary
+  numeric callback types. Refuse unsafe v1 integers, BLOBs, invalid text and
+  unrepresentable numbers before export promotion instead of silently losing data.
 - Stage snapshot exports in immutable generations and publish the manifest
   last, preserving prior packs on failure and logical incremental shard IDs.
   Read tables in one transaction, with additive caller-owned `ReadTx` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.14.10 - Unreleased
 
+- Reject unsupported cascading foreign keys and triggers before generic
+  incremental snapshot mutation, preserving skipped and destination-only rows.
+  Dependency-aware custom importer callbacks retain their existing contract.
 - Preserve exact signed integers on snapshot import while retaining ordinary
   numeric callback types. Refuse unsafe v1 integers, BLOBs, invalid text and
   unrepresentable numbers before export promotion instead of silently losing data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.14.10 - Unreleased
 
+- Reject newer SQLite schema versions before applying caller schema, release
+  transactions when callbacks panic, and isolate unnamed in-memory stores while
+  retaining explicitly named shared databases.
+
 ## v0.14.9 - 2026-09-05
 
 **Highlights:** Safer snapshot shard paths and recovery from interrupted scheduler-history writes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   provider-less token login and polling, preserving loopback development.
 - Redact URL userinfo from Git command failures without changing successful
   archive output.
+- Stage SQLite captures before replacement, remove stale destination sidecars,
+  and preserve the previous bundle when capture or promotion fails.
 - Preserve sidecars when a configured source root is a symlink, and reject
   invalid source roots before creating the destination.
 - Publish newly generated backup identities without overwriting a concurrent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.14.10 - Unreleased
 
+- Preserve unpublished local commits when `PullCurrent` receives an explicit
+  remote, and reject divergent history instead of resetting it.
 - Honor requested TOML permissions on existing files before writing replacement
   content, including the private default.
 - Include Grain, iMessage, Photos, and WeChat in default metadata discovery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.14.10 - Unreleased
 
+- Publish encrypted backup rotations with unique immutable shard and index
+  paths under a held writer lock. Preserve the prior pack on failure, restrict
+  cleanup to its manifest-owned paths, and report post-commit cleanup errors
+  together with the committed manifest.
 - Hold a persistent OS lock for the complete scheduler run; repeated cleanup
   cannot remove another owner's lock. Legacy PID locks require stopped-runner
   migration; mixed old/new runners are not supported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.14.10 - Unreleased
 
+- Honor requested TOML permissions on existing files before writing replacement
+  content, including the private default.
 - Include Grain, iMessage, Photos, and WeChat in default metadata discovery
   without automatically scheduling source-specific imports.
 - Reject newer SQLite schema versions before applying caller schema, release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.14.10 - Unreleased
 
+- Preserve sidecars when a configured source root is a symlink, and reject
+  invalid source roots before creating the destination.
 - Publish newly generated backup identities without overwriting a concurrent
   creator's key.
 - Preserve unpublished local commits when `PullCurrent` receives an explicit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.14.10 - Unreleased
+## v0.15.0 - 2026-09-08
 
 - Reject unsupported cascading foreign keys and triggers before generic
   incremental snapshot mutation, preserving skipped and destination-only rows.
@@ -19,13 +19,16 @@
   together with the committed manifest.
 - Hold a persistent OS lock for the complete scheduler run; repeated cleanup
   cannot remove another owner's lock. Legacy PID locks require stopped-runner
-  migration; mixed old/new runners are not supported.
+  migration; stop all older runners before upgrading. Mixed old/new runners
+  are not supported.
 - Require secure, same-origin credential transport for remote redirects and
   provider-less token login and polling, preserving loopback development.
 - Redact URL userinfo from Git command failures without changing successful
   archive output.
 - Stage SQLite captures before replacement, remove stale destination sidecars,
-  and preserve the previous bundle when capture or promotion fails.
+  and preserve the previous bundle when capture or promotion fails. Raw file
+  copies require a quiescent source or an app-owned coherent snapshot; staging
+  does not make copies from a live writer transactionally consistent.
 - Preserve sidecars when a configured source root is a symlink, and reject
   invalid source roots before creating the destination.
 - Publish newly generated backup identities without overwriting a concurrent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.14.10 - Unreleased
 
+- Include Grain, iMessage, Photos, and WeChat in default metadata discovery
+  without automatically scheduling source-specific imports.
 - Reject newer SQLite schema versions before applying caller schema, release
   transactions when callbacks panic, and isolate unnamed in-memory stores while
   retaining explicitly named shared databases.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,17 @@ See the [package guide](docs/packages.md) for the complete inventory and [Go pac
 
 ## crawlctl
 
-`crawlctl` discovers installed crawl apps through their machine-readable metadata, runs configured refresh jobs under a single-process lock, and records JSONL run history.
+`crawlctl` discovers installed crawl apps through their machine-readable metadata, runs configured refresh jobs under a held OS lock, and records JSONL run history.
+
+The lock file is persistent: do not remove or replace it to unlock the runner.
+Closing the owning handle or exiting releases the lock. Keep its directory
+private; on Windows, file access follows the directory's ACLs. Unsupported OS
+locking fails closed.
+
+Stop all old runners before upgrading from PID-file locking. Legacy or ambiguous
+lock contents require an explicit stopped-runner migration: verify all old
+runners are stopped, archive that legacy file once, then start the new runner.
+There is no mixed old/new runner safety or automatic stale-PID reclamation.
 
 Default discovery checks `gitcrawl`, `discrawl`, `notcrawl`, `wacrawl`,
 `telecrawl`, `slacrawl`, `graincrawl`, `imsgcrawl`, `photoscrawl`, and `weicrawl`.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ See the [package guide](docs/packages.md) for the complete inventory and [Go pac
 
 `crawlctl` discovers installed crawl apps through their machine-readable metadata, runs configured refresh jobs under a single-process lock, and records JSONL run history.
 
+Default discovery checks `gitcrawl`, `discrawl`, `notcrawl`, `wacrawl`,
+`telecrawl`, `slacrawl`, `graincrawl`, `imsgcrawl`, `photoscrawl`, and `weicrawl`.
+Use `--app` to select binaries explicitly. Discovery does not automatically
+schedule source-specific commands such as Photos' `import_apple`.
+
 If a write is interrupted, history reads ignore a truncated final JSON value and the next run repairs that tail before appending. Valid final records without a trailing newline are retained; complete corrupt records still report an error.
 
 | Command | Purpose |

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -4,7 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -14,6 +17,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crawlkit/internal/filelock"
 )
 
 const FormatVersion = 1
@@ -63,7 +68,10 @@ func WriteSnapshot(ctx context.Context, cfg Config, shards []Shard, old Manifest
 	return WriteSnapshotWithFiles(ctx, cfg, shards, nil, old)
 }
 
-func WriteSnapshotWithFiles(ctx context.Context, cfg Config, shards []Shard, files []File, old Manifest) (Manifest, error) {
+// WriteSnapshotWithFiles publishes immutable objects followed by the manifest.
+// Writers for the same root are excluded by a persistent OS lock. After the
+// manifest commits, a cleanup error returns the populated committed manifest.
+func WriteSnapshotWithFiles(ctx context.Context, cfg Config, shards []Shard, files []File, old Manifest) (result Manifest, resultErr error) {
 	if err := ctx.Err(); err != nil {
 		return Manifest{}, err
 	}
@@ -76,6 +84,40 @@ func WriteSnapshotWithFiles(ctx context.Context, cfg Config, shards []Shard, fil
 			return Manifest{}, fmt.Errorf("backup shard uses reserved file index namespace: %s", shard.Path)
 		}
 	}
+	if err := os.MkdirAll(cfg.Repo, 0o700); err != nil {
+		return Manifest{}, err
+	}
+	lock, err := filelock.Acquire(filepath.Join(cfg.Repo, ".crawlkit-backup.lock"))
+	if err != nil {
+		return Manifest{}, fmt.Errorf("lock backup writer: %w", err)
+	}
+	defer lock.Close()
+	current, err := ReadManifest(cfg.Repo)
+	currentExists := err == nil
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return Manifest{}, err
+	}
+	var created []string
+	recordCreated := func(rel string) { created = append(created, rel) }
+	recordShard := func(entry ShardEntry) {
+		if _, reused := old.Entry(entry.Path); !reused {
+			recordCreated(entry.Path)
+		}
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			for _, rel := range created {
+				target, err := ResolveShardPath(cfg.Repo, rel)
+				if err == nil {
+					err = os.Remove(target)
+				}
+				if err != nil && !errors.Is(err, os.ErrNotExist) {
+					resultErr = errors.Join(resultErr, fmt.Errorf("remove unpublished backup object: %w", err))
+				}
+			}
+		}
+	}()
 	recipients := normalizedStrings(cfg.Recipients)
 	reuseEncrypted := sameStrings(old.Recipients, recipients)
 	manifest := Manifest{
@@ -100,6 +142,7 @@ func WriteSnapshotWithFiles(ctx context.Context, cfg Config, shards []Shard, fil
 		if err != nil {
 			return Manifest{}, err
 		}
+		recordShard(entry)
 		if err := ctx.Err(); err != nil {
 			return Manifest{}, err
 		}
@@ -110,7 +153,7 @@ func WriteSnapshotWithFiles(ctx context.Context, cfg Config, shards []Shard, fil
 		manifest.Counts[countKey] += rows
 		manifest.Shards = append(manifest.Shards, entry)
 	}
-	filesManifest, fileIndex, err := writeFiles(ctx, cfg, old, files, reuseEncrypted)
+	filesManifest, fileIndex, err := writeFiles(ctx, cfg, old, files, reuseEncrypted, recordCreated)
 	if err != nil {
 		return Manifest{}, err
 	}
@@ -124,11 +167,12 @@ func WriteSnapshotWithFiles(ctx context.Context, cfg Config, shards []Shard, fil
 		if err != nil {
 			return Manifest{}, err
 		}
+		recordShard(entry)
 		manifest.Shards = append(manifest.Shards, entry)
 	}
 	sort.Slice(manifest.Shards, func(i, j int) bool { return manifest.Shards[i].Path < manifest.Shards[j].Path })
-	if EquivalentManifest(old, manifest) {
-		return old, nil
+	if currentExists && EquivalentManifest(current, manifest) {
+		return current, nil
 	}
 	if err := ctx.Err(); err != nil {
 		return Manifest{}, err
@@ -136,11 +180,9 @@ func WriteSnapshotWithFiles(ctx context.Context, cfg Config, shards []Shard, fil
 	if err := writeManifest(ctx, cfg.Repo, manifest); err != nil {
 		return Manifest{}, err
 	}
-	if err := ctx.Err(); err != nil {
-		return Manifest{}, err
-	}
-	if err := removeStaleBackupFiles(ctx, cfg.Repo, manifest.Shards, manifest.Files, true); err != nil {
-		return Manifest{}, err
+	committed = true
+	if err := removePreviousBackupFiles(ctx, cfg.Repo, current, manifest); err != nil {
+		return manifest, fmt.Errorf("backup manifest committed; cleanup failed: %w", err)
 	}
 	return manifest, nil
 }
@@ -181,24 +223,29 @@ func writeShard(ctx context.Context, cfg Config, old Manifest, table, rel string
 		return ShardEntry{}, err
 	}
 	hash := SHA256Hex(plaintext)
-	targetRel := rel
-	oldEntry, hasOldEntry := old.logicalEntry(table, rel)
-	if hasOldEntry {
-		if oldEntry.SHA256 != hash || !reuseEncrypted {
-			targetRel = versionedShardPath(rel, hash)
-		} else {
-			targetRel = oldEntry.Path
-		}
-	}
-	target, err := ResolveShardPath(cfg.Repo, targetRel)
+	rel, err := cleanShardPath(rel)
 	if err != nil {
 		return ShardEntry{}, err
 	}
-	if reuseEncrypted && hasOldEntry && oldEntry.Path == targetRel && oldEntry.SHA256 == hash {
-		if info, err := os.Stat(target); err == nil {
+	oldEntry, hasOldEntry := old.logicalEntry(table, rel)
+	if reuseEncrypted && hasOldEntry && oldEntry.SHA256 == hash {
+		target, err := ResolveShardPath(cfg.Repo, oldEntry.Path)
+		if err != nil {
+			return ShardEntry{}, err
+		}
+		if info, err := os.Stat(target); err == nil && info.Mode().IsRegular() {
 			oldEntry.Bytes = info.Size()
 			return oldEntry, nil
 		}
+	}
+	var generation [16]byte
+	if _, err := rand.Read(generation[:]); err != nil {
+		return ShardEntry{}, err
+	}
+	targetRel := strings.TrimSuffix(versionedShardPath(rel, hash), ".age") + "-" + hex.EncodeToString(generation[:]) + ".age"
+	target, err := ResolveShardPath(cfg.Repo, targetRel)
+	if err != nil {
+		return ShardEntry{}, err
 	}
 	if err := ctx.Err(); err != nil {
 		return ShardEntry{}, err
@@ -213,7 +260,7 @@ func writeShard(ctx context.Context, cfg Config, old Manifest, table, rel string
 	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
 		return ShardEntry{}, err
 	}
-	if err := writeFileAtomicContext(ctx, target, encrypted, 0o600); err != nil {
+	if err := writeNewShard(ctx, target, encrypted); err != nil {
 		return ShardEntry{}, err
 	}
 	return ShardEntry{Table: table, Path: targetRel, Rows: rows, SHA256: hash, Bytes: int64(len(encrypted))}, nil
@@ -224,7 +271,12 @@ func (m Manifest) logicalEntry(table, rel string) (ShardEntry, bool) {
 		return entry, true
 	}
 	for _, entry := range m.Shards {
-		if entry.Table == table && entry.Path == versionedShardPath(rel, entry.SHA256) {
+		legacy := versionedShardPath(rel, entry.SHA256)
+		suffix, generated := strings.CutPrefix(entry.Path, strings.TrimSuffix(legacy, ".age")+"-")
+		generation := strings.TrimSuffix(suffix, ".age")
+		_, hexErr := hex.DecodeString(generation)
+		if entry.Table == table && (entry.Path == legacy ||
+			(generated && strings.HasSuffix(suffix, ".age") && len(generation) == 32 && hexErr == nil && strings.ToLower(generation) == generation)) {
 			return entry, true
 		}
 	}
@@ -237,6 +289,37 @@ func versionedShardPath(rel, hash string) string {
 		hash = hash[:12]
 	}
 	return prefix + "-" + hash + ".age"
+}
+
+func writeNewShard(ctx context.Context, target string, data []byte) error {
+	file, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	complete := false
+	defer func() {
+		_ = file.Close()
+		if !complete {
+			_ = os.Remove(target)
+		}
+	}()
+	if _, err := file.Write(data); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := syncDir(filepath.Dir(target)); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	complete = true
+	return nil
 }
 
 func DecryptShardFile(cfg Config, shard ShardEntry) ([]byte, error) {
@@ -446,6 +529,50 @@ func EquivalentManifest(a, b Manifest) bool {
 
 func RemoveStaleShards(repo string, shards []ShardEntry) error {
 	return removeStaleShards(context.Background(), repo, shards)
+}
+
+func removePreviousBackupFiles(ctx context.Context, repo string, previous, current Manifest) error {
+	paths := func(manifest Manifest) (map[string]bool, error) {
+		out := make(map[string]bool, len(manifest.Shards)+len(manifest.Files))
+		for _, shard := range manifest.Shards {
+			target, err := ResolveShardPath(repo, shard.Path)
+			if err != nil {
+				return nil, err
+			}
+			out[target] = true
+		}
+		for _, file := range manifest.Files {
+			target, err := ResolveShardPath(repo, file.Shard)
+			if err != nil {
+				return nil, err
+			}
+			out[target] = true
+		}
+		return out, nil
+	}
+	keep, err := paths(current)
+	if err != nil {
+		return err
+	}
+	prior, err := paths(previous)
+	if err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	for target := range prior {
+		if keep[target] {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := os.Remove(target); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return nil
 }
 
 func removeStaleShards(ctx context.Context, repo string, shards []ShardEntry) error {

--- a/backup/crypto.go
+++ b/backup/crypto.go
@@ -36,7 +36,29 @@ func EnsureIdentity(path string) (string, error) {
 		return "", err
 	}
 	data := []byte(identity.String() + "\n")
-	if err := os.WriteFile(path, data, 0o600); err != nil {
+	file, err := os.CreateTemp(filepath.Dir(path), ".identity-")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+	if _, err := file.Write(data); err != nil {
+		return "", err
+	}
+	if err := file.Sync(); err != nil {
+		return "", err
+	}
+	if err := file.Close(); err != nil {
+		return "", err
+	}
+	// Publish a complete key without replacing a concurrent creator's identity.
+	if err := os.Link(file.Name(), path); err != nil {
+		if os.IsExist(err) {
+			return RecipientFromIdentity(path)
+		}
+		return "", err
+	}
+	if err := syncDir(filepath.Dir(path)); err != nil {
 		return "", err
 	}
 	return identity.Recipient().String(), nil

--- a/backup/files.go
+++ b/backup/files.go
@@ -105,7 +105,7 @@ func CollectFiles(ctx context.Context, root, prefix string) ([]File, error) {
 	return files, nil
 }
 
-func writeFiles(ctx context.Context, cfg Config, old Manifest, files []File, reuseEncrypted bool) ([]FileEntry, []fileIndexRecord, error) {
+func writeFiles(ctx context.Context, cfg Config, old Manifest, files []File, reuseEncrypted bool, recordCreated func(string)) ([]FileEntry, []fileIndexRecord, error) {
 	ordered := append([]File(nil), files...)
 	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Path < ordered[j].Path })
 	oldByHash := make(map[string]indexedFile, len(old.Files))
@@ -181,6 +181,7 @@ func writeFiles(ctx context.Context, cfg Config, old Manifest, files []File, reu
 			return nil, nil, err
 		}
 		keepTemp = false
+		recordCreated(shard)
 		if err := syncDir(filepath.Dir(target)); err != nil {
 			return nil, nil, err
 		}

--- a/backup/identity_test.go
+++ b/backup/identity_test.go
@@ -1,0 +1,68 @@
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestEnsureIdentityConcurrentCreatorsAgree(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "keys", "identity.age")
+	const count = 16
+	start := make(chan struct{})
+	results := make([]string, count)
+	errs := make([]error, count)
+	var workers sync.WaitGroup
+	for i := range count {
+		workers.Go(func() {
+			<-start
+			results[i], errs[i] = EnsureIdentity(path)
+		})
+	}
+	close(start)
+	workers.Wait()
+	want, err := RecipientFromIdentity(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range count {
+		if errs[i] != nil || results[i] != want {
+			t.Errorf("creator %d: recipient=%q error=%v, want surviving %q", i, results[i], errs[i], want)
+		}
+	}
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("identity staging files leaked: %v, %v", entries, err)
+	}
+}
+
+func TestEnsureIdentityPreservesExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "identity.age")
+	first, err := EnsureIdentity(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := EnsureIdentity(path)
+	if err != nil || second != first {
+		t.Fatalf("existing identity = %q, %v", second, err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil || string(after) != string(before) {
+		t.Fatal("existing identity changed")
+	}
+	if err := os.WriteFile(path, []byte("invalid existing identity"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := EnsureIdentity(path); err == nil {
+		t.Fatal("invalid identity accepted")
+	}
+	after, err = os.ReadFile(path)
+	if err != nil || string(after) != "invalid existing identity" {
+		t.Fatalf("invalid identity was replaced: %q, %v", after, err)
+	}
+}

--- a/backup/publication_test.go
+++ b/backup/publication_test.go
@@ -1,0 +1,247 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/crawlkit/internal/filelock"
+)
+
+func publicationConfig(t *testing.T) Config {
+	t.Helper()
+	dir := t.TempDir()
+	identity := filepath.Join(dir, "age.key")
+	recipient, err := EnsureIdentity(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return Config{Repo: filepath.Join(dir, "repo"), Identity: identity, Recipients: []string{recipient}}
+}
+
+func rotatedConfig(t *testing.T, cfg Config) Config {
+	t.Helper()
+	next := publicationConfig(t)
+	next.Repo = cfg.Repo
+	return next
+}
+
+func publishedFiles(t *testing.T, repo string) map[string][]byte {
+	t.Helper()
+	files := map[string][]byte{}
+	err := filepath.WalkDir(repo, func(path string, entry os.DirEntry, err error) error {
+		if err != nil || entry.IsDir() || strings.HasSuffix(path, ".lock") {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err == nil {
+			rel, relErr := filepath.Rel(repo, path)
+			if relErr != nil {
+				return relErr
+			}
+			files[rel] = data
+		}
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return files
+}
+
+func TestSnapshotRotationFailurePreservesPublishedCiphertext(t *testing.T) {
+	cfg := publicationConfig(t)
+	shards := []Shard{{Table: "messages", Path: "data/messages/01.jsonl.gz.age", Rows: []row{{ID: "1", Body: "first"}}}}
+	first, err := WriteSnapshot(context.Background(), cfg, shards, Manifest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	shards[0].Rows = []row{{ID: "1", Body: "changed"}}
+	current, err := WriteSnapshot(context.Background(), cfg, shards, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := publishedFiles(t, cfg.Repo)
+	next := rotatedConfig(t, cfg)
+	failing := append(append([]Shard(nil), shards...), Shard{Table: "later", Path: "data/later.age", Rows: make(chan int)})
+	if _, err := WriteSnapshot(context.Background(), next, failing, current); err == nil {
+		t.Fatal("expected later encoding failure")
+	}
+	if !reflect.DeepEqual(before, publishedFiles(t, cfg.Repo)) {
+		t.Error("failed rotation changed published bytes or leaked unpublished objects")
+	}
+	if _, err := ReadSnapshot(cfg, current); err != nil {
+		t.Fatalf("old recipient cannot read current pack after failure: %v", err)
+	}
+	rotated, err := WriteSnapshot(context.Background(), next, shards, current)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rotated.Shards[0].Path == current.Shards[0].Path {
+		t.Fatal("successful rotation reused physical ciphertext path")
+	}
+	if _, err := ReadSnapshot(next, rotated); err != nil {
+		t.Fatalf("new recipient cannot read successful rotation: %v", err)
+	}
+	unchanged, err := WriteSnapshot(context.Background(), next, shards, rotated)
+	if err != nil || !EquivalentManifest(rotated, unchanged) || !unchanged.Exported.Equal(rotated.Exported) {
+		t.Fatalf("unchanged generation was rewritten: %+v, %v", unchanged, err)
+	}
+}
+
+func TestSnapshotIndexRotationManifestFailurePreservesPublishedIndex(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires Unix directory permissions")
+	}
+	cfg := publicationConfig(t)
+	source := filepath.Join(t.TempDir(), "media.bin")
+	if err := os.WriteFile(source, []byte("first"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	files := []File{{Path: "media/item.bin", Source: source}}
+	first, err := WriteSnapshotWithFiles(context.Background(), cfg, nil, files, Manifest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, []byte("changed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	current, err := WriteSnapshotWithFiles(context.Background(), cfg, nil, files, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := publishedFiles(t, cfg.Repo)
+	if err := os.Chmod(cfg.Repo, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chmod(cfg.Repo, 0o700)
+	if _, err := WriteSnapshotWithFiles(context.Background(), rotatedConfig(t, cfg), nil, files, current); err == nil {
+		t.Fatal("expected manifest promotion failure")
+	}
+	if !reflect.DeepEqual(before, publishedFiles(t, cfg.Repo)) {
+		t.Error("failed rotation changed published bytes or leaked unpublished objects")
+	}
+	if _, err := RestoreFiles(context.Background(), cfg, current, t.TempDir()); err != nil {
+		t.Fatalf("old recipient cannot restore prior files: %v", err)
+	}
+}
+
+func TestSnapshotCleanupOnlyRemovesPriorManifestPaths(t *testing.T) {
+	cfg := publicationConfig(t)
+	shards := []Shard{{Table: "messages", Path: "data/messages.age", Rows: []row{{ID: "1"}}}}
+	first, err := WriteSnapshot(context.Background(), cfg, shards, Manifest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	unowned := filepath.Join(cfg.Repo, "data", "unowned.age")
+	if err := os.WriteFile(unowned, []byte("unowned"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	shards[0].Rows = []row{{ID: "2"}}
+	if _, err := WriteSnapshot(context.Background(), cfg, shards, first); err != nil {
+		t.Fatal(err)
+	}
+	if data, err := os.ReadFile(unowned); err != nil || string(data) != "unowned" {
+		t.Fatalf("cleanup removed unowned data: %q, %v", data, err)
+	}
+	if _, err := os.Stat(filepath.Join(cfg.Repo, first.Shards[0].Path)); !os.IsNotExist(err) {
+		t.Fatalf("obsolete owned ciphertext was not removed: %v", err)
+	}
+}
+
+func TestSnapshotCleanupFailureReturnsCommittedManifest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires Unix directory permissions")
+	}
+	cfg := publicationConfig(t)
+	first, err := WriteSnapshot(context.Background(), cfg, []Shard{
+		{Table: "old", Path: "data/old/items.age", Rows: []row{{ID: "1"}}},
+	}, Manifest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldDir := filepath.Join(cfg.Repo, "data", "old")
+	if err := os.Chmod(oldDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chmod(oldDir, 0o700)
+	result, err := WriteSnapshot(context.Background(), cfg, []Shard{
+		{Table: "new", Path: "data/new/items.age", Rows: []row{{ID: "2"}}},
+	}, first)
+	if err == nil || !strings.Contains(err.Error(), "committed") || !strings.Contains(err.Error(), "cleanup") {
+		t.Fatalf("missing explicit post-commit cleanup outcome: %v", err)
+	}
+	actual, readErr := ReadManifest(cfg.Repo)
+	if readErr != nil || result.Format != FormatVersion || !EquivalentManifest(result, actual) {
+		t.Fatalf("missing committed manifest: result=%+v actual=%+v err=%v", result, actual, readErr)
+	}
+	if _, err := ReadSnapshot(cfg, result); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSnapshotWriterHonorsHeldOSLock(t *testing.T) {
+	cfg := publicationConfig(t)
+	if err := os.MkdirAll(cfg.Repo, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	lock, err := filelock.Acquire(filepath.Join(cfg.Repo, ".crawlkit-backup.lock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.Close()
+	if _, err := WriteSnapshot(context.Background(), cfg, nil, Manifest{}); err == nil {
+		t.Fatal("writer ignored held lock with empty metadata")
+	}
+	if _, err := os.Stat(filepath.Join(cfg.Repo, "manifest.json")); !os.IsNotExist(err) {
+		t.Fatalf("contending writer touched manifest: %v", err)
+	}
+	if err := lock.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WriteSnapshot(context.Background(), cfg, nil, Manifest{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLogicalEntryAcceptsLegacyAndGeneratedPaths(t *testing.T) {
+	rel := "data/messages/01.jsonl.gz.age"
+	hash := SHA256Hex([]byte("fixture"))
+	legacy := versionedShardPath(rel, hash)
+	generated := strings.TrimSuffix(legacy, ".age") + "-" + strings.Repeat("a", 32) + ".age"
+	for _, physical := range []string{rel, legacy, generated} {
+		entry := ShardEntry{Table: "messages", Path: physical, SHA256: hash}
+		manifest := Manifest{Shards: []ShardEntry{entry}}
+		if got, ok := manifest.logicalEntry("messages", rel); !ok || got != entry {
+			t.Fatalf("logical lookup failed for %q", physical)
+		}
+		if _, ok := manifest.logicalEntry("messages", "data/messages/02.jsonl.gz.age"); ok {
+			t.Fatalf("different logical shard matched %q", physical)
+		}
+	}
+	for _, suffix := range []string{strings.Repeat("A", 32), strings.Repeat("g", 32), "a", strings.Repeat("a", 32) + "/other"} {
+		manifest := Manifest{Shards: []ShardEntry{{Table: "messages", Path: strings.TrimSuffix(legacy, ".age") + "-" + suffix + ".age", SHA256: hash}}}
+		if _, ok := manifest.logicalEntry("messages", rel); ok {
+			t.Fatalf("invalid generated suffix accepted: %q", suffix)
+		}
+	}
+}
+
+func TestWriteNewShardDoesNotClobberExistingPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "existing.age")
+	before := []byte("published ciphertext")
+	if err := os.WriteFile(path, before, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeNewShard(context.Background(), path, []byte("replacement")); err == nil {
+		t.Fatal("existing path accepted")
+	}
+	if after, err := os.ReadFile(path); err != nil || !bytes.Equal(before, after) {
+		t.Fatalf("existing ciphertext changed: %q, %v", after, err)
+	}
+}

--- a/cache/sqlite.go
+++ b/cache/sqlite.go
@@ -26,7 +26,8 @@ type SQLiteSnapshot struct {
 
 // SnapshotSQLite copies a SQLite database and its optional WAL/SHM sidecars.
 // The caller owns DestinationDir and decides whether snapshots are temporary
-// or retained.
+// or retained. The caller must exclude concurrent destination readers/writers
+// during replacement; publishing three fixed filenames is not atomic.
 func SnapshotSQLite(opts SQLiteSnapshotOptions) (SQLiteSnapshot, error) {
 	source := strings.TrimSpace(opts.SourcePath)
 	if source == "" {
@@ -53,19 +54,101 @@ func SnapshotSQLite(opts SQLiteSnapshotOptions) (SQLiteSnapshot, error) {
 	if err := os.MkdirAll(destination, 0o700); err != nil {
 		return SQLiteSnapshot{}, fmt.Errorf("create sqlite snapshot dir: %w", err)
 	}
+	stage, err := os.MkdirTemp(destination, ".sqlite-snapshot-")
+	if err != nil {
+		return SQLiteSnapshot{}, fmt.Errorf("create sqlite snapshot staging dir: %w", err)
+	}
+	retainStage := false
+	defer func() {
+		if !retainStage {
+			_ = os.RemoveAll(stage)
+		}
+	}()
+	for _, dir := range []string{"next", "previous"} {
+		if err := os.Mkdir(filepath.Join(stage, dir), 0o700); err != nil {
+			return SQLiteSnapshot{}, err
+		}
+	}
+	stagedPath := filepath.Join(stage, "next", name)
 
 	result := SQLiteSnapshot{SourcePath: source, Path: filepath.Join(destination, name)}
+	copiedSuffixes := map[string]bool{}
 	for _, suffix := range []string{"", "-wal", "-shm"} {
-		size, copied, err := copyOptionalFile(source+suffix, result.Path+suffix, opts.MaxFileBytes)
+		size, copied, err := copyOptionalFile(source+suffix, stagedPath+suffix, opts.MaxFileBytes)
 		if err != nil {
 			return SQLiteSnapshot{}, err
 		}
+		if suffix == "" && !copied {
+			return SQLiteSnapshot{}, errors.New("sqlite source disappeared during capture")
+		}
 		if copied {
+			copiedSuffixes[suffix] = true
 			result.Files = append(result.Files, result.Path+suffix)
 			result.SizeBytes += size
 		}
 	}
+	retainStage, err = publishSQLiteBundle(stagedPath, filepath.Join(stage, "previous", name), result.Path, copiedSuffixes)
+	if err != nil {
+		return SQLiteSnapshot{}, err
+	}
+	if err := os.RemoveAll(stage); err != nil {
+		retainStage = true
+		return result, fmt.Errorf("sqlite snapshot committed; staging cleanup failed: %w", err)
+	}
 	return result, nil
+}
+
+func publishSQLiteBundle(staged, previous, target string, copied map[string]bool) (bool, error) {
+	suffixes := []string{"", "-wal", "-shm"}
+	var old, published []string
+	for _, suffix := range suffixes {
+		info, err := os.Lstat(target + suffix)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return false, err
+		}
+		if !info.Mode().IsRegular() && info.Mode()&os.ModeSymlink == 0 {
+			return false, fmt.Errorf("sqlite snapshot destination is not a file: %s", target+suffix)
+		}
+		old = append(old, suffix)
+	}
+	var moved []string
+	rollback := func(cause error) (bool, error) {
+		var restoreErr error
+		for _, suffix := range published {
+			if err := os.Remove(target + suffix); err != nil {
+				restoreErr = errors.Join(restoreErr, err)
+			}
+		}
+		for _, suffix := range moved {
+			if err := os.Rename(previous+suffix, target+suffix); err != nil {
+				restoreErr = errors.Join(restoreErr, err)
+			}
+		}
+		if restoreErr != nil {
+			return true, errors.Join(cause, fmt.Errorf("restore previous sqlite snapshot; recovery files retained at %s: %w", filepath.Dir(previous), restoreErr))
+		}
+		return false, cause
+	}
+	for _, suffix := range old {
+		if err := os.Rename(target+suffix, previous+suffix); err != nil {
+			return rollback(err)
+		}
+		moved = append(moved, suffix)
+	}
+	// Install the new sidecars before making their corresponding main visible.
+	for _, suffix := range []string{"-wal", "-shm", ""} {
+		if !copied[suffix] {
+			continue
+		}
+		if err := os.Rename(staged+suffix, target+suffix); err != nil {
+			return rollback(err)
+		}
+		published = append(published, suffix)
+	}
+	return false, nil
 }
 
 func SQLiteModifiedAfter(path string, cutoff time.Time) bool {

--- a/cache/sqlite_test.go
+++ b/cache/sqlite_test.go
@@ -1,0 +1,166 @@
+package cache
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openclaw/crawlkit/store"
+)
+
+func TestSnapshotSQLiteReusedDestinationDropsStaleWAL(t *testing.T) {
+	ctx := context.Background()
+	source := filepath.Join(t.TempDir(), "source.db")
+	st, err := store.Open(ctx, store.Options{Path: source, Schema: `create table items(value text); insert into items values('old');`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	destination := t.TempDir()
+	sentinel := filepath.Join(destination, "unrelated")
+	if err := os.WriteFile(sentinel, []byte("retain"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	opts := SQLiteSnapshotOptions{SourcePath: source, DestinationDir: destination, Name: "archive.db"}
+	first, err := SnapshotSQLite(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wal, err := os.Stat(first.Path + "-wal")
+	if err != nil || wal.Size() == 0 {
+		t.Fatalf("fixture lacks uncheckpointed WAL: %v, %v", wal, err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `update items set value='new'; pragma wal_checkpoint(TRUNCATE);`); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(source + "-wal"); !os.IsNotExist(err) {
+		t.Fatalf("source WAL still exists: %v", err)
+	}
+	second, err := SnapshotSQLite(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if _, err := os.Stat(second.Path + suffix); !os.IsNotExist(err) {
+			t.Errorf("stale destination sidecar %s retained: %v", suffix, err)
+		}
+	}
+	ro, err := store.OpenReadOnly(ctx, second.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ro.Close()
+	var value string
+	if err := ro.DB().QueryRowContext(ctx, `select value from items`).Scan(&value); err != nil || value != "new" {
+		t.Fatalf("reused snapshot value = %q, error = %v", value, err)
+	}
+	if data, err := os.ReadFile(sentinel); err != nil || string(data) != "retain" {
+		t.Fatalf("unrelated destination file changed: %q, %v", data, err)
+	}
+}
+
+func TestSnapshotSQLiteFailurePreservesPreviousBundle(t *testing.T) {
+	for _, failingSuffix := range []string{"-wal", "-shm"} {
+		t.Run(failingSuffix, func(t *testing.T) {
+			source := filepath.Join(t.TempDir(), "source.db")
+			destination := t.TempDir()
+			target := filepath.Join(destination, "archive.db")
+			for _, suffix := range []string{"", "-wal", "-shm"} {
+				if err := os.WriteFile(target+suffix, []byte("old"+suffix), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				data := []byte("new")
+				if suffix == failingSuffix {
+					data = []byte("exceeds maximum")
+				}
+				if err := os.WriteFile(source+suffix, data, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, err := SnapshotSQLite(SQLiteSnapshotOptions{
+				SourcePath: source, DestinationDir: destination, Name: "archive.db", MaxFileBytes: 8,
+			}); err == nil {
+				t.Fatal("expected sidecar size failure")
+			}
+			for _, suffix := range []string{"", "-wal", "-shm"} {
+				got, err := os.ReadFile(target + suffix)
+				if err != nil || string(got) != "old"+suffix {
+					t.Errorf("previous %s changed: %q, %v", suffix, got, err)
+				}
+			}
+			entries, err := os.ReadDir(destination)
+			if err != nil || len(entries) != 3 {
+				t.Fatalf("staging files leaked: %v, %v", entries, err)
+			}
+		})
+	}
+}
+
+func TestPublishSQLiteBundleRollsBackFailedMainPromotion(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "archive.db")
+	staged := filepath.Join(t.TempDir(), "archive.db")
+	previous := filepath.Join(t.TempDir(), "archive.db")
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		if err := os.WriteFile(target+suffix, []byte("old"+suffix), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(staged+"-wal", []byte("new WAL"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	retained, err := publishSQLiteBundle(staged, previous, target, map[string]bool{"": true, "-wal": true})
+	if err == nil || retained {
+		t.Fatalf("failed main promotion: retained=%v, error=%v", retained, err)
+	}
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		data, err := os.ReadFile(target + suffix)
+		if err != nil || string(data) != "old"+suffix {
+			t.Fatalf("old bundle not restored at %s: %q, %v", suffix, data, err)
+		}
+	}
+}
+
+func TestSnapshotSQLitePreservesExistingAliasCompatibility(t *testing.T) {
+	for _, kind := range []string{"same path", "hardlink"} {
+		t.Run(kind, func(t *testing.T) {
+			dir := t.TempDir()
+			source := filepath.Join(dir, "source.db")
+			if err := os.WriteFile(source, []byte("source bytes"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			before, err := os.Stat(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			name := "source.db"
+			if kind == "hardlink" {
+				name = "alias.db"
+				if err := os.Link(source, filepath.Join(dir, name)); err != nil {
+					t.Skipf("hardlinks unavailable: %v", err)
+				}
+			}
+			snapshot, err := SnapshotSQLite(SQLiteSnapshotOptions{SourcePath: source, DestinationDir: dir, Name: name})
+			if err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(source)
+			if err != nil || string(data) != "source bytes" {
+				t.Fatalf("source changed: %q, %v", data, err)
+			}
+			data, err = os.ReadFile(snapshot.Path)
+			if err != nil || string(data) != "source bytes" {
+				t.Fatalf("snapshot content: %q, %v", data, err)
+			}
+			if kind == "hardlink" {
+				after, err := os.Stat(source)
+				if err != nil || !os.SameFile(before, after) {
+					t.Fatalf("distinct source inode replaced: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -298,7 +298,23 @@ func WriteTOML(path string, src any, perm os.FileMode) error {
 	if perm == 0 {
 		perm = 0o600
 	}
-	return os.WriteFile(resolved, data, perm)
+	// Apply permissions before truncation so replacement secrets are never
+	// written using a pre-existing file's more permissive mode.
+	file, err := os.OpenFile(resolved, os.O_WRONLY|os.O_CREATE, perm)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	if err := file.Chmod(perm); err != nil {
+		return err
+	}
+	if err := file.Truncate(0); err != nil {
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		return err
+	}
+	return file.Close()
 }
 
 func TokenDiagnosticForEnv(env string) TokenDiagnostic {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,6 +7,85 @@ import (
 	"testing"
 )
 
+func TestWriteTOMLHonorsReplacementPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits")
+	}
+	for _, mode := range []os.FileMode{0, 0o600, 0o640, 0o644} {
+		t.Run(mode.String(), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if err := os.WriteFile(path, []byte("value = 'old'\n"), 0o666); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chmod(path, 0o666); err != nil {
+				t.Fatal(err)
+			}
+			if err := WriteTOML(path, map[string]string{"value": "replacement"}, mode); err != nil {
+				t.Fatal(err)
+			}
+			want := mode
+			if want == 0 {
+				want = 0o600
+			}
+			info, err := os.Stat(path)
+			if err != nil || info.Mode().Perm() != want {
+				t.Fatalf("mode = %v, error = %v, want %o", info, err, want)
+			}
+		})
+	}
+}
+
+func TestWriteTOMLPreservesFileOnMarshalFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	before := []byte("value = 'old'\n")
+	if err := os.WriteFile(path, before, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteTOML(path, map[string]any{"unsupported": make(chan int)}, 0); err == nil {
+		t.Fatal("expected marshal failure")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != string(before) {
+		t.Fatalf("existing config changed: %q, %v", data, err)
+	}
+}
+
+func TestWriteTOMLPreservesLinkSemantics(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX link and permission fixtures")
+	}
+	for _, kind := range []string{"symlink", "hardlink", "dangling symlink"} {
+		t.Run(kind, func(t *testing.T) {
+			dir := t.TempDir()
+			target := filepath.Join(dir, "target.toml")
+			link := filepath.Join(dir, "config.toml")
+			if kind != "dangling symlink" {
+				if err := os.WriteFile(target, []byte("old = true\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			create := os.Symlink
+			if kind == "hardlink" {
+				create = os.Link
+			}
+			if err := create(target, link); err != nil {
+				t.Skipf("link unavailable: %v", err)
+			}
+			if err := WriteTOML(link, map[string]bool{"updated": true}, 0); err != nil {
+				t.Fatal(err)
+			}
+			var got map[string]bool
+			if err := LoadTOML(target, &got); err != nil || !got["updated"] {
+				t.Fatalf("linked target = %v, error = %v", got, err)
+			}
+			info, err := os.Stat(target)
+			if err != nil || info.Mode().Perm() != 0o600 {
+				t.Fatalf("linked target mode = %v, error = %v", info, err)
+			}
+		})
+	}
+}
+
 func TestDefaultPathsUseConfigDir(t *testing.T) {
 	home := t.TempDir()
 	setTestHome(t, home)

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -54,6 +54,15 @@ custom JSON/text encoders own their transformation. The prior pack survives a
 refusal. This prevents silent loss, not full BLOB export support or recovery of
 binary/text distinctions already lost by old writers.
 
+Generic incremental deletes and `INSERT OR REPLACE` refuse inbound cascading,
+`SET NULL` or `SET DEFAULT` foreign keys and triggers on affected tables before
+`BeforeImport` runs. Otherwise skipped/unlisted tables can lose local history.
+The generic guard supports unshadowed main-schema tables and includes temporary
+triggers. Restrictive foreign keys keep normal transactional failure behavior.
+Dependency-aware custom `DeleteTable` and `ImportRow` callbacks retain their
+contract and own the safety of their writes; hooks must not invalidate the
+checked schema. Full import behavior is unchanged.
+
 Encrypted backup writers hold `.crawlkit-backup.lock` through publication and
 cleanup. This persistent local marker is not manifest-owned; never unlink it
 to release a writer. Publish only exact current/prior manifest paths when an

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -36,6 +36,24 @@ must not commit or roll back. Legacy filter closures retain their own database
 bindings. The driver's `ReadOnly` option is not an authorization boundary for
 trusted callbacks.
 
+Snapshot rows remain v1 JSON objects; no new wire format is enabled. Import
+callbacks still receive ordinary numbers as `float64`. Exact integral tokens
+outside +/- (2^53-1), including decimal/exponent spellings, become `int64` when
+they fit; no `json.Number` escapes to callers. Integers outside signed 64-bit
+range, oversized fractional magnitudes, overflow, nonzero underflow, numeric
+tokens over 4096 bytes and invalid Unicode fail transactionally. Ordinary
+fractional values retain float64 rounding.
+
+V1 export refuses admitted BLOBs and integers outside +/- (2^53-1), including
+integral-looking REALs, before publishing the manifest. It also refuses invalid
+UTF-8 and numbers the reader cannot represent. Excluded rows do not fail.
+Filters retain the legacy BLOB-as-string input and may remove unsupported cells
+or replace them with an explicit supported representation, such as prefixed
+base64 text; an unchanged implicit BLOB string is not sufficient. Explicit
+custom JSON/text encoders own their transformation. The prior pack survives a
+refusal. This prevents silent loss, not full BLOB export support or recovery of
+binary/text distinctions already lost by old writers.
+
 Encrypted backup writers hold `.crawlkit-backup.lock` through publication and
 cleanup. This persistent local marker is not manifest-owned; never unlink it
 to release a writer. Publish only exact current/prior manifest paths when an

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -15,6 +15,27 @@
 - `backup` writes age-encrypted JSONL/Gzip shards and manifests, manages recipients and identities, lists Git-backed history, and verifies historical restores.
 - `mirror` clones, initializes, pulls, commits, and pushes Git-backed archives. It also provides non-mutating fetches, immutable snapshot tags, Git-object reads, and history inspection.
 
+Snapshot exports use `tables/.generations/<32 lowercase hex>/<table>/<ordinal>.jsonl.gz`,
+where the ordinal has at least six digits. Manifest fields are unchanged;
+planners match these paths to legacy `tables/<table>/<ordinal>.jsonl.gz` IDs.
+Unchanged physical shards are reused only after comparing actual bytes.
+Old literal readers can consume the paths; old planners may request replacement.
+Strict downstream publication validators must explicitly admit this form.
+
+Export holds `.crawlkit-snapshot.lock`, stages closed/synced shards, and publishes
+the manifest last. Failures before promotion retain the prior pack. Cleanup
+deletes exact prior managed files only; unlisted files and directories are not
+recursively owned, and empty generation directories may remain. Post-promotion
+cleanup errors return the committed manifest. Readers must coordinate with
+pruning; this is not a read lease or a power-loss durability guarantee.
+
+All table reads use one transaction. `ReadTx` optionally borrows a caller's
+transaction without ending it, even on error. `FilterTx` runs after the legacy
+filter for admitted rows, using that same transaction; it must only read and
+must not commit or roll back. Legacy filter closures retain their own database
+bindings. The driver's `ReadOnly` option is not an authorization boundary for
+trusted callbacks.
+
 Encrypted backup writers hold `.crawlkit-backup.lock` through publication and
 cleanup. This persistent local marker is not manifest-owned; never unlink it
 to release a writer. Publish only exact current/prior manifest paths when an

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -15,6 +15,19 @@
 - `backup` writes age-encrypted JSONL/Gzip shards and manifests, manages recipients and identities, lists Git-backed history, and verifies historical restores.
 - `mirror` clones, initializes, pulls, commits, and pushes Git-backed archives. It also provides non-mutating fetches, immutable snapshot tags, Git-object reads, and history inspection.
 
+Encrypted backup writers hold `.crawlkit-backup.lock` through publication and
+cleanup. This persistent local marker is not manifest-owned; never unlink it
+to release a writer. Publish only exact current/prior manifest paths when an
+app stages a backup for Git. Generic `mirror.Commit` remains unchanged.
+
+New encrypted shards and file indexes use unique physical names; legacy
+logical names and manifest fields remain readable. The manifest is published
+last. A failure before publication preserves the prior pack. A cleanup error
+after publication returns the committed manifest and an explicit cleanup
+error. Cleanup removes only exact prior manifest-owned objects, not unrelated
+files. Callers must coordinate readers with pruning; this is not a concurrent
+reader lease or a power-loss durability guarantee.
+
 ## Search
 
 - `embed` provides OpenAI-compatible, Ollama, and llama.cpp embedding clients plus probe diagnostics.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -42,9 +42,11 @@ Homebrew handoff.
    `ASC_ISSUER_ID`, and `ASC_PRIVATE_KEY_P8`. The shared workflow validates
    them before creating a tag.
 2. Choose an unused version and prepare a release PR from the current protected
-   `main` head. The next patch section is **v0.14.10 - Unreleased**; v0.14.9 is
-   already published. Date the versioned changelog section and run (Node.js is
-   required for the dispatch regression tests):
+   `main` head. **v0.15.0 - 2026-09-08** is prepared for the broader shared
+   infrastructure changes; v0.14.9 remains the published release until the
+   unified workflow publishes v0.15.0. Confirm the version is still unused and
+   the changelog section is dated, then run (Node.js is required for the dispatch
+   regression tests):
 
    ```bash
    make check

--- a/docs/remote-contract.md
+++ b/docs/remote-contract.md
@@ -21,6 +21,14 @@ secrets, and deployment cadence.
 The Worker exposes `GET /v1/contract` without authentication. Clients can use
 that route to verify protocol support before login or before publishing.
 
+## Credential Transport
+
+Bearer requests, GitHub-token login and login polling require HTTPS, except
+for explicitly configured loopback HTTP development endpoints. Credential-bearing
+redirects must retain the original scheme, hostname and effective port, including
+307/308 redirects that replay a login body. Caller redirect policies may further
+restrict redirects; the client does not mutate the caller's HTTP client.
+
 ## Compatibility
 
 The v1 contract is additive:

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/mattn/go-isatty v0.0.24
 	github.com/pelletier/go-toml/v2 v2.4.3
+	golang.org/x/sys v0.47.0
 	modernc.org/sqlite v1.58.0
 )
 
@@ -37,7 +38,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v1.0.0 // indirect
 	golang.org/x/crypto v0.56.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	modernc.org/libc v1.75.6 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/internal/filelock/filelock.go
+++ b/internal/filelock/filelock.go
@@ -1,0 +1,66 @@
+// Package filelock holds a nonblocking OS lock on a persistent regular file.
+// All users must keep the pathname and inode in place, including on release.
+package filelock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+)
+
+var ErrLocked = errors.New("already locked")
+
+type Lock struct {
+	File    *os.File
+	Created bool
+	once    sync.Once
+	err     error
+}
+
+func Acquire(path string) (*Lock, error) {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+	created := err == nil
+	if errors.Is(err, os.ErrExist) {
+		info, statErr := os.Lstat(path)
+		if statErr != nil {
+			return nil, statErr
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("lock path is not a regular file: %s", path)
+		}
+		file, err = os.OpenFile(path, os.O_RDWR, 0o600)
+	}
+	if err != nil {
+		return nil, err
+	}
+	fail := func(err error) (*Lock, error) {
+		_ = file.Close()
+		return nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return fail(err)
+	}
+	entry, err := os.Lstat(path)
+	if err != nil {
+		return fail(err)
+	}
+	if !info.Mode().IsRegular() || !entry.Mode().IsRegular() || !os.SameFile(info, entry) {
+		return fail(fmt.Errorf("lock path changed or is not a regular file: %s", path))
+	}
+	if err := lockFile(file); err != nil {
+		return fail(err)
+	}
+	if err := file.Chmod(0o600); err != nil {
+		return fail(err)
+	}
+	return &Lock{File: file, Created: created}, nil
+}
+
+// Close releases the kernel lock by closing its owning handle. It is idempotent
+// and never unlinks the file, so old cleanup cannot expose a later owner.
+func (lock *Lock) Close() error {
+	lock.once.Do(func() { lock.err = lock.File.Close() })
+	return lock.err
+}

--- a/internal/filelock/filelock_other.go
+++ b/internal/filelock/filelock_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris && !windows
+
+package filelock
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+func lockFile(*os.File) error {
+	return fmt.Errorf("OS file locking is unsupported on %s", runtime.GOOS)
+}

--- a/internal/filelock/filelock_test.go
+++ b/internal/filelock/filelock_test.go
@@ -1,0 +1,58 @@
+package filelock
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestAcquireKeepsOnePrivateInode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lock")
+	first, err := Acquire(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	if !first.Created {
+		t.Fatal("first lock was not newly created")
+	}
+	before, err := first.File.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" && before.Mode().Perm() != 0o600 {
+		t.Fatalf("lock permissions = %o", before.Mode().Perm())
+	}
+	if other, err := Acquire(path); !errors.Is(err, ErrLocked) {
+		if other != nil {
+			_ = other.Close()
+		}
+		t.Fatalf("second acquisition = %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	second, err := Acquire(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Close()
+	if second.Created {
+		t.Fatal("release removed lock file")
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if other, err := Acquire(path); !errors.Is(err, ErrLocked) {
+		if other != nil {
+			_ = other.Close()
+		}
+		t.Fatalf("repeated cleanup exposed next holder: %v", err)
+	}
+	after, err := second.File.Stat()
+	if err != nil || !os.SameFile(before, after) {
+		t.Fatalf("lock inode changed: %v", err)
+	}
+}

--- a/internal/filelock/filelock_unix.go
+++ b/internal/filelock/filelock_unix.go
@@ -1,0 +1,26 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package filelock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockFile(file *os.File) error {
+	var info unix.Stat_t
+	if err := unix.Fstat(int(file.Fd()), &info); err != nil {
+		return err
+	}
+	if info.Nlink != 1 {
+		return fmt.Errorf("lock file must not have hardlink aliases")
+	}
+	err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+		return ErrLocked
+	}
+	return err
+}

--- a/internal/filelock/filelock_windows.go
+++ b/internal/filelock/filelock_windows.go
@@ -1,0 +1,26 @@
+package filelock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFile(file *os.File) error {
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(windows.Handle(file.Fd()), &info); err != nil {
+		return err
+	}
+	if info.NumberOfLinks != 1 {
+		return fmt.Errorf("lock file must not have hardlink aliases")
+	}
+	err := windows.LockFileEx(windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0, 1, 0, &windows.Overlapped{})
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return ErrLocked
+	}
+	return err
+}

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -104,9 +104,6 @@ func Pull(ctx context.Context, opts Options) error {
 
 func PullCurrent(ctx context.Context, opts Options) error {
 	opts = normalize(opts)
-	if opts.Remote != "" {
-		return Pull(ctx, opts)
-	}
 	if err := EnsureRepo(ctx, opts); err != nil {
 		return err
 	}

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -466,7 +468,7 @@ func isSQLiteSidecar(path string) bool {
 func run(ctx context.Context, dir, git string, args ...string) error {
 	out, err := output(ctx, dir, git, args...)
 	if err != nil {
-		return fmt.Errorf("%s %s: %w\n%s", git, strings.Join(args, " "), err, strings.TrimSpace(out))
+		return fmt.Errorf("%s %s: %w\n%s", git, redactGitURLs(strings.Join(args, " ")), err, strings.TrimSpace(out))
 	}
 	return nil
 }
@@ -477,7 +479,39 @@ func output(ctx context.Context, dir, git string, args ...string) (string, error
 		cmd.Dir = dir
 	}
 	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return redactGitURLs(string(out)), err
+	}
 	return string(out), err
+}
+
+var gitURLPattern = regexp.MustCompile(`[a-zA-Z][a-zA-Z0-9+.-]*://[^\s"'<>]+`)
+
+func redactGitURLs(text string) string {
+	return gitURLPattern.ReplaceAllStringFunc(text, func(raw string) string {
+		parsed, err := url.Parse(raw)
+		if err == nil {
+			if parsed.User == nil {
+				return raw
+			}
+			parsed.User = url.User("REDACTED")
+			return parsed.String()
+		}
+		// Git also reports malformed URLs; invalid escapes must not bypass
+		// userinfo redaction in an otherwise recognizable authority.
+		scheme, rest, ok := strings.Cut(raw, "://")
+		if !ok {
+			return raw
+		}
+		authority := rest
+		if end := strings.IndexAny(rest, "/?#"); end >= 0 {
+			authority = rest[:end]
+		}
+		if at := strings.LastIndexByte(authority, '@'); at >= 0 {
+			return scheme + "://REDACTED@" + rest[at+1:]
+		}
+		return raw
+	})
 }
 
 func isNonFastForward(out string) bool {

--- a/mirror/pull_current_test.go
+++ b/mirror/pull_current_test.go
@@ -1,0 +1,76 @@
+package mirror
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPullCurrentExplicitRemotePreservesLocalHistory(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	if err := run(ctx, "", "git", "init", "--bare", remote); err != nil {
+		t.Fatal(err)
+	}
+	seed := Options{RepoPath: filepath.Join(root, "seed"), Remote: remote, Branch: "main"}
+	if err := EnsureRepo(ctx, seed); err != nil {
+		t.Fatal(err)
+	}
+	writeCommit := func(opts Options, name, value string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(opts.RepoPath, name), []byte(value), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if changed, err := Commit(ctx, opts, value); err != nil || !changed {
+			t.Fatalf("commit: %v, %v", changed, err)
+		}
+	}
+	writeCommit(seed, "base", "base")
+	if err := Push(ctx, seed); err != nil {
+		t.Fatal(err)
+	}
+	opts := Options{RepoPath: filepath.Join(root, "local"), Remote: remote, Branch: "main"}
+	if err := PullCurrent(ctx, opts); err != nil {
+		t.Fatal(err)
+	}
+	writeCommit(seed, "remote", "new remote")
+	if err := Push(ctx, seed); err != nil {
+		t.Fatal(err)
+	}
+	if err := PullCurrent(ctx, opts); err != nil {
+		t.Fatalf("fast-forward: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(opts.RepoPath, "remote")); err != nil {
+		t.Fatal("remote update not pulled")
+	}
+	writeCommit(opts, "local", "unpublished")
+	before, err := output(ctx, opts.RepoPath, "git", "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := PullCurrent(ctx, opts); err != nil {
+		t.Fatalf("ahead pull: %v", err)
+	}
+	after, err := output(ctx, opts.RepoPath, "git", "rev-parse", "HEAD")
+	if err != nil || after != before {
+		t.Fatalf("ahead HEAD changed: %q -> %q, %v", before, after, err)
+	}
+	writeCommit(seed, "diverged", "divergent remote")
+	if err := Push(ctx, seed); err != nil {
+		t.Fatal(err)
+	}
+	if err := PullCurrent(ctx, opts); err == nil {
+		t.Fatal("divergent pull should fail")
+	}
+	after, err = output(ctx, opts.RepoPath, "git", "rev-parse", "HEAD")
+	if err != nil || after != before {
+		t.Fatalf("divergent HEAD changed: %q -> %q, %v", before, after, err)
+	}
+	data, err := os.ReadFile(filepath.Join(opts.RepoPath, "local"))
+	if err != nil || strings.TrimSpace(string(data)) != "unpublished" {
+		t.Fatalf("local work lost: %q, %v", data, err)
+	}
+}

--- a/mirror/redaction_test.go
+++ b/mirror/redaction_test.go
@@ -1,0 +1,56 @@
+package mirror
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestGitErrorsRedactURLCredentials(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("synthetic POSIX Git executable")
+	}
+	dir := t.TempDir()
+	git := filepath.Join(dir, "git-error")
+	if err := os.WriteFile(git, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" >&2\nprintf 'fatal: rejected https://other:sample@example.invalid/repo\\n' >&2\nexit 2\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, remote := range []string{
+		"https://user:placeholder@example.invalid/repo",
+		"https://test-auth-token@example.invalid/repo",
+		(&url.URL{Scheme: "https", Host: "example.invalid", User: url.UserPassword("user", "fake/part"), Path: "/repo"}).String(),
+		"https://user:placeholder@example.invalid/invalid%zz",
+	} {
+		err := run(context.Background(), dir, git, "fetch", remote)
+		if err == nil {
+			t.Fatal("expected Git failure")
+		}
+		for _, secret := range []string{"placeholder", "test-auth-token", "fake%2Fpart", "sample"} {
+			if strings.Contains(err.Error(), secret) {
+				t.Errorf("Git error leaked %q: %v", secret, err)
+			}
+		}
+		if !strings.Contains(err.Error(), "example.invalid/") || !strings.Contains(err.Error(), "fatal: rejected") {
+			t.Fatalf("useful error context lost: %v", err)
+		}
+	}
+}
+
+func TestSuccessfulGitOutputIsNotRedacted(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("synthetic POSIX Git executable")
+	}
+	git := filepath.Join(t.TempDir(), "git-output")
+	want := "https://user:example@example.invalid/repo"
+	if err := os.WriteFile(git, []byte("#!/bin/sh\nprintf '%s' '"+want+"'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	got, err := output(context.Background(), "", git, "show", "HEAD:document")
+	if err != nil || got != want {
+		t.Fatalf("archive bytes changed: %q, %v", got, err)
+	}
+}

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -152,7 +152,7 @@ func NewClient(opts Options) (*Client, error) {
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return nil, fmt.Errorf("invalid remote endpoint %q", endpoint)
 	}
-	if opts.TokenProvider != nil && parsed.Scheme != "https" && !isLocalHTTPHost(parsed.Hostname()) {
+	if opts.TokenProvider != nil && !credentialTransportAllowed(parsed) {
 		return nil, fmt.Errorf("remote endpoint %q cannot use bearer auth over %s", endpoint, parsed.Scheme)
 	}
 	client := opts.HTTPClient
@@ -174,6 +174,25 @@ func NewClient(opts Options) (*Client, error) {
 func isLocalHTTPHost(host string) bool {
 	host = strings.ToLower(strings.TrimSpace(host))
 	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
+func credentialTransportAllowed(endpoint *url.URL) bool {
+	return endpoint.Scheme == "https" ||
+		(endpoint.Scheme == "http" && isLocalHTTPHost(endpoint.Hostname()))
+}
+
+func sameOrigin(left, right *url.URL) bool {
+	port := func(u *url.URL) string {
+		if explicit := u.Port(); explicit != "" {
+			return explicit
+		}
+		if u.Scheme == "https" {
+			return "443"
+		}
+		return "80"
+	}
+	return left.Scheme == right.Scheme &&
+		strings.EqualFold(left.Hostname(), right.Hostname()) && port(left) == port(right)
 }
 
 func NewClientFromConfig(cfg Config, opts Options) (*Client, error) {
@@ -483,7 +502,7 @@ func (c *Client) publishStatus(ctx context.Context, app, archive, snapshotID str
 	if err != nil {
 		return out, err
 	}
-	err = c.doRequest(ctx, req, false, &out, true)
+	err = c.doRequest(ctx, req, false, &out, true, true)
 	if err == nil && snapshotID != "" {
 		if out.App != app || out.Archive != archive {
 			return PublisherStatus{}, fmt.Errorf(
@@ -1812,7 +1831,12 @@ func (c *Client) do(ctx context.Context, method, route string, input, output any
 	if err != nil {
 		return err
 	}
-	return c.doRequest(ctx, req, input != nil, output, auth)
+	credentials := auth
+	switch input.(type) {
+	case GitHubTokenLoginRequest, *GitHubTokenLoginRequest, LoginPollRequest, *LoginPollRequest:
+		credentials = true
+	}
+	return c.doRequest(ctx, req, input != nil, output, auth, credentials)
 }
 
 func (c *Client) doRaw(ctx context.Context, method, route string, body io.Reader, size int64, headers http.Header, output any, auth bool) error {
@@ -1830,10 +1854,16 @@ func (c *Client) doRaw(ctx context.Context, method, route string, body io.Reader
 			req.Header.Add(name, value)
 		}
 	}
-	return c.doRequest(ctx, req, true, output, auth)
+	return c.doRequest(ctx, req, true, output, auth, auth)
 }
 
-func (c *Client) doRequest(ctx context.Context, req *http.Request, hasBody bool, output any, auth bool) error {
+func (c *Client) doRequest(ctx context.Context, req *http.Request, hasBody bool, output any, auth, credentials bool) error {
+	if req.URL.User != nil || req.Header.Get("Authorization") != "" {
+		credentials = true
+	}
+	if credentials && !credentialTransportAllowed(req.URL) {
+		return errors.New("remote credentials require HTTPS except for loopback HTTP")
+	}
 	req.Header.Set("accept", "application/json")
 	req.Header.Set("user-agent", c.userAgent)
 	if hasBody && req.Header.Get("content-type") == "" {
@@ -1849,7 +1879,35 @@ func (c *Client) doRequest(ctx context.Context, req *http.Request, hasBody bool,
 		}
 		req.Header.Set("authorization", "Bearer "+token)
 	}
-	resp, err := c.httpClient.Do(req)
+	httpClient := c.httpClient
+	if credentials {
+		// Keep the caller's client reusable; this policy belongs to this request.
+		client := *httpClient
+		policy := client.CheckRedirect
+		origin := *req.URL
+		checkOrigin := func(next *http.Request) error {
+			if !credentialTransportAllowed(next.URL) || !sameOrigin(&origin, next.URL) {
+				return errors.New("remote credential redirect must retain the original scheme, host and port")
+			}
+			return nil
+		}
+		client.CheckRedirect = func(next *http.Request, via []*http.Request) error {
+			if err := checkOrigin(next); err != nil {
+				return err
+			}
+			if policy != nil {
+				if err := policy(next, via); err != nil {
+					return err
+				}
+			} else if len(via) >= 10 {
+				return errors.New("stopped after 10 redirects")
+			}
+			// A caller policy can modify next.URL as well as accept or reject it.
+			return checkOrigin(next)
+		}
+		httpClient = &client
+	}
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/remote/transport_policy_test.go
+++ b/remote/transport_policy_test.go
@@ -1,0 +1,201 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func credentialCall(client *Client, kind string) error {
+	switch kind {
+	case "bearer":
+		_, err := client.Whoami(context.Background())
+		return err
+	case "login":
+		_, err := client.LoginWithGitHubToken(context.Background(), "synthetic-login-token")
+		return err
+	default:
+		_, err := client.PollGitHubLogin(context.Background(), "login-id", "synthetic-poll-secret")
+		return err
+	}
+}
+
+func TestCredentialRequestsRejectRemoteHTTPWithoutProvider(t *testing.T) {
+	for _, kind := range []string{"login", "poll"} {
+		t.Run(kind, func(t *testing.T) {
+			calls := 0
+			client, err := NewClient(Options{
+				Endpoint: "http://archive.example.invalid",
+				HTTPClient: &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					calls++
+					return &http.Response{StatusCode: 200, Header: http.Header{}, Body: io.NopCloser(strings.NewReader("{}"))}, nil
+				})},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := credentialCall(client, kind); err == nil {
+				t.Error("credential-bearing remote HTTP request accepted")
+			}
+			if calls != 0 {
+				t.Fatalf("unsafe transport called %d times", calls)
+			}
+		})
+	}
+}
+
+func TestCredentialRedirectsStayOnSecureOrigin(t *testing.T) {
+	for _, kind := range []string{"bearer", "login", "poll"} {
+		for _, code := range []int{http.StatusTemporaryRedirect, http.StatusPermanentRedirect} {
+			for _, downgrade := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/%d/downgrade=%v", kind, code, downgrade), func(t *testing.T) {
+					var received atomic.Int32
+					handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						received.Add(1)
+						_, _ = io.Copy(io.Discard, r.Body)
+						_, _ = io.WriteString(w, "{}")
+					})
+					var target *httptest.Server
+					if downgrade {
+						target = httptest.NewServer(handler)
+					} else {
+						target = httptest.NewTLSServer(handler)
+					}
+					defer target.Close()
+					source := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						http.Redirect(w, r, target.URL+"/receive", code)
+					}))
+					defer source.Close()
+					client, err := NewClient(Options{Endpoint: source.URL, HTTPClient: source.Client(), TokenProvider: StaticToken("synthetic-bearer")})
+					if err != nil {
+						t.Fatal(err)
+					}
+					if err := credentialCall(client, kind); err == nil {
+						t.Error("credential redirect accepted")
+					}
+					if got := received.Load(); got != 0 {
+						t.Fatalf("redirect receiver called %d times", got)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestCredentialRedirectPreservesCallerPolicyAndClient(t *testing.T) {
+	source := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/finish" {
+			http.Redirect(w, r, "/finish", http.StatusTemporaryRedirect)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer synthetic-bearer" {
+			t.Error("same-origin redirect lost bearer")
+		}
+		_, _ = io.WriteString(w, "{}")
+	}))
+	defer source.Close()
+	httpClient := source.Client()
+	client, err := NewClient(Options{Endpoint: source.URL, HTTPClient: httpClient, TokenProvider: StaticToken("synthetic-bearer")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := credentialCall(client, "bearer"); err != nil {
+		t.Fatalf("same-origin redirect failed: %v", err)
+	}
+	if httpClient.CheckRedirect != nil {
+		t.Fatal("caller HTTP client was mutated")
+	}
+	blocked := errors.New("caller refused redirect")
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error { return blocked }
+	if err := credentialCall(client, "bearer"); !errors.Is(err, blocked) {
+		t.Fatalf("caller policy lost: %v", err)
+	}
+}
+
+func TestCredentialRedirectRechecksCallerModifiedURL(t *testing.T) {
+	var received atomic.Int32
+	target := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received.Add(1)
+		_, _ = io.WriteString(w, "{}")
+	}))
+	defer target.Close()
+	source := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/finish", http.StatusTemporaryRedirect)
+	}))
+	defer source.Close()
+	httpClient := source.Client()
+	httpClient.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
+		req.URL, _ = url.Parse(target.URL)
+		return nil
+	}
+	client, err := NewClient(Options{Endpoint: source.URL, HTTPClient: httpClient, TokenProvider: StaticToken("synthetic-bearer")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := credentialCall(client, "bearer"); err == nil || received.Load() != 0 {
+		t.Fatalf("caller-modified unsafe redirect reached transport: error=%v calls=%d", err, received.Load())
+	}
+}
+
+func TestCredentialRedirectRetainsSameOriginBodies(t *testing.T) {
+	for _, kind := range []string{"login", "poll"} {
+		t.Run(kind, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/finish" {
+					http.Redirect(w, r, "/finish", http.StatusPermanentRedirect)
+					return
+				}
+				body, err := io.ReadAll(r.Body)
+				if err != nil || !strings.Contains(string(body), "synthetic-") || r.Method != http.MethodPost {
+					t.Errorf("same-origin body/method lost: %s %q, %v", r.Method, body, err)
+				}
+				_, _ = io.WriteString(w, "{}")
+			}))
+			defer server.Close()
+			client, err := NewClient(Options{Endpoint: server.URL})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := credentialCall(client, kind); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestAnonymousRedirectPolicyIsUnchanged(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "{}")
+	}))
+	defer target.Close()
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer source.Close()
+	client, err := NewClient(Options{Endpoint: source.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Contract(context.Background()); err != nil {
+		t.Fatalf("anonymous cross-origin contract redirect changed: %v", err)
+	}
+}
+
+func TestCredentialOriginUsesDefaultPorts(t *testing.T) {
+	left, _ := url.Parse("https://example.invalid/a")
+	right, _ := url.Parse("https://EXAMPLE.invalid:443/b")
+	if !sameOrigin(left, right) {
+		t.Fatal("explicit default port changed origin")
+	}
+	right.Host = "example.invalid:444"
+	if sameOrigin(left, right) {
+		t.Fatal("different explicit port retained origin")
+	}
+}

--- a/scheduler/discover.go
+++ b/scheduler/discover.go
@@ -39,7 +39,7 @@ func Discover(ctx context.Context, binaries []string) []App {
 }
 
 func DefaultBinaries() []string {
-	return []string{"gitcrawl", "discrawl", "notcrawl", "wacrawl", "telecrawl", "slacrawl"}
+	return []string{"gitcrawl", "discrawl", "notcrawl", "wacrawl", "telecrawl", "slacrawl", "graincrawl", "imsgcrawl", "photoscrawl", "weicrawl"}
 }
 
 func discoverOne(ctx context.Context, binary string) App {

--- a/scheduler/discover_test.go
+++ b/scheduler/discover_test.go
@@ -1,0 +1,85 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"github.com/openclaw/crawlkit/control"
+)
+
+func TestDefaultBinariesCoversFamily(t *testing.T) {
+	want := []string{"gitcrawl", "discrawl", "notcrawl", "wacrawl", "telecrawl", "slacrawl", "graincrawl", "imsgcrawl", "photoscrawl", "weicrawl"}
+	if got := DefaultBinaries(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("default binaries = %v, want %v", got, want)
+	}
+	first := DefaultBinaries()
+	first[0] = "changed"
+	if got := DefaultBinaries()[0]; got != want[0] {
+		t.Fatalf("caller mutated defaults: %q", got)
+	}
+}
+
+func TestDiscoverUsesOnlySelectedMetadataAndSupportedJobs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("synthetic POSIX executable fixtures")
+	}
+	dir := t.TempDir()
+	for _, id := range []string{"graincrawl", "imsgcrawl", "photoscrawl", "weicrawl"} {
+		manifest := control.NewManifest(id, id, id)
+		command := "sync"
+		if id == "photoscrawl" {
+			command = "import_apple"
+		}
+		manifest.Commands = map[string]control.Command{
+			command: {Argv: []string{id, command, "--json"}, Mutates: true},
+		}
+		data, err := json.Marshal(manifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		script := fmt.Sprintf("#!/bin/sh\n[ \"$#\" = 2 ] && [ \"$1\" = metadata ] && [ \"$2\" = --json ] || exit 9\nprintf '%%s\\n' '%s'\n", data)
+		if err := os.WriteFile(filepath.Join(dir, id), []byte(script), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", dir)
+	apps := Discover(context.Background(), nil)
+	found := 0
+	for _, app := range apps {
+		if !app.Found {
+			continue
+		}
+		found++
+		if app.Manifest == nil || app.Legacy {
+			t.Fatalf("metadata not used: %+v", app)
+		}
+		job, ok := DefaultJobForApp(app, nil)
+		if app.ID == "photoscrawl" {
+			if ok {
+				t.Fatalf("discovery enabled automatic photo ingestion: %+v", job)
+			}
+		} else if !ok || !reflect.DeepEqual(job.Command, []string{app.Path, "sync", "--json"}) {
+			t.Fatalf("manifest sync not retained: app=%+v job=%+v", app, job)
+		}
+	}
+	if found != 4 {
+		t.Fatalf("found = %d, want 4", found)
+	}
+	explicit := Discover(context.Background(), []string{"graincrawl", "graincrawl", " "})
+	if len(explicit) != 1 || explicit[0].ID != "graincrawl" {
+		t.Fatalf("explicit override/deduplication changed: %+v", explicit)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "weicrawl"), []byte("#!/bin/sh\nprintf '{invalid}'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	invalid := Discover(context.Background(), []string{"weicrawl"})[0]
+	if invalid.Manifest != nil || invalid.Legacy {
+		t.Fatalf("invalid metadata received invented manifest: %+v", invalid)
+	}
+}

--- a/scheduler/lock_test.go
+++ b/scheduler/lock_test.go
@@ -1,0 +1,191 @@
+package scheduler
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openclaw/crawlkit/internal/filelock"
+)
+
+func TestSchedulerLockRepeatedCleanupPreservesOwner(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lock")
+	releaseA, err := acquireLock(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	releaseA()
+	releaseB, err := acquireLock(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseB()
+	releaseA()
+	if releaseC, err := acquireLock(path); err == nil {
+		releaseC()
+		t.Error("repeated old cleanup exposed the current owner")
+	}
+	releaseB()
+	last, err := os.Stat(path)
+	if err != nil || !os.SameFile(first, last) {
+		t.Fatalf("lock inode removed or replaced: %v", err)
+	}
+}
+
+func TestSchedulerLockRejectsLegacyMetadata(t *testing.T) {
+	for _, data := range []string{"", "pid=", "pid=0\n", fmt.Sprintf("pid=%d\n", os.Getpid()), "unknown-protocol\n"} {
+		t.Run(fmt.Sprintf("%q", data), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "lock")
+			if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if release, err := acquireLock(path); err == nil {
+				release()
+				t.Fatal("legacy or ambiguous lock accepted without stopped-runner upgrade")
+			}
+			got, err := os.ReadFile(path)
+			if err != nil || string(got) != data {
+				t.Fatalf("legacy metadata changed: %q, %v", got, err)
+			}
+		})
+	}
+}
+
+func TestSchedulerLockSubprocessLifecycle(t *testing.T) {
+	for _, mode := range []string{"release", "exit", "empty", "partial"} {
+		t.Run(mode, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "lock")
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestSchedulerLockProcessHelper$", "--", path, mode)
+			in, err := cmd.StdinPipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			out, err := cmd.StdoutPipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			var stderr bytes.Buffer
+			cmd.Stderr = &stderr
+			if err := cmd.Start(); err != nil {
+				t.Fatal(err)
+			}
+			waited := false
+			defer func() {
+				if !waited {
+					cancel()
+					_ = cmd.Wait()
+				}
+			}()
+			line, err := bufio.NewReader(out).ReadString('\n')
+			if err != nil || strings.TrimSpace(line) != "locked" {
+				t.Fatalf("child acquisition: %q, %v, %s", line, err, stderr.String())
+			}
+			if release, err := acquireLock(path); err == nil {
+				release()
+				t.Fatal("second process entered a held lock")
+			}
+			if _, err := in.Write([]byte("finish\n")); err != nil {
+				t.Fatal(err)
+			}
+			_ = in.Close()
+			err = cmd.Wait()
+			waited = true
+			if err != nil {
+				t.Fatalf("child exit: %v: %s", err, stderr.String())
+			}
+			release, err := acquireLock(path)
+			if mode == "empty" || mode == "partial" {
+				if err == nil {
+					release()
+					t.Fatal("ambiguous metadata accepted after holder exit")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("could not acquire after child %s: %v", mode, err)
+			}
+			release()
+		})
+	}
+}
+
+func TestSchedulerLockProcessHelper(t *testing.T) {
+	i := slices.Index(os.Args, "--")
+	if i < 0 {
+		return
+	}
+	path, mode := os.Args[i+1], os.Args[i+2]
+	var release func()
+	var err error
+	if mode == "empty" || mode == "partial" {
+		lock, lockErr := filelock.Acquire(path)
+		err = lockErr
+		if err == nil {
+			release = func() { _ = lock.Close() }
+			if mode == "partial" {
+				_, err = lock.File.WriteAt([]byte("crawlkit-os-"), 0)
+			}
+		}
+	} else {
+		release, err = acquireLock(path)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println("locked")
+	if _, err := bufio.NewReader(os.Stdin).ReadString('\n'); err != nil {
+		t.Fatal(err)
+	}
+	if mode == "exit" {
+		os.Exit(0)
+	}
+	release()
+}
+
+func TestSchedulerLockRejectsNonregularAndLinkedAliases(t *testing.T) {
+	for _, kind := range []string{"directory", "symlink", "hardlink"} {
+		t.Run(kind, func(t *testing.T) {
+			dir := t.TempDir()
+			target, lockPath := filepath.Join(dir, "target"), filepath.Join(dir, "lock")
+			original := []byte("retained unrelated data\n")
+			if err := os.WriteFile(target, original, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			switch kind {
+			case "directory":
+				if err := os.Mkdir(lockPath, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			case "symlink":
+				if err := os.Symlink(target, lockPath); err != nil {
+					t.Skipf("symlinks unavailable: %v", err)
+				}
+			case "hardlink":
+				if err := os.Link(target, lockPath); err != nil {
+					t.Skipf("hardlinks unavailable: %v", err)
+				}
+			}
+			if release, err := acquireLock(lockPath); err == nil {
+				release()
+				t.Fatal("unsafe lock path accepted")
+			}
+			if data, err := os.ReadFile(target); err != nil || !bytes.Equal(data, original) {
+				t.Fatalf("alias target changed: %q, %v", data, err)
+			}
+		})
+	}
+}

--- a/scheduler/run.go
+++ b/scheduler/run.go
@@ -14,10 +14,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
-	"syscall"
 	"time"
+
+	"github.com/openclaw/crawlkit/internal/filelock"
 )
 
 type RunOptions struct {
@@ -422,53 +422,36 @@ func ensureRuntimeDirs(paths Paths) error {
 }
 
 func acquireLock(path string) (func(), error) {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return nil, err
 	}
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	lock, err := filelock.Acquire(path)
 	if err != nil {
-		if errors.Is(err, os.ErrExist) {
-			if stale, staleErr := lockIsStale(path); staleErr == nil && stale {
-				if removeErr := os.Remove(path); removeErr != nil {
-					return nil, fmt.Errorf("remove stale crawlctl lock %s: %w", path, removeErr)
-				}
-				return acquireLock(path)
-			}
+		if errors.Is(err, filelock.ErrLocked) {
 			return nil, fmt.Errorf("crawlctl already running: %s", path)
 		}
 		return nil, err
 	}
-	_, _ = fmt.Fprintf(file, "pid=%d\nstarted_at=%s\n", os.Getpid(), time.Now().UTC().Format(time.RFC3339))
-	_ = file.Close()
-	return func() { _ = os.Remove(path) }, nil
-}
-
-func lockIsStale(path string) (bool, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return false, err
+	fail := func(err error) (func(), error) {
+		_ = lock.Close()
+		return nil, err
 	}
-	for _, line := range strings.Split(string(data), "\n") {
-		key, value, ok := strings.Cut(line, "=")
-		if !ok || key != "pid" {
-			continue
+	const protocol = "crawlkit-os-lock=1\n"
+	if !lock.Created {
+		header := make([]byte, len(protocol))
+		if _, err := lock.File.ReadAt(header, 0); err != nil || string(header) != protocol {
+			return fail(fmt.Errorf("legacy or ambiguous crawlctl lock %s: stop all old runners and archive the old lock before upgrading", path))
 		}
-		pid, err := strconv.Atoi(strings.TrimSpace(value))
-		if err != nil || pid <= 0 {
-			return true, nil
-		}
-		return !processExists(pid), nil
 	}
-	return true, nil
-}
-
-func processExists(pid int) bool {
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return false
+	// PID and timestamp are diagnostics only. The held OS lock owns exclusion.
+	data := []byte(fmt.Sprintf("%spid=%d\nstarted_at=%s\n", protocol, os.Getpid(), time.Now().UTC().Format(time.RFC3339)))
+	if _, err := lock.File.WriteAt(data, 0); err != nil {
+		return fail(err)
 	}
-	err = proc.Signal(syscall.Signal(0))
-	return err == nil || !errors.Is(err, os.ErrProcessDone)
+	if err := lock.File.Truncate(int64(len(data))); err != nil {
+		return fail(err)
+	}
+	return func() { _ = lock.Close() }, nil
 }
 
 func safeName(value string) string {

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -124,7 +124,7 @@ func TestRunRecordsHistory(t *testing.T) {
 	}
 }
 
-func TestRunRecoversInvalidStaleLock(t *testing.T) {
+func TestRunRejectsAmbiguousLegacyLockBeforeJobs(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell command path differs on windows")
 	}
@@ -139,11 +139,8 @@ func TestRunRecoversInvalidStaleLock(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Jobs["ok"] = Job{Enabled: true, Command: []string{"sh", "-c", "echo ok"}}
 	records, err := Run(context.Background(), RunOptions{Config: cfg, Paths: paths})
-	if err != nil {
-		t.Fatalf("run: %v", err)
-	}
-	if len(records) != 1 || records[0].Status != "success" {
-		t.Fatalf("records = %#v", records)
+	if err == nil || !strings.Contains(err.Error(), "legacy or ambiguous") || len(records) != 0 {
+		t.Fatalf("ambiguous old lock did not stop jobs: records=%#v, error=%v", records, err)
 	}
 }
 

--- a/snapshot/export.go
+++ b/snapshot/export.go
@@ -1,0 +1,296 @@
+package snapshot
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/openclaw/crawlkit/internal/filelock"
+)
+
+func exportSnapshot(ctx context.Context, opts ExportOptions) (result Manifest, resultErr error) {
+	if opts.DB == nil && opts.ReadTx == nil {
+		return Manifest{}, errors.New("db is required")
+	}
+	if strings.TrimSpace(opts.RootDir) == "" {
+		return Manifest{}, errors.New("root dir is required")
+	}
+	if len(opts.Tables) == 0 {
+		return Manifest{}, errors.New("at least one table is required")
+	}
+	for _, table := range opts.Tables {
+		if _, err := tableShardDir(table); err != nil {
+			return Manifest{}, err
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return Manifest{}, err
+	}
+	if err := os.MkdirAll(opts.RootDir, 0o755); err != nil {
+		return Manifest{}, err
+	}
+	lock, err := filelock.Acquire(filepath.Join(opts.RootDir, ".crawlkit-snapshot.lock"))
+	if err != nil {
+		return Manifest{}, fmt.Errorf("lock snapshot writer: %w", err)
+	}
+	defer lock.Close()
+	root, err := os.OpenRoot(opts.RootDir)
+	if err != nil {
+		return Manifest{}, err
+	}
+	defer root.Close()
+	previous, err := ReadManifest(opts.RootDir)
+	if err != nil && !errors.Is(err, ErrNoManifest) {
+		return Manifest{}, err
+	}
+	if err := root.MkdirAll(filepath.FromSlash("tables/.generations"), 0o755); err != nil {
+		return Manifest{}, err
+	}
+	var id [16]byte
+	if _, err := rand.Read(id[:]); err != nil {
+		return Manifest{}, err
+	}
+	generation := "tables/.generations/" + hex.EncodeToString(id[:])
+	if err := root.Mkdir(filepath.FromSlash(generation), 0o755); err != nil {
+		return Manifest{}, err
+	}
+	created := []string{}
+	committed := false
+	defer func() {
+		keep := managedSnapshotFiles(result)
+		for _, rel := range created {
+			if committed && keep[rel] {
+				continue
+			}
+			if err := root.Remove(filepath.FromSlash(rel)); err != nil && !errors.Is(err, os.ErrNotExist) {
+				label := "remove unpublished snapshot shard"
+				if committed {
+					label = "snapshot manifest committed; cleanup failed"
+				}
+				resultErr = errors.Join(resultErr, fmt.Errorf("%s: %w", label, err))
+			}
+		}
+	}()
+	tx := opts.ReadTx
+	if tx == nil {
+		tx, err = opts.DB.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+		if err != nil {
+			return Manifest{}, fmt.Errorf("begin export read transaction: %w", err)
+		}
+		defer tx.Rollback()
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	maxShardBytes := opts.MaxShardBytes
+	if maxShardBytes == 0 {
+		maxShardBytes = defaultMaxShardBytes
+	}
+	manifest := Manifest{
+		Version: 1, GeneratedAt: now().UTC(), Sidecars: opts.Sidecars,
+		Files: map[string]string{"manifest": ManifestName},
+	}
+	for _, table := range opts.Tables {
+		entry, err := exportTable(ctx, tx, root, generation, table, maxShardBytes, opts.Filter, opts.FilterTx,
+			func(rel string) { created = append(created, rel) })
+		if err != nil {
+			return Manifest{}, err
+		}
+		if err := reuseSnapshotShards(root, previous, &entry); err != nil {
+			return Manifest{}, err
+		}
+		manifest.Tables = append(manifest.Tables, entry)
+	}
+	if opts.ReadTx == nil {
+		if err := tx.Commit(); err != nil {
+			return Manifest{}, fmt.Errorf("finish export read transaction: %w", err)
+		}
+	}
+	if err := publishSnapshotManifest(ctx, root, manifest, hex.EncodeToString(id[:])); err != nil {
+		return Manifest{}, err
+	}
+	committed = true
+	result = manifest
+	keep := managedSnapshotFiles(manifest)
+	for rel := range managedSnapshotFiles(previous) {
+		if keep[rel] {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return result, fmt.Errorf("snapshot manifest committed; cleanup failed: %w", err)
+		}
+		if err := root.Remove(filepath.FromSlash(rel)); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return result, fmt.Errorf("snapshot manifest committed; cleanup failed: %w", err)
+		}
+	}
+	return result, nil
+}
+
+func publishSnapshotManifest(ctx context.Context, root *os.Root, manifest Manifest, generation string) error {
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := ".manifest-" + generation + ".tmp"
+	file, err := root.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	defer root.Remove(tmp)
+	defer file.Close()
+	if _, err := file.Write(append(data, '\n')); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	// No error is reported after rename: callers may only roll back before it.
+	return root.Rename(tmp, ManifestName)
+}
+
+var snapshotOrdinal = regexp.MustCompile(`^[0-9]{6,}\.jsonl\.gz$`)
+var snapshotGeneration = regexp.MustCompile(`^[0-9a-f]{32}$`)
+
+func logicalShardPath(table, physical string) (string, bool) {
+	if _, err := tableShardDir(table); err != nil {
+		return physical, false
+	}
+	parts := strings.Split(physical, "/")
+	if len(parts) == 3 && parts[0] == "tables" && parts[1] == table && snapshotOrdinal.MatchString(parts[2]) {
+		return physical, true
+	}
+	if len(parts) == 5 && parts[0] == "tables" && parts[1] == ".generations" &&
+		snapshotGeneration.MatchString(parts[2]) && parts[3] == table && snapshotOrdinal.MatchString(parts[4]) {
+		return "tables/" + table + "/" + parts[4], true
+	}
+	return physical, false
+}
+
+func logicalFileKey(table, physical string) string {
+	logical, _ := logicalShardPath(table, physical)
+	return logical
+}
+
+func sameLogicalFileManifest(table string, a, b FileManifest) bool {
+	a.Path, b.Path = logicalFileKey(table, a.Path), logicalFileKey(table, b.Path)
+	return sameFileManifest(a, b)
+}
+
+func sameLogicalFileManifests(table string, a, b []FileManifest) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !sameLogicalFileManifest(table, a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func managedSnapshotFiles(manifest Manifest) map[string]bool {
+	files := map[string]bool{}
+	for _, table := range manifest.Tables {
+		paths := table.Files
+		if len(paths) == 0 && table.File != "" {
+			paths = []string{table.File}
+		}
+		for _, rel := range paths {
+			if _, managed := logicalShardPath(table.Name, rel); managed {
+				files[rel] = true
+			}
+		}
+	}
+	return files
+}
+
+func reuseSnapshotShards(root *os.Root, previous Manifest, current *TableManifest) error {
+	owned := managedSnapshotFiles(previous)
+	prior := map[string]FileManifest{}
+	for _, table := range previous.Tables {
+		if table.Name != current.Name {
+			continue
+		}
+		for _, file := range tableFileManifests(table) {
+			if owned[file.Path] {
+				prior[logicalFileKey(table.Name, file.Path)] = file
+			}
+		}
+	}
+	for i, file := range current.FileManifests {
+		old, ok := prior[logicalFileKey(current.Name, file.Path)]
+		if !ok || !sameLogicalFileManifest(current.Name, old, file) {
+			continue
+		}
+		same, err := sameSnapshotBytes(root, old.Path, file.Path)
+		if err != nil {
+			return err
+		}
+		if same {
+			current.Files[i] = old.Path
+			current.FileManifests[i].Path = old.Path
+		}
+	}
+	return nil
+}
+
+func sameSnapshotBytes(root *os.Root, oldPath, newPath string) (bool, error) {
+	info, err := root.Stat(filepath.FromSlash(oldPath))
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !info.Mode().IsRegular() {
+		return false, nil
+	}
+	old, err := root.Open(filepath.FromSlash(oldPath))
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	defer old.Close()
+	next, err := root.Open(filepath.FromSlash(newPath))
+	if err != nil {
+		return false, err
+	}
+	defer next.Close()
+	a, b := make([]byte, 64*1024), make([]byte, 64*1024)
+	for {
+		n, errA := io.ReadFull(old, a)
+		m, errB := io.ReadFull(next, b)
+		if errA != nil && errA != io.EOF && errA != io.ErrUnexpectedEOF {
+			return false, errA
+		}
+		if errB != nil && errB != io.EOF && errB != io.ErrUnexpectedEOF {
+			return false, errB
+		}
+		if n != m || !bytes.Equal(a[:n], b[:m]) {
+			return false, nil
+		}
+		if errA != nil || errB != nil {
+			return errA == errB, nil
+		}
+	}
+}

--- a/snapshot/export_test.go
+++ b/snapshot/export_test.go
@@ -1,0 +1,300 @@
+package snapshot
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/crawlkit/internal/filelock"
+	"github.com/openclaw/crawlkit/store"
+)
+
+func exportTestDB(t *testing.T, schema string) *sql.DB {
+	t.Helper()
+	s, err := store.Open(context.Background(), store.Options{
+		Path: filepath.Join(t.TempDir(), "test.db"), Schema: schema, MaxOpenConns: 2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s.DB()
+}
+
+func packBytes(t *testing.T, root string, manifest Manifest) map[string][]byte {
+	t.Helper()
+	paths := []string{ManifestName}
+	for _, table := range manifest.Tables {
+		paths = append(paths, table.Files...)
+	}
+	out := map[string][]byte{}
+	for _, rel := range paths {
+		data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("pack file %s: %v", rel, err)
+		}
+		out[rel] = data
+	}
+	return out
+}
+
+func TestExportFailurePreservesPreviousPack(t *testing.T) {
+	db := exportTestDB(t, `create table things(id integer primary key, value text); insert into things values(1,'old');`)
+	root := t.TempDir()
+	first, err := Export(context.Background(), ExportOptions{DB: db, RootDir: root, Tables: []string{"things"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := packBytes(t, root, first)
+	mustExec(t, db, `update things set value='new'`)
+	if _, err := Export(context.Background(), ExportOptions{DB: db, RootDir: root, Tables: []string{"things", "missing"}}); err == nil {
+		t.Fatal("missing table accepted")
+	}
+	if !reflect.DeepEqual(before, packBytes(t, root, first)) {
+		t.Fatal("failed export changed prior pack")
+	}
+}
+
+func TestExportOneReadSnapshotAcrossTables(t *testing.T) {
+	db := exportTestDB(t, `create table parents(id integer, version integer); create table children(id integer, version integer);
+insert into parents values(1,1); insert into children values(1,1);`)
+	root := t.TempDir()
+	wrote := false
+	_, err := Export(context.Background(), ExportOptions{DB: db, RootDir: root, Tables: []string{"parents", "children"},
+		Filter: func(table string, row map[string]any) (bool, error) {
+			if table == "parents" && !wrote {
+				wrote = true
+				_, err := db.Exec(`begin; update parents set version=2; update children set version=2; commit;`)
+				return true, err
+			}
+			return true, nil
+		}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst := exportTestDB(t, `create table parents(id integer, version integer); create table children(id integer, version integer);`)
+	if _, err := Import(context.Background(), ImportOptions{DB: dst, RootDir: root}); err != nil {
+		t.Fatal(err)
+	}
+	var parent, child int
+	if err := dst.QueryRow(`select parents.version, children.version from parents,children`).Scan(&parent, &child); err != nil {
+		t.Fatal(err)
+	}
+	if parent != 1 || child != 1 {
+		t.Fatalf("incoherent exported versions: parent=%d child=%d", parent, child)
+	}
+}
+
+func TestExportCallerTransactionAndFilterOrder(t *testing.T) {
+	db := exportTestDB(t, `create table things(id integer primary key, value text); insert into things values(1,'old'),(2,'excluded');`)
+	db.SetMaxOpenConns(1)
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	if _, err := tx.Exec(`update things set value='uncommitted' where id=1`); err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	_, err = Export(context.Background(), ExportOptions{
+		ReadTx: tx, RootDir: t.TempDir(), Tables: []string{"things"},
+		Filter: func(_ string, row map[string]any) (bool, error) {
+			if row["id"] == int64(2) {
+				return false, nil
+			}
+			row["value"] = "legacy filter ran"
+			return true, nil
+		},
+		FilterTx: func(ctx context.Context, current *sql.Tx, _ string, row map[string]any) (bool, error) {
+			calls++
+			if current != tx || row["value"] != "legacy filter ran" {
+				t.Fatal("transaction callback ownership or ordering changed")
+			}
+			var value string
+			err := current.QueryRowContext(ctx, `select value from things where id=1`).Scan(&value)
+			if err == nil && value != "uncommitted" {
+				t.Fatalf("callback read another database view: %q", value)
+			}
+			return true, err
+		},
+	})
+	if err != nil || calls != 1 {
+		t.Fatalf("export/callback: calls=%d error=%v", calls, err)
+	}
+	if _, err := tx.Exec(`update things set value='still owned' where id=1`); err != nil {
+		t.Fatalf("export ended caller transaction: %v", err)
+	}
+	if _, err := Export(context.Background(), ExportOptions{ReadTx: tx, RootDir: t.TempDir(), Tables: []string{"missing"}}); err == nil {
+		t.Fatal("expected failed export")
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("failed export ended caller transaction: %v", err)
+	}
+	var value string
+	if err := db.QueryRow(`select value from things where id=1`).Scan(&value); err != nil || value != "old" {
+		t.Fatalf("caller rollback lost ownership: %q, %v", value, err)
+	}
+}
+
+func TestExportGenerationReuseAndExactCleanup(t *testing.T) {
+	db := exportTestDB(t, `create table things(id integer primary key, value text); insert into things values(1,'first'),(2,'second');`)
+	opts := ExportOptions{DB: db, RootDir: t.TempDir(), Tables: []string{"things"}, MaxShardBytes: 1}
+	first, err := Export(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, rel := range first.Tables[0].Files {
+		if logical, ok := logicalShardPath("things", rel); !ok || !strings.HasPrefix(rel, "tables/.generations/") || logical == rel {
+			t.Fatalf("invalid generated path: %q", rel)
+		}
+	}
+	unowned := filepath.Join(opts.RootDir, filepath.Dir(first.Tables[0].Files[0]), "unlisted.txt")
+	if err := os.WriteFile(unowned, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	same, err := Export(context.Background(), opts)
+	if err != nil || PlanIncrementalImport(first, same).Changed() || !reflect.DeepEqual(first.Tables[0].Files, same.Tables[0].Files) {
+		t.Fatalf("unchanged physical reuse/plan: %+v, %v", same, err)
+	}
+	mustExec(t, db, `insert into things values(3,'third')`)
+	appended, err := Export(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := PlanIncrementalImport(same, appended)
+	if plan.Tables[0].Mode != TableImportFiles || len(plan.Tables[0].Files) != 1 {
+		t.Fatalf("append plan: %+v", plan)
+	}
+	mustExec(t, db, `update things set value='changed third' where id=3`)
+	changed, err := Export(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if PlanIncrementalImport(appended, changed).Tables[0].Mode != TableImportReplace {
+		t.Fatal("changed-tail exact replacement contract changed")
+	}
+	if plan := PlanMergeImport(appended, changed); plan.Tables[0].Mode != TableImportFiles || len(plan.Tables[0].Files) != 1 {
+		t.Fatalf("changed-tail merge plan: %+v", plan)
+	}
+	if data, err := os.ReadFile(unowned); err != nil || string(data) != "keep" {
+		t.Fatalf("unlisted generation file removed: %q, %v", data, err)
+	}
+	oldTail := appended.Tables[0].Files[2]
+	if _, err := os.Stat(filepath.Join(opts.RootDir, oldTail)); !os.IsNotExist(err) {
+		t.Fatalf("obsolete owned shard retained: %v", err)
+	}
+}
+
+func TestExportChecksBytesBeforeLegacyReuse(t *testing.T) {
+	db := exportTestDB(t, `create table things(id integer); insert into things values(1);`)
+	opts := ExportOptions{DB: db, RootDir: t.TempDir(), Tables: []string{"things"}}
+	first, err := Export(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := "tables/things/000000.jsonl.gz"
+	if err := os.MkdirAll(filepath.Join(opts.RootDir, "tables/things"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(filepath.Join(opts.RootDir, first.Tables[0].Files[0]), filepath.Join(opts.RootDir, legacy)); err != nil {
+		t.Fatal(err)
+	}
+	first.Tables[0].Files[0], first.Tables[0].FileManifests[0].Path = legacy, legacy
+	if err := WriteManifest(opts.RootDir, first); err != nil {
+		t.Fatal(err)
+	}
+	reused, err := Export(context.Background(), opts)
+	if err != nil || reused.Tables[0].Files[0] != legacy {
+		t.Fatalf("valid legacy shard not reused: %+v, %v", reused, err)
+	}
+	if err := os.WriteFile(filepath.Join(opts.RootDir, legacy), []byte("corrupt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	repaired, err := Export(context.Background(), opts)
+	if err != nil || repaired.Tables[0].Files[0] == legacy {
+		t.Fatalf("claimed hash trusted without actual bytes: %+v, %v", repaired, err)
+	}
+}
+
+func TestExportCleanupFailureReturnsCommittedManifest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires Unix directory permissions")
+	}
+	db := exportTestDB(t, `create table things(id integer); insert into things values(1);`)
+	opts := ExportOptions{DB: db, RootDir: t.TempDir(), Tables: []string{"things"}}
+	first, err := Export(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent := filepath.Dir(filepath.Join(opts.RootDir, first.Tables[0].Files[0]))
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chmod(parent, 0o755)
+	mustExec(t, db, `insert into things values(2)`)
+	result, err := Export(context.Background(), opts)
+	if err == nil || !strings.Contains(err.Error(), "committed; cleanup failed") {
+		t.Fatalf("cleanup outcome = %v", err)
+	}
+	actual, readErr := ReadManifest(opts.RootDir)
+	if readErr != nil || result.Version != 1 || !reflect.DeepEqual(actual, result) {
+		t.Fatalf("missing committed manifest: %+v, %v", result, readErr)
+	}
+}
+
+func TestExportHeldLockAndRootConfinement(t *testing.T) {
+	db := exportTestDB(t, `create table things(id integer); insert into things values(1);`)
+	root := t.TempDir()
+	lock, err := filelock.Acquire(filepath.Join(root, ".crawlkit-snapshot.lock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.Close()
+	opts := ExportOptions{DB: db, RootDir: root, Tables: []string{"things"}}
+	if _, err := Export(context.Background(), opts); err == nil {
+		t.Fatal("held writer lock ignored")
+	}
+	_ = lock.Close()
+	outside := t.TempDir()
+	sentinel := filepath.Join(outside, "retained")
+	if err := os.WriteFile(sentinel, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "tables")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if _, err := Export(context.Background(), opts); err == nil {
+		t.Fatal("output followed an outside-root table directory")
+	}
+	if data, err := os.ReadFile(sentinel); err != nil || !bytes.Equal(data, []byte("outside")) {
+		t.Fatalf("outside directory changed: %q, %v", data, err)
+	}
+}
+
+func TestPlanStrictGenerationLogicalMatching(t *testing.T) {
+	file := FileManifest{Path: "tables/things/000000.jsonl.gz", Rows: 1, Size: 50, SHA256: "same"}
+	table := TableManifest{Name: "things", Columns: []string{"id"}, FileManifests: []FileManifest{file}}
+	generated := "tables/.generations/" + strings.Repeat("a", 32) + "/things/000000.jsonl.gz"
+	for _, rel := range []string{generated, strings.Replace(generated, "aaaa", "AAAA", 1), strings.Replace(generated, "/things/", "/other/", 1), strings.Replace(generated, "000000", "0", 1)} {
+		current := table
+		next := file
+		next.Path = rel
+		current.FileManifests = []FileManifest{next}
+		for _, merge := range []bool{false, true} {
+			plan := planTableIncrement(table, current, merge)
+			if (plan.Mode == TableImportSkip) != (rel == generated) {
+				t.Fatalf("logical matching %q merge=%v: %+v", rel, merge, plan)
+			}
+		}
+	}
+	if _, managed := logicalShardPath("..", "tables/../000000.jsonl.gz"); managed {
+		t.Fatal("unsafe manifest table made a path appear exporter-owned")
+	}
+}

--- a/snapshot/import_dependencies.go
+++ b/snapshot/import_dependencies.go
@@ -1,0 +1,79 @@
+package snapshot
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Generic DELETE and INSERT OR REPLACE can change rows in tables omitted by
+// an incremental plan. Inspect the destination before any caller hooks mutate it.
+// Dependency-aware custom callbacks retain responsibility for their own writes.
+func checkIncrementalDependencies(ctx context.Context, tx *sql.Tx, plan ImportPlan, opts IncrementalImportOptions) error {
+	checked := make(map[string]bool)
+	for _, table := range plan.Tables {
+		generic := false
+		switch table.Mode {
+		case TableImportSkip:
+			continue
+		case TableImportReplace:
+			hasFiles := len(table.Table.Files) > 0 || strings.TrimSpace(table.Table.File) != ""
+			generic = opts.DeleteTable == nil || (opts.ImportRow == nil && hasFiles)
+		case TableImportFiles:
+			generic = opts.ImportRow == nil && len(table.Files) > 0
+		default:
+			return fmt.Errorf("unknown table import mode %q for %s", table.Mode, table.Table.Name)
+		}
+		name := table.Table.Name
+		if !generic || checked[name] {
+			continue
+		}
+		if err := checkGenericImportTable(ctx, tx, name); err != nil {
+			return err
+		}
+		checked[name] = true
+	}
+	return nil
+}
+
+func checkGenericImportTable(ctx context.Context, tx *sql.Tx, table string) error {
+	// The generic path supports main-schema tables. Refuse shadowed/other-schema
+	// targets rather than checking one table and mutating another.
+	var mainTable, shadowed bool
+	if err := tx.QueryRowContext(ctx, `select
+exists(select 1 from main.sqlite_schema where type='table' and name=? collate nocase),
+exists(select 1 from temp.sqlite_schema where type in ('table','view') and name=? collate nocase)`,
+		table, table).Scan(&mainTable, &shadowed); err != nil {
+		return fmt.Errorf("inspect incremental target %s: %w", table, err)
+	}
+	if !mainTable || shadowed {
+		return fmt.Errorf("incremental table %s requires an unshadowed main-schema table or dependency-aware custom callbacks", table)
+	}
+
+	var child, action string
+	err := tx.QueryRowContext(ctx, `select s.name, f."on_delete"
+from main.sqlite_schema as s, pragma_foreign_key_list(s.name, 'main') as f
+where s.type='table' and f."table"=? collate nocase
+and f."on_delete" in ('CASCADE','SET NULL','SET DEFAULT') limit 1`, table).Scan(&child, &action)
+	if err == nil {
+		return fmt.Errorf("incremental table %s has unsupported ON DELETE %s dependency from %s; use dependency-aware custom callbacks", table, action, child)
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("inspect incremental foreign keys for %s: %w", table, err)
+	}
+
+	var trigger string
+	err = tx.QueryRowContext(ctx, `select name from (
+select name, tbl_name from main.sqlite_schema where type='trigger'
+union all select name, tbl_name from temp.sqlite_schema where type='trigger'
+) where tbl_name=? collate nocase limit 1`, table).Scan(&trigger)
+	if err == nil {
+		return fmt.Errorf("incremental table %s has unsupported trigger %s; use dependency-aware custom callbacks", table, trigger)
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("inspect incremental triggers for %s: %w", table, err)
+	}
+	return nil
+}

--- a/snapshot/import_dependencies_test.go
+++ b/snapshot/import_dependencies_test.go
@@ -1,0 +1,214 @@
+package snapshot
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func dependencyFixture(t *testing.T, action string, exportedChild bool) (*sql.DB, IncrementalImportOptions) {
+	t.Helper()
+	schema := `create table things(id integer primary key, value text);
+create table children(id integer primary key, parent_id integer references THINGS(id) on delete ` + action + `);`
+	src := exportTestDB(t, schema+`insert into things values(1,'first'); insert into children values(1,1);`)
+	tables := []string{"things"}
+	if exportedChild {
+		tables = append(tables, "children")
+	}
+	root := t.TempDir()
+	export := ExportOptions{DB: src, RootDir: root, Tables: tables}
+	first, err := Export(context.Background(), export)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst := exportTestDB(t, schema)
+	if _, err := Import(context.Background(), ImportOptions{DB: dst, RootDir: root}); err != nil {
+		t.Fatal(err)
+	}
+	mustExec(t, dst, `insert into children values(2,1)`)
+	mustExec(t, src, `update things set value='second'`)
+	current, err := Export(context.Background(), export)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dst, IncrementalImportOptions{DB: dst, RootDir: root, Previous: first, Current: current}
+}
+
+func assertDependencyRows(t *testing.T, db *sql.DB, wantChildren int, wantValue string) {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`select count(*) from children where parent_id=1`).Scan(&count); err != nil || count != wantChildren {
+		t.Fatalf("dependent history changed: count=%d err=%v", count, err)
+	}
+	var value string
+	if err := db.QueryRow(`select value from things where id=1`).Scan(&value); err != nil || value != wantValue {
+		t.Fatalf("parent value=%q err=%v", value, err)
+	}
+}
+
+func TestIncrementalRejectsDestructiveForeignKeysBeforeHooks(t *testing.T) {
+	for _, action := range []string{"CASCADE", "SET NULL", "SET DEFAULT"} {
+		for _, exportedChild := range []bool{false, true} {
+			for _, merge := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/child=%t/merge=%t", action, exportedChild, merge), func(t *testing.T) {
+					db, opts := dependencyFixture(t, action, exportedChild)
+					if merge {
+						opts.Plan = PlanMergeImport(opts.Previous, opts.Current)
+						if opts.Plan.Tables[0].Mode != TableImportFiles {
+							t.Fatal("fixture did not exercise partial-file INSERT OR REPLACE")
+						}
+					}
+					hookCalled := false
+					opts.BeforeImport = func(context.Context, *sql.Tx) error { hookCalled = true; return nil }
+					_, _, err := ImportIncremental(context.Background(), opts)
+					if err == nil || !strings.Contains(err.Error(), "ON DELETE "+action) || hookCalled {
+						t.Fatalf("dependency not refused before hooks: err=%v hook=%v", err, hookCalled)
+					}
+					count := 1
+					if exportedChild {
+						count++
+					}
+					assertDependencyRows(t, db, count, "first")
+				})
+			}
+		}
+	}
+}
+
+func TestIncrementalDependencyAwareCallbacks(t *testing.T) {
+	db, opts := dependencyFixture(t, "CASCADE", true)
+	upsert := func(ctx context.Context, tx *sql.Tx, _ string, row map[string]any) error {
+		_, err := tx.ExecContext(ctx, `insert into things(id,value) values(?,?)
+on conflict(id) do update set value=excluded.value`, row["id"], row["value"])
+		return err
+	}
+	noDelete := func(context.Context, *sql.Tx, string) error { return nil }
+	opts.ImportRow = upsert
+	if _, _, err := ImportIncremental(context.Background(), opts); err == nil {
+		t.Fatal("custom importer did not protect the remaining generic delete")
+	}
+	opts.ImportRow = nil
+	opts.DeleteTable = noDelete
+	if _, _, err := ImportIncremental(context.Background(), opts); err == nil {
+		t.Fatal("custom delete did not protect the remaining generic replacement")
+	}
+	assertDependencyRows(t, db, 2, "first")
+	opts.ImportRow = upsert
+	if _, _, err := ImportIncremental(context.Background(), opts); err != nil {
+		t.Fatalf("dependency-aware callbacks refused: %v", err)
+	}
+	assertDependencyRows(t, db, 2, "second")
+}
+
+func TestIncrementalRestrictiveForeignKeysRollBack(t *testing.T) {
+	for _, action := range []string{"RESTRICT", "NO ACTION"} {
+		t.Run(action, func(t *testing.T) {
+			db, opts := dependencyFixture(t, action, true)
+			mustExec(t, db, `create table hooks(value text)`)
+			called := false
+			opts.BeforeImport = func(ctx context.Context, tx *sql.Tx) error {
+				called = true
+				_, err := tx.ExecContext(ctx, `insert into hooks values('before')`)
+				return err
+			}
+			if _, _, err := ImportIncremental(context.Background(), opts); err == nil || !called {
+				t.Fatalf("expected ordinary constraint failure, not cascade preflight: err=%v called=%v", err, called)
+			}
+			assertDependencyRows(t, db, 2, "first")
+			var count int
+			if err := db.QueryRow(`select count(*) from hooks`).Scan(&count); err != nil || count != 0 {
+				t.Fatalf("constraint failure did not roll back hook: %d %v", count, err)
+			}
+		})
+	}
+}
+
+func TestIncrementalRejectsTriggersBeforeHooks(t *testing.T) {
+	for _, temporary := range []bool{false, true} {
+		t.Run(fmt.Sprint(temporary), func(t *testing.T) {
+			src := exportTestDB(t, `create table things(id integer primary key, value text); insert into things values(1,'second');`)
+			root := t.TempDir()
+			current, err := Export(context.Background(), ExportOptions{DB: src, RootDir: root, Tables: []string{"things"}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			dst := exportTestDB(t, `create table things(id integer primary key, value text); insert into things values(1,'first');
+create table children(id integer primary key, parent_id integer); insert into children values(1,1);`)
+			dst.SetMaxOpenConns(1)
+			prefix := ""
+			if temporary {
+				prefix = "temp "
+			}
+			mustExec(t, dst, `create `+prefix+`trigger remove_child after delete on THINGS begin delete from children; end`)
+			hookCalled := false
+			_, _, err = ImportIncremental(context.Background(), IncrementalImportOptions{
+				DB: dst, RootDir: root, Current: current,
+				Plan:         ImportPlan{Tables: []TableImportPlan{{Table: current.Tables[0], Mode: TableImportReplace}}},
+				BeforeImport: func(context.Context, *sql.Tx) error { hookCalled = true; return nil },
+			})
+			if err == nil || !strings.Contains(err.Error(), "trigger") || hookCalled {
+				t.Fatalf("trigger not refused before hooks: err=%v hook=%v", err, hookCalled)
+			}
+			assertDependencyRows(t, dst, 1, "first")
+		})
+	}
+}
+
+func TestIncrementalRefusesShadowedGenericTarget(t *testing.T) {
+	db := exportTestDB(t, `create table things(id integer);`)
+	db.SetMaxOpenConns(1)
+	mustExec(t, db, `create temp table things(id integer); insert into things values(7)`)
+	hookCalled := false
+	_, _, err := ImportIncremental(context.Background(), IncrementalImportOptions{
+		DB: db, Current: Manifest{Version: 1, Tables: []TableManifest{{Name: "things"}}},
+		Plan:         ImportPlan{Tables: []TableImportPlan{{Table: TableManifest{Name: "things"}, Mode: TableImportReplace}}},
+		BeforeImport: func(context.Context, *sql.Tx) error { hookCalled = true; return nil },
+	})
+	if err == nil || !strings.Contains(err.Error(), "unshadowed") || hookCalled {
+		t.Fatalf("shadowed target not refused: err=%v hook=%v", err, hookCalled)
+	}
+	var id int
+	if err := db.QueryRow(`select id from things`).Scan(&id); err != nil || id != 7 {
+		t.Fatalf("shadowed table mutated: %d %v", id, err)
+	}
+}
+
+func TestIncrementalEmptyReplacementCustomDelete(t *testing.T) {
+	for _, file := range []string{"", " \t "} {
+		t.Run(fmt.Sprintf("file=%q", file), func(t *testing.T) {
+			db := exportTestDB(t, `create table things(id integer primary key, value text);
+create table children(id integer primary key, parent_id integer references things(id) on delete cascade);
+insert into things values(1,'retained'); insert into children values(1,1);`)
+			table := TableManifest{Name: "things", File: file}
+			hookCalled, deleteCalled := false, false
+			opts := IncrementalImportOptions{
+				DB: db, Current: Manifest{Version: 1, Tables: []TableManifest{table}},
+				Plan:         ImportPlan{Tables: []TableImportPlan{{Table: table, Mode: TableImportReplace}}},
+				BeforeImport: func(context.Context, *sql.Tx) error { hookCalled = true; return nil },
+			}
+			if _, _, err := ImportIncremental(context.Background(), opts); err == nil || hookCalled {
+				t.Fatalf("empty replacement still needs a safe delete: err=%v hook=%v", err, hookCalled)
+			}
+			opts.DeleteTable = func(context.Context, *sql.Tx, string) error { deleteCalled = true; return nil }
+			if _, _, err := ImportIncremental(context.Background(), opts); err != nil || !deleteCalled || !hookCalled {
+				t.Fatalf("unused ImportRow callback required: err=%v delete=%v hook=%v", err, deleteCalled, hookCalled)
+			}
+			assertDependencyRows(t, db, 1, "retained")
+		})
+	}
+}
+
+func TestIncrementalLegacyFileStillNeedsSafeImporter(t *testing.T) {
+	db, opts := dependencyFixture(t, "CASCADE", true)
+	table := opts.Current.Tables[0]
+	table.File = table.Files[0]
+	table.Files = nil
+	opts.Plan = ImportPlan{Tables: []TableImportPlan{{Table: table, Mode: TableImportReplace}}}
+	opts.DeleteTable = func(context.Context, *sql.Tx, string) error { return nil }
+	if _, _, err := ImportIncremental(context.Background(), opts); err == nil {
+		t.Fatal("legacy singular file can still execute a generic replacement")
+	}
+	assertDependencyRows(t, db, 2, "first")
+}

--- a/snapshot/integrity_test.go
+++ b/snapshot/integrity_test.go
@@ -1,0 +1,752 @@
+package snapshot
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/crawlkit/store"
+)
+
+func TestImportIntegrityValidMetadata(t *testing.T) {
+	for _, mode := range []string{"full", "replace", "merge"} {
+		for _, metadata := range []string{"complete", "hash only", "size only", "rows only", "metadata only", "reordered", "aliased Files", "aliased File", "legacy Files", "legacy File"} {
+			t.Run(mode+"/"+metadata, func(t *testing.T) {
+				root, manifest := integritySnapshot(t,
+					[]map[string]any{{"id": "one", "body": "first"}},
+					[]map[string]any{{"id": "two", "body": "second"}},
+				)
+				table := &manifest.Tables[0]
+				wantRows := 2
+				switch metadata {
+				case "hash only":
+					for i := range table.FileManifests {
+						table.FileManifests[i].Size = 0
+					}
+				case "size only":
+					for i := range table.FileManifests {
+						table.FileManifests[i].SHA256 = ""
+					}
+				case "rows only":
+					for i := range table.FileManifests {
+						table.FileManifests[i].Size = 0
+						table.FileManifests[i].SHA256 = ""
+					}
+				case "metadata only":
+					table.Files = nil
+				case "reordered":
+					table.FileManifests[0], table.FileManifests[1] = table.FileManifests[1], table.FileManifests[0]
+				case "aliased Files":
+					table.Files[0] = "tables/things/x/../000000.jsonl.gz"
+				case "aliased File":
+					table.File = "tables/things/x/../000000.jsonl.gz"
+					table.Files = table.Files[:1]
+					table.FileManifests = table.FileManifests[:1]
+					table.Rows = 1
+					wantRows = 1
+				case "legacy Files":
+					table.FileManifests = nil
+					table.Rows = 0
+				case "legacy File":
+					table.File = table.Files[1]
+					table.Files = nil
+					table.FileManifests = nil
+					table.Rows = 0
+					wantRows = 1
+				}
+				db := integrityDB(t)
+				if err := runIntegrityImport(t, mode, manifest, ImportOptions{DB: db, RootDir: root}); err != nil {
+					t.Fatal(err)
+				}
+				assertIntegrityCount(t, db, `select count(*) from things where id != 'old'`, wantRows)
+				wantOld := 0
+				if mode == "merge" {
+					wantOld = 1
+				}
+				assertIntegrityCount(t, db, `select count(*) from things where id = 'old'`, wantOld)
+			})
+		}
+	}
+}
+
+func TestImportIntegrityCountsDecodedRowsBeforeCallbacks(t *testing.T) {
+	for _, mode := range []string{"full", "replace", "merge"} {
+		t.Run(mode, func(t *testing.T) {
+			root, manifest := integritySnapshot(t, []map[string]any{
+				{"id": "one", "body": "keep"},
+				{},
+				nil,
+				{"id": "filtered", "body": "skip"},
+				{"id": "ignored", "body": "skip"},
+			}, nil)
+			db := integrityDB(t)
+			filterCalls, importCalls := 0, 0
+			var progress []ImportProgress
+			err := runIntegrityImport(t, mode, manifest, ImportOptions{
+				DB: db, RootDir: root,
+				Filter: func(_ string, row map[string]any) (bool, error) {
+					filterCalls++
+					return row["id"] != "filtered", nil
+				},
+				ImportRow: func(ctx context.Context, tx *sql.Tx, table string, row map[string]any) error {
+					importCalls++
+					if row["id"] == "ignored" {
+						return nil
+					}
+					return insertRow(ctx, tx, table, row)
+				},
+				Progress: func(event ImportProgress) { progress = append(progress, event) },
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if filterCalls != 3 || importCalls != 2 {
+				t.Fatalf("filter calls = %d, import calls = %d", filterCalls, importCalls)
+			}
+			assertIntegrityCount(t, db, `select count(*) from things where id != 'old'`, 1)
+			if got := progress[len(progress)-1]; got.Phase != "table_done" || got.Rows != 2 || got.TotalRows != 5 {
+				t.Fatalf("table progress = %+v", got)
+			}
+		})
+	}
+}
+
+func TestImportIntegrityRollsBackBadLaterFile(t *testing.T) {
+	for _, mode := range []string{"full", "replace", "merge"} {
+		for _, corruption := range []struct {
+			name string
+			want string
+		}{
+			{"hash", "compressed SHA256 mismatch"},
+			{"size small", "compressed size mismatch"},
+			{"size large", "compressed size mismatch"},
+			{"negative size", "compressed size mismatch"},
+			{"rows zero", "row count mismatch"},
+			{"rows large", "row count mismatch"},
+			{"truncated gzip", "unexpected EOF"},
+			{"gzip checksum", "invalid checksum"},
+			{"legacy truncated gzip", "unexpected EOF"},
+		} {
+			t.Run(mode+"/"+corruption.name, func(t *testing.T) {
+				root, manifest := integritySnapshot(t,
+					[]map[string]any{{"id": "one", "body": "first"}},
+					[]map[string]any{{"id": "two", "body": "second"}},
+				)
+				bad := &manifest.Tables[0].FileManifests[1]
+				switch corruption.name {
+				case "hash":
+					bad.SHA256 = strings.Repeat("0", 64)
+				case "size small":
+					bad.Size--
+				case "size large":
+					bad.Size++
+				case "negative size":
+					bad.Size = -1
+				case "rows zero":
+					bad.Rows = 0
+					manifest.Tables[0].Rows = 1
+				case "rows large":
+					bad.Rows = 2
+					manifest.Tables[0].Rows = 3
+				default:
+					path := filepath.Join(root, filepath.FromSlash(bad.Path))
+					data, err := os.ReadFile(path)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if corruption.name == "gzip checksum" {
+						data[len(data)-8] ^= 1
+					} else {
+						data = data[:len(data)-1]
+					}
+					if err := os.WriteFile(path, data, 0o600); err != nil {
+						t.Fatal(err)
+					}
+					if corruption.name == "legacy truncated gzip" {
+						manifest.Tables[0].FileManifests = nil
+					}
+				}
+				db := integrityDB(t)
+				beforeCalled, deleteCalled, afterCalled := false, false, false
+				var imported []string
+				var progress []ImportProgress
+				err := runIntegrityImport(t, mode, manifest, ImportOptions{
+					DB: db, RootDir: root,
+					BeforeImport: func(ctx context.Context, tx *sql.Tx) error {
+						beforeCalled = true
+						_, err := tx.ExecContext(ctx, `insert into audit values ('before')`)
+						return err
+					},
+					DeleteTable: func(ctx context.Context, tx *sql.Tx, table string) error {
+						deleteCalled = true
+						if _, err := tx.ExecContext(ctx, `insert into audit values ('delete')`); err != nil {
+							return err
+						}
+						return deleteImportTable(ctx, tx, table, nil)
+					},
+					ImportRow: func(ctx context.Context, tx *sql.Tx, table string, row map[string]any) error {
+						imported = append(imported, row["id"].(string))
+						if _, err := tx.ExecContext(ctx, `insert into audit values ('row')`); err != nil {
+							return err
+						}
+						return insertRow(ctx, tx, table, row)
+					},
+					AfterImport: func(ctx context.Context, tx *sql.Tx) error {
+						afterCalled = true
+						_, err := tx.ExecContext(ctx, `insert into audit values ('after')`)
+						return err
+					},
+					Progress: func(event ImportProgress) { progress = append(progress, event) },
+				})
+				if err == nil || !strings.Contains(err.Error(), corruption.want) {
+					t.Fatalf("error = %v, want %q", err, corruption.want)
+				}
+				if !strings.Contains(err.Error(), manifest.Tables[0].Files[1]) {
+					t.Fatalf("error does not identify bad shard: %v", err)
+				}
+				if !beforeCalled || deleteCalled != (mode != "merge") || afterCalled {
+					t.Fatalf("hooks: before=%t delete=%t after=%t", beforeCalled, deleteCalled, afterCalled)
+				}
+				if len(imported) == 0 || imported[0] != "one" {
+					t.Fatalf("first file was not imported before failure: %v", imported)
+				}
+				done := 0
+				for _, event := range progress {
+					if event.Phase == "file_done" {
+						done++
+						if event.File != manifest.Tables[0].Files[0] {
+							t.Fatalf("corrupt file reported done: %+v", event)
+						}
+					}
+					if event.Phase == "table_done" {
+						t.Fatalf("failed table reported done: %+v", event)
+					}
+				}
+				if done != 1 {
+					t.Fatalf("completed files = %d", done)
+				}
+				assertIntegrityCount(t, db, `select count(*) from things`, 1)
+				assertIntegrityCount(t, db, `select count(*) from things where id = 'old' and body = 'original'`, 1)
+				assertIntegrityCount(t, db, `select count(*) from audit`, 0)
+			})
+		}
+	}
+}
+
+func TestImportIntegrityRejectsInconsistentPaths(t *testing.T) {
+	for _, mode := range []string{"full", "replace", "merge", "skip"} {
+		for _, mismatch := range []string{"missing entry", "extra entry", "missing path", "wrong path", "duplicate metadata", "duplicate file", "conflicting File"} {
+			t.Run(mode+"/"+mismatch, func(t *testing.T) {
+				root, manifest := integritySnapshot(t,
+					[]map[string]any{{"id": "one", "body": "first"}},
+					[]map[string]any{{"id": "two", "body": "second"}},
+				)
+				table := &manifest.Tables[0]
+				switch mismatch {
+				case "missing entry":
+					table.FileManifests = table.FileManifests[:1]
+				case "extra entry":
+					table.Files = table.Files[:1]
+				case "missing path":
+					table.FileManifests[1].Path = ""
+				case "wrong path":
+					table.FileManifests[1].Path = "other.jsonl.gz"
+				case "duplicate metadata":
+					table.FileManifests[1] = table.FileManifests[0]
+				case "duplicate file":
+					table.Files[1] = table.Files[0]
+				case "conflicting File":
+					table.File = "other.jsonl.gz"
+				}
+				db := integrityDB(t)
+				err := runIntegrityImport(t, mode, manifest, ImportOptions{DB: db, RootDir: root})
+				if err == nil || !strings.Contains(err.Error(), "table things:") {
+					t.Fatalf("expected manifest metadata error, got %v", err)
+				}
+				assertIntegrityCount(t, db, `select count(*) from things`, 1)
+				assertIntegrityCount(t, db, `select count(*) from things where id = 'old'`, 1)
+			})
+		}
+	}
+}
+
+func TestImportIntegrityLegacyPartialPlan(t *testing.T) {
+	for _, field := range []string{"File", "Files"} {
+		t.Run(field, func(t *testing.T) {
+			root, manifest := integritySnapshot(t,
+				[]map[string]any{{"id": "one", "body": "first"}},
+				[]map[string]any{{"id": "two", "body": "second"}},
+			)
+			table := &manifest.Tables[0]
+			table.FileManifests = nil
+			table.Rows = 0
+			if field == "File" {
+				table.File = table.Files[1]
+				table.Files = nil
+			}
+			files := tableFileManifests(*table)
+			plan := ImportPlan{Tables: []TableImportPlan{{
+				Table: *table,
+				Mode:  TableImportFiles,
+				Files: files[len(files)-1:],
+			}}}
+			db := integrityDB(t)
+			if _, _, err := ImportIncremental(context.Background(), IncrementalImportOptions{
+				DB: db, RootDir: root, Current: manifest, Plan: plan,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			assertIntegrityCount(t, db, `select count(*) from things`, 2)
+			assertIntegrityCount(t, db, `select count(*) from things where id in ('old', 'two')`, 2)
+		})
+	}
+}
+
+func TestImportIntegrityRejectsInconsistentRows(t *testing.T) {
+	for _, mode := range []string{"full", "replace", "merge", "skip"} {
+		for _, mismatch := range []string{"missing last shard", "zero total", "small total", "large total", "negative total", "negative file rows", "overflow"} {
+			t.Run(mode+"/"+mismatch, func(t *testing.T) {
+				root, manifest := integritySnapshot(t,
+					[]map[string]any{{"id": "one", "body": "first"}},
+					[]map[string]any{{"id": "two", "body": "second"}},
+				)
+				table := &manifest.Tables[0]
+				switch mismatch {
+				case "missing last shard":
+					table.Files = table.Files[:1]
+					table.FileManifests = table.FileManifests[:1]
+				case "zero total":
+					table.Rows = 0
+				case "small total":
+					table.Rows = 1
+				case "large total":
+					table.Rows = 3
+				case "negative total":
+					table.Rows = -1
+				case "negative file rows":
+					table.FileManifests[1].Rows = -1
+				case "overflow":
+					table.Rows = int(^uint(0) >> 1)
+					table.FileManifests[0].Rows = table.Rows
+				}
+				db := integrityDB(t)
+				afterCalled := false
+				err := runIntegrityImport(t, mode, manifest, ImportOptions{
+					DB: db, RootDir: root,
+					BeforeImport: func(ctx context.Context, tx *sql.Tx) error {
+						_, err := tx.ExecContext(ctx, `insert into audit values ('before')`)
+						return err
+					},
+					AfterImport: func(context.Context, *sql.Tx) error {
+						afterCalled = true
+						return nil
+					},
+				})
+				if err == nil || !strings.Contains(err.Error(), "table things:") || !strings.Contains(err.Error(), "row count") {
+					t.Fatalf("expected table row count error, got %v", err)
+				}
+				if afterCalled {
+					t.Fatal("AfterImport called with invalid table row count")
+				}
+				assertIntegrityCount(t, db, `select count(*) from things`, 1)
+				assertIntegrityCount(t, db, `select count(*) from things where id = 'old' and body = 'original'`, 1)
+				assertIntegrityCount(t, db, `select count(*) from audit`, 0)
+			})
+		}
+	}
+}
+
+func TestImportIntegrityRejectsStrippedPlannedMetadata(t *testing.T) {
+	root, manifest := integritySnapshot(t, []map[string]any{{"id": "one", "body": "first"}})
+	table := manifest.Tables[0]
+	plan := ImportPlan{Tables: []TableImportPlan{{
+		Table: table,
+		Mode:  TableImportFiles,
+		Files: []FileManifest{{Path: table.Files[0]}},
+	}}}
+	db := integrityDB(t)
+	_, _, err := ImportIncremental(context.Background(), IncrementalImportOptions{
+		DB: db, RootDir: root, Current: manifest, Plan: plan,
+	})
+	if err == nil || !strings.Contains(err.Error(), "inconsistent planned file manifest") {
+		t.Fatalf("expected planned metadata error, got %v", err)
+	}
+	assertIntegrityCount(t, db, `select count(*) from things where id = 'old'`, 1)
+}
+
+func TestImportIntegrityBindsSuppliedPlanToCurrentManifest(t *testing.T) {
+	for _, mode := range []TableImportMode{TableImportReplace, TableImportFiles} {
+		for _, metadata := range []string{"stripped", "forged"} {
+			t.Run(string(mode)+"/"+metadata, func(t *testing.T) {
+				root, current := integritySnapshot(t, []map[string]any{{"id": "one", "body": "first"}})
+				table := current.Tables[0]
+				path := filepath.Join(root, filepath.FromSlash(table.Files[0]))
+				data, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				// Changing the gzip mtime preserves rows and size but changes its hash.
+				data[4] ^= 1
+				if err := os.WriteFile(path, data, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				files := []FileManifest{{Path: table.Files[0]}}
+				table.FileManifests = nil
+				table.Rows = 0
+				if metadata == "forged" {
+					files[0] = current.Tables[0].FileManifests[0]
+					files[0].SHA256 = fmt.Sprintf("%x", sha256.Sum256(data))
+					table.FileManifests = files
+					table.Rows = files[0].Rows
+				}
+				plan := ImportPlan{Tables: []TableImportPlan{{Table: table, Mode: mode, Files: files}}}
+				db := integrityDB(t)
+				afterCalled := false
+				_, _, err = ImportIncremental(context.Background(), IncrementalImportOptions{
+					DB: db, RootDir: root, Current: current, Plan: plan,
+					BeforeImport: func(ctx context.Context, tx *sql.Tx) error {
+						_, err := tx.ExecContext(ctx, `insert into audit values ('before')`)
+						return err
+					},
+					AfterImport: func(context.Context, *sql.Tx) error {
+						afterCalled = true
+						return nil
+					},
+				})
+				want := "compressed SHA256 mismatch"
+				if mode == TableImportFiles {
+					want = "inconsistent planned file manifest"
+				}
+				if err == nil || !strings.Contains(err.Error(), want) {
+					t.Fatalf("error = %v, want %q", err, want)
+				}
+				if afterCalled {
+					t.Fatal("AfterImport called for a corrupt supplied plan")
+				}
+				assertIntegrityCount(t, db, `select count(*) from things`, 1)
+				assertIntegrityCount(t, db, `select count(*) from things where id = 'old' and body = 'original'`, 1)
+				assertIntegrityCount(t, db, `select count(*) from audit`, 0)
+				if metadata == "stripped" && len(plan.Tables[0].Table.FileManifests) != 0 {
+					t.Fatal("import mutated the caller's plan metadata")
+				}
+			})
+		}
+	}
+}
+
+func TestImportIntegrityRejectsPlanTableAbsentFromCurrent(t *testing.T) {
+	root, current := integritySnapshot(t, []map[string]any{{"id": "one", "body": "first"}})
+	plan := PlanMergeImport(Manifest{Version: current.Version}, current)
+	plan.Tables[0].Table.Name = "missing"
+	db := integrityDB(t)
+	_, _, err := ImportIncremental(context.Background(), IncrementalImportOptions{
+		DB: db, RootDir: root, Current: current, Plan: plan,
+	})
+	if err == nil || !strings.Contains(err.Error(), `planned table "missing" is not in the current manifest`) {
+		t.Fatalf("expected missing plan table error, got %v", err)
+	}
+	assertIntegrityCount(t, db, `select count(*) from things where id = 'old'`, 1)
+}
+
+func TestImportIntegrityRejectsShadowedCurrentTable(t *testing.T) {
+	root, current := integritySnapshot(t, []map[string]any{{"id": "one", "body": "first"}})
+	legacy := current.Tables[0]
+	legacy.FileManifests = nil
+	current.Tables = append(current.Tables, legacy)
+	db := integrityDB(t)
+	_, _, err := ImportIncremental(context.Background(), IncrementalImportOptions{
+		DB: db, RootDir: root, Current: current, Previous: Manifest{Version: current.Version},
+	})
+	if err == nil || !strings.Contains(err.Error(), `duplicate table "things" in the current manifest`) {
+		t.Fatalf("expected duplicate current table error, got %v", err)
+	}
+	assertIntegrityCount(t, db, `select count(*) from things where id = 'old'`, 1)
+}
+
+func TestImportIntegrityRejectsInvalidLegacyPlanPaths(t *testing.T) {
+	for _, field := range []string{"File", "Files"} {
+		for _, invalid := range []string{"undeclared", "duplicate"} {
+			t.Run(field+"/"+invalid, func(t *testing.T) {
+				root, current := integritySnapshot(t,
+					[]map[string]any{{"id": "one", "body": "first"}},
+					[]map[string]any{{"id": "two", "body": "second"}},
+				)
+				table := &current.Tables[0]
+				knownPath := table.Files[0]
+				table.FileManifests = nil
+				table.Rows = 0
+				if field == "File" {
+					table.File = knownPath
+					table.Files = nil
+				}
+				selected := []FileManifest{{Path: knownPath}}
+				if invalid == "undeclared" {
+					rel := "tables/things/undeclared.jsonl.gz"
+					writeGzipJSONL(t, filepath.Join(root, filepath.FromSlash(rel)), map[string]any{"id": "rogue", "body": "undeclared"})
+					selected = append(selected, FileManifest{Path: rel})
+				} else {
+					selected = append(selected, selected[0])
+				}
+				plan := ImportPlan{Tables: []TableImportPlan{{
+					Table: *table, Mode: TableImportFiles, Files: selected,
+				}}}
+				db := integrityDB(t)
+				afterCalled := false
+				_, _, err := ImportIncremental(context.Background(), IncrementalImportOptions{
+					DB: db, RootDir: root, Current: current, Plan: plan,
+					BeforeImport: func(ctx context.Context, tx *sql.Tx) error {
+						_, err := tx.ExecContext(ctx, `insert into audit values ('before')`)
+						return err
+					},
+					AfterImport: func(context.Context, *sql.Tx) error {
+						afterCalled = true
+						return nil
+					},
+				})
+				if err == nil || !strings.Contains(err.Error(), "inconsistent planned file manifest") {
+					t.Fatalf("expected invalid legacy plan path error, got %v", err)
+				}
+				if afterCalled {
+					t.Fatal("AfterImport called with invalid legacy plan paths")
+				}
+				assertIntegrityCount(t, db, `select count(*) from things`, 1)
+				assertIntegrityCount(t, db, `select count(*) from things where id = 'old' and body = 'original'`, 1)
+				assertIntegrityCount(t, db, `select count(*) from audit`, 0)
+			})
+		}
+	}
+}
+
+func TestImportIntegrityRejectsNegativeLegacyRows(t *testing.T) {
+	for _, mode := range []string{"full", "replace", "merge", "skip"} {
+		for _, field := range []string{"File", "Files", "no files"} {
+			t.Run(mode+"/"+field, func(t *testing.T) {
+				root, current := integritySnapshot(t, []map[string]any{{"id": "one", "body": "first"}})
+				table := &current.Tables[0]
+				table.FileManifests = nil
+				table.Rows = -1
+				if field == "File" {
+					table.File = table.Files[0]
+					table.Files = nil
+				} else if field == "no files" {
+					table.Files = nil
+				}
+				db := integrityDB(t)
+				err := runIntegrityImport(t, mode, current, ImportOptions{DB: db, RootDir: root})
+				if err == nil || !strings.Contains(err.Error(), "negative row count") {
+					t.Fatalf("expected negative legacy row count error, got %v", err)
+				}
+				assertIntegrityCount(t, db, `select count(*) from things`, 1)
+				assertIntegrityCount(t, db, `select count(*) from things where id = 'old' and body = 'original'`, 1)
+			})
+		}
+	}
+}
+
+func TestImportIntegrityRejectsDuplicateActivePlans(t *testing.T) {
+	for _, legacy := range []bool{false, true} {
+		for _, first := range []TableImportMode{TableImportFiles, TableImportReplace} {
+			for _, second := range []TableImportMode{TableImportFiles, TableImportReplace} {
+				t.Run(fmt.Sprintf("legacy=%t/%s/%s", legacy, first, second), func(t *testing.T) {
+					root, current := integritySnapshot(t, []map[string]any{{"id": "one", "body": "first"}})
+					if legacy {
+						current.Tables[0].FileManifests = nil
+						current.Tables[0].Rows = 0
+					}
+					table := current.Tables[0]
+					files := tableFileManifests(table)
+					plan := ImportPlan{Tables: []TableImportPlan{
+						{Table: table, Mode: first, Files: files},
+						{Table: table, Mode: second, Files: files},
+					}}
+					db := integrityDB(t)
+					beforeCalled := false
+					_, _, err := ImportIncremental(context.Background(), IncrementalImportOptions{
+						DB: db, RootDir: root, Current: current, Plan: plan,
+						BeforeImport: func(context.Context, *sql.Tx) error {
+							beforeCalled = true
+							return nil
+						},
+					})
+					if err == nil || !strings.Contains(err.Error(), `duplicate active plan for table "things"`) {
+						t.Fatalf("expected duplicate active plan error, got %v", err)
+					}
+					if beforeCalled {
+						t.Fatal("BeforeImport called before rejecting duplicate active plans")
+					}
+					assertIntegrityCount(t, db, `select count(*) from things`, 1)
+					assertIntegrityCount(t, db, `select count(*) from things where id = 'old' and body = 'original'`, 1)
+				})
+			}
+		}
+	}
+}
+
+func TestImportIntegrityRejectsAliasedManifestPaths(t *testing.T) {
+	for _, mode := range []string{"full", "replace", "merge", "skip"} {
+		for _, metadata := range []string{"modern", "legacy", "Files only"} {
+			t.Run(mode+"/"+metadata, func(t *testing.T) {
+				root, current := integritySnapshot(t, []map[string]any{{"id": "one", "body": "first"}})
+				table := &current.Tables[0]
+				alias := table.FileManifests[0]
+				alias.Path = "tables/things/x/../000000.jsonl.gz"
+				table.Files = append(table.Files, alias.Path)
+				if metadata == "legacy" {
+					table.FileManifests = nil
+					table.Rows = 0
+				} else if metadata == "modern" {
+					table.FileManifests = append(table.FileManifests, alias)
+					table.Rows += alias.Rows
+				}
+				db := integrityDB(t)
+				afterCalled := false
+				err := runIntegrityImport(t, mode, current, ImportOptions{
+					DB: db, RootDir: root,
+					BeforeImport: func(ctx context.Context, tx *sql.Tx) error {
+						_, err := tx.ExecContext(ctx, `insert into audit values ('before')`)
+						return err
+					},
+					AfterImport: func(context.Context, *sql.Tx) error {
+						afterCalled = true
+						return nil
+					},
+				})
+				if err == nil || !strings.Contains(err.Error(), "table things:") {
+					t.Fatalf("expected duplicate shard path error, got %v", err)
+				}
+				if afterCalled {
+					t.Fatal("AfterImport called for duplicate shard paths")
+				}
+				assertIntegrityCount(t, db, `select count(*) from things`, 1)
+				assertIntegrityCount(t, db, `select count(*) from things where id = 'old' and body = 'original'`, 1)
+				assertIntegrityCount(t, db, `select count(*) from audit`, 0)
+			})
+		}
+	}
+}
+
+func TestImportIntegrityAliasedPlanPaths(t *testing.T) {
+	for _, metadata := range []string{"modern", "legacy File", "legacy Files"} {
+		for _, duplicate := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/duplicate=%t", metadata, duplicate), func(t *testing.T) {
+				root, current := integritySnapshot(t, []map[string]any{{"id": "one", "body": "first"}})
+				table := &current.Tables[0]
+				if metadata != "modern" {
+					table.FileManifests = nil
+					table.Rows = 0
+				}
+				if metadata == "legacy File" {
+					table.File = table.Files[0]
+					table.Files = nil
+				}
+				original := tableFileManifests(*table)[0]
+				alias := original
+				alias.Path = "tables/things/x/../000000.jsonl.gz"
+				selected := []FileManifest{alias}
+				if duplicate {
+					selected = append(selected, original)
+				}
+				plan := ImportPlan{Tables: []TableImportPlan{{
+					Table: *table, Mode: TableImportFiles, Files: selected,
+				}}}
+				db := integrityDB(t)
+				_, _, err := ImportIncremental(context.Background(), IncrementalImportOptions{
+					DB: db, RootDir: root, Current: current, Plan: plan,
+					ImportRow: func(ctx context.Context, tx *sql.Tx, table string, row map[string]any) error {
+						_, err := tx.ExecContext(ctx, `insert into audit values ('row')`)
+						return err
+					},
+				})
+				wantRows := 1
+				if duplicate {
+					wantRows = 0
+					if err == nil || !strings.Contains(err.Error(), "inconsistent planned file manifest") {
+						t.Fatalf("expected duplicate planned shard error, got %v", err)
+					}
+				} else if err != nil {
+					t.Fatal(err)
+				}
+				assertIntegrityCount(t, db, `select count(*) from audit`, wantRows)
+				assertIntegrityCount(t, db, `select count(*) from things where id = 'old' and body = 'original'`, 1)
+			})
+		}
+	}
+}
+
+func integritySnapshot(t *testing.T, shards ...[]map[string]any) (string, Manifest) {
+	t.Helper()
+	root := t.TempDir()
+	table := TableManifest{Name: "things", Columns: []string{"id", "body"}}
+	for i, rows := range shards {
+		rel := fmt.Sprintf("tables/things/%06d.jsonl.gz", i)
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		writeGzipJSONL(t, path, rows...)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		table.Files = append(table.Files, rel)
+		table.FileManifests = append(table.FileManifests, FileManifest{
+			Path: rel, Rows: len(rows), Size: int64(len(data)), SHA256: fmt.Sprintf("%x", sha256.Sum256(data)),
+		})
+		table.Rows += len(rows)
+	}
+	return root, Manifest{Version: 1, Tables: []TableManifest{table}}
+}
+
+func integrityDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := store.Open(context.Background(), store.Options{
+		Path: filepath.Join(t.TempDir(), "dst.db"),
+		Schema: `create table things(id text primary key, body text not null);
+create table audit(event text not null);`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	mustExec(t, db.DB(), `insert into things values ('old', 'original')`)
+	return db.DB()
+}
+
+func runIntegrityImport(t *testing.T, mode string, manifest Manifest, opts ImportOptions) error {
+	t.Helper()
+	ctx := context.Background()
+	if mode == "full" {
+		if err := WriteManifest(opts.RootDir, manifest); err != nil {
+			t.Fatal(err)
+		}
+		_, err := Import(ctx, opts)
+		return err
+	}
+	previous := Manifest{Version: manifest.Version}
+	plan := PlanIncrementalImport(previous, manifest)
+	if mode == "merge" {
+		plan = PlanMergeImport(previous, manifest)
+	} else if mode == "skip" {
+		previous = manifest
+		plan = PlanIncrementalImport(previous, manifest)
+	}
+	_, _, err := ImportIncremental(ctx, IncrementalImportOptions{
+		DB: opts.DB, RootDir: opts.RootDir, Previous: previous, Current: manifest, Plan: plan,
+		DeleteTable: opts.DeleteTable, Filter: opts.Filter, ImportRow: opts.ImportRow, Progress: opts.Progress,
+		BeforeImport: opts.BeforeImport, AfterImport: opts.AfterImport,
+	})
+	return err
+}
+
+func assertIntegrityCount(t *testing.T, db *sql.DB, query string, want int) {
+	t.Helper()
+	var got int
+	if err := db.QueryRow(query).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("%s: got %d, want %d", query, got, want)
+	}
+}

--- a/snapshot/sidecar.go
+++ b/snapshot/sidecar.go
@@ -38,12 +38,19 @@ func SyncSidecarTree(ctx context.Context, opts SidecarTreeOptions) ([]Sidecar, e
 		return nil, err
 	}
 	targetRoot := filepath.Join(root, filepath.FromSlash(targetRel))
-	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
-		return nil, fmt.Errorf("create sidecar target: %w", err)
-	}
 	sourceRoot, err := filepath.EvalSymlinks(source)
 	if err != nil {
 		return nil, fmt.Errorf("resolve sidecar source: %w", err)
+	}
+	sourceInfo, err := os.Stat(sourceRoot)
+	if err != nil {
+		return nil, fmt.Errorf("stat sidecar source: %w", err)
+	}
+	if !sourceInfo.IsDir() {
+		return nil, fmt.Errorf("sidecar source is not a directory: %s", source)
+	}
+	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
+		return nil, fmt.Errorf("create sidecar target: %w", err)
 	}
 	targetRoot, err = filepath.EvalSymlinks(targetRoot)
 	if err != nil {
@@ -54,14 +61,14 @@ func SyncSidecarTree(ctx context.Context, opts SidecarTreeOptions) ([]Sidecar, e
 	}
 	keep := map[string]struct{}{}
 	var sidecars []Sidecar
-	err = filepath.WalkDir(source, func(sourcePath string, entry os.DirEntry, walkErr error) error {
+	err = filepath.WalkDir(sourceRoot, func(sourcePath string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if sourcePath == source || entry.IsDir() {
+		if sourcePath == sourceRoot || entry.IsDir() {
 			return nil
 		}
 		if entry.Type()&os.ModeSymlink != 0 {
@@ -74,7 +81,7 @@ func SyncSidecarTree(ctx context.Context, opts SidecarTreeOptions) ([]Sidecar, e
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("sidecar source is not a regular file: %s", sourcePath)
 		}
-		rel, err := filepath.Rel(source, sourcePath)
+		rel, err := filepath.Rel(sourceRoot, sourcePath)
 		if err != nil {
 			return err
 		}

--- a/snapshot/sidecar_test.go
+++ b/snapshot/sidecar_test.go
@@ -1,0 +1,53 @@
+package snapshot
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSyncSidecarTreeRootAliasesAndInvalidRoots(t *testing.T) {
+	source := t.TempDir()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "page.txt"), []byte("retained"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	opts := SidecarTreeOptions{SourceDir: source, RootDir: root, TargetDir: "pages"}
+	if _, err := SyncSidecarTree(context.Background(), opts); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(t.TempDir(), "alias")
+	if err := os.Symlink(source, alias); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	opts.SourceDir = alias
+	sidecars, err := SyncSidecarTree(context.Background(), opts)
+	if err != nil || len(sidecars) != 1 {
+		t.Fatalf("root symlink: sidecars=%v, error=%v", sidecars, err)
+	}
+	for _, invalid := range []string{filepath.Join(source, "page.txt"), filepath.Join(source, "missing")} {
+		opts.SourceDir = invalid
+		if _, err := SyncSidecarTree(context.Background(), opts); err == nil {
+			t.Errorf("invalid source %q accepted", invalid)
+		}
+		got, err := os.ReadFile(filepath.Join(root, "pages", "page.txt"))
+		if err != nil || string(got) != "retained" {
+			t.Fatalf("previous sidecar lost: %q, error=%v", got, err)
+		}
+	}
+}
+
+func TestSyncSidecarTreeInvalidRootDoesNotCreateTarget(t *testing.T) {
+	root := t.TempDir()
+	_, err := SyncSidecarTree(context.Background(), SidecarTreeOptions{
+		SourceDir: filepath.Join(root, "missing"),
+		RootDir:   root, TargetDir: "pages",
+	})
+	if err == nil {
+		t.Fatal("missing source accepted")
+	}
+	if _, err := os.Stat(filepath.Join(root, "pages")); !os.IsNotExist(err) {
+		t.Fatalf("invalid source created target: %v", err)
+	}
+}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -26,11 +26,14 @@ const ManifestName = "manifest.json"
 const defaultMaxShardBytes int64 = 40 * 1024 * 1024
 
 type ExportOptions struct {
-	DB            *sql.DB
+	DB *sql.DB
+	// ReadTx is optional and caller-owned. Export never commits or rolls it back.
+	ReadTx        *sql.Tx
 	RootDir       string
 	Tables        []string
 	MaxShardBytes int64
 	Filter        RowFilter
+	FilterTx      RowFilterTx
 	Sidecars      []Sidecar
 	Now           func() time.Time
 }
@@ -48,6 +51,10 @@ type ImportOptions struct {
 }
 
 type RowFilter func(table string, row map[string]any) (bool, error)
+
+// RowFilterTx runs after Filter for admitted rows, using the export transaction.
+// It must not mutate the database or end the transaction.
+type RowFilterTx func(ctx context.Context, tx *sql.Tx, table string, row map[string]any) (bool, error)
 
 type RowImportFunc func(ctx context.Context, tx *sql.Tx, table string, row map[string]any) error
 
@@ -141,47 +148,7 @@ type IncrementalImportOptions struct {
 }
 
 func Export(ctx context.Context, opts ExportOptions) (Manifest, error) {
-	if opts.DB == nil {
-		return Manifest{}, errors.New("db is required")
-	}
-	if strings.TrimSpace(opts.RootDir) == "" {
-		return Manifest{}, errors.New("root dir is required")
-	}
-	if len(opts.Tables) == 0 {
-		return Manifest{}, errors.New("at least one table is required")
-	}
-	now := opts.Now
-	if now == nil {
-		now = func() time.Time { return time.Now().UTC() }
-	}
-	maxShardBytes := opts.MaxShardBytes
-	if maxShardBytes == 0 {
-		maxShardBytes = defaultMaxShardBytes
-	}
-	tablesDir := filepath.Join(opts.RootDir, "tables")
-	if err := os.RemoveAll(tablesDir); err != nil {
-		return Manifest{}, fmt.Errorf("reset tables dir: %w", err)
-	}
-	if err := os.MkdirAll(tablesDir, 0o755); err != nil {
-		return Manifest{}, fmt.Errorf("create tables dir: %w", err)
-	}
-	manifest := Manifest{
-		Version:     1,
-		GeneratedAt: now().UTC(),
-		Sidecars:    opts.Sidecars,
-		Files:       map[string]string{"manifest": ManifestName},
-	}
-	for _, table := range opts.Tables {
-		entry, err := exportTable(ctx, opts.DB, opts.RootDir, table, maxShardBytes, opts.Filter)
-		if err != nil {
-			return Manifest{}, err
-		}
-		manifest.Tables = append(manifest.Tables, entry)
-	}
-	if err := WriteManifest(opts.RootDir, manifest); err != nil {
-		return Manifest{}, err
-	}
-	return manifest, nil
+	return exportSnapshot(ctx, opts)
 }
 
 func Import(ctx context.Context, opts ImportOptions) (Manifest, error) {
@@ -434,12 +401,13 @@ func WriteManifest(rootDir string, manifest Manifest) error {
 	return nil
 }
 
-func exportTable(ctx context.Context, db *sql.DB, rootDir, table string, maxShardBytes int64, filter RowFilter) (TableManifest, error) {
+func exportTable(ctx context.Context, tx *sql.Tx, root *os.Root, generation, table string, maxShardBytes int64, filter RowFilter, filterTx RowFilterTx, created func(string)) (TableManifest, error) {
 	relDir, err := tableShardDir(table)
 	if err != nil {
 		return TableManifest{}, err
 	}
-	rows, err := db.QueryContext(ctx, "select * from "+store.QuoteIdent(table))
+	relDir = generation + "/" + table
+	rows, err := tx.QueryContext(ctx, "select * from "+store.QuoteIdent(table))
 	if err != nil {
 		return TableManifest{}, fmt.Errorf("query table %s: %w", table, err)
 	}
@@ -449,11 +417,12 @@ func exportTable(ctx context.Context, db *sql.DB, rootDir, table string, maxShar
 		return TableManifest{}, err
 	}
 	writer := &shardWriter{
-		rootDir:       rootDir,
+		root:          root,
 		relDir:        relDir,
 		maxShardBytes: maxShardBytes,
+		created:       created,
 	}
-	if err := os.MkdirAll(filepath.Join(rootDir, filepath.FromSlash(relDir)), 0o755); err != nil {
+	if err := root.MkdirAll(filepath.FromSlash(relDir), 0o755); err != nil {
 		return TableManifest{}, fmt.Errorf("create table dir %s: %w", table, err)
 	}
 	defer writer.close()
@@ -476,6 +445,15 @@ func exportTable(ctx context.Context, db *sql.DB, rootDir, table string, maxShar
 			keep, err := filter(table, row)
 			if err != nil {
 				return TableManifest{}, fmt.Errorf("filter table %s: %w", table, err)
+			}
+			if !keep {
+				continue
+			}
+		}
+		if filterTx != nil {
+			keep, err := filterTx(ctx, tx, table, row)
+			if err != nil {
+				return TableManifest{}, fmt.Errorf("filter table %s in export transaction: %w", table, err)
 			}
 			if !keep {
 				continue
@@ -622,7 +600,8 @@ func insertRow(ctx context.Context, tx *sql.Tx, table string, row map[string]any
 }
 
 type shardWriter struct {
-	rootDir       string
+	root          *os.Root
+	created       func(string)
 	relDir        string
 	maxShardBytes int64
 	nextShard     int
@@ -647,11 +626,11 @@ func (w *shardWriter) Write(p []byte) (int, error) {
 
 func (w *shardWriter) open() error {
 	rel := filepath.ToSlash(filepath.Join(w.relDir, fmt.Sprintf("%06d.jsonl.gz", w.nextShard)))
-	path := filepath.Join(w.rootDir, filepath.FromSlash(rel))
-	file, err := os.Create(path)
+	file, err := w.root.OpenFile(filepath.FromSlash(rel), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		return fmt.Errorf("create %s: %w", rel, err)
 	}
+	w.created(rel)
 	w.nextShard++
 	w.rowsInShard = 0
 	w.files = append(w.files, rel)
@@ -693,6 +672,9 @@ func (w *shardWriter) close() error {
 		w.gz = nil
 	}
 	if w.file != nil {
+		if err := w.file.Sync(); err != nil && closeErr == nil {
+			closeErr = err
+		}
 		if err := w.file.Close(); err != nil && closeErr == nil {
 			closeErr = err
 		}
@@ -747,7 +729,7 @@ func planTableIncrement(previous, current TableManifest, merge bool) TableImport
 	if !allFilesHaveFingerprints(previousFiles) || !allFilesHaveFingerprints(currentFiles) {
 		return TableImportPlan{Table: current, Mode: TableImportReplace, Files: currentFiles, Reason: "missing file fingerprints"}
 	}
-	if sameFileManifests(previousFiles, currentFiles) {
+	if sameLogicalFileManifests(current.Name, previousFiles, currentFiles) {
 		return TableImportPlan{Table: current, Mode: TableImportSkip, Reason: "unchanged"}
 	}
 	if merge {
@@ -757,7 +739,7 @@ func planTableIncrement(previous, current TableManifest, merge bool) TableImport
 		return TableImportPlan{Table: current, Mode: TableImportReplace, Files: currentFiles, Reason: "files removed"}
 	}
 	for i := 0; i < len(previousFiles)-1; i++ {
-		if !sameFileManifest(previousFiles[i], currentFiles[i]) {
+		if !sameLogicalFileManifest(current.Name, previousFiles[i], currentFiles[i]) {
 			return TableImportPlan{Table: current, Mode: TableImportReplace, Files: currentFiles, Reason: "non-tail file changed"}
 		}
 	}
@@ -765,10 +747,10 @@ func planTableIncrement(previous, current TableManifest, merge bool) TableImport
 	if len(previousFiles) > 0 {
 		oldTail := previousFiles[len(previousFiles)-1]
 		newTail := currentFiles[len(previousFiles)-1]
-		if oldTail.Path != newTail.Path {
+		if logicalFileKey(current.Name, oldTail.Path) != logicalFileKey(current.Name, newTail.Path) {
 			return TableImportPlan{Table: current, Mode: TableImportReplace, Files: currentFiles, Reason: "tail path changed"}
 		}
-		if !sameFileManifest(oldTail, newTail) {
+		if !sameLogicalFileManifest(current.Name, oldTail, newTail) {
 			return TableImportPlan{Table: current, Mode: TableImportReplace, Files: currentFiles, Reason: "tail file changed"}
 		}
 	}
@@ -784,19 +766,20 @@ func planTableIncrement(previous, current TableManifest, merge bool) TableImport
 func planTableMerge(previousFiles, currentFiles []FileManifest, current TableManifest) TableImportPlan {
 	previousByPath := make(map[string]FileManifest, len(previousFiles))
 	for _, file := range previousFiles {
-		previousByPath[file.Path] = file
+		previousByPath[logicalFileKey(current.Name, file.Path)] = file
 	}
 	currentPaths := make(map[string]struct{}, len(currentFiles))
 	changed := make([]FileManifest, 0, len(currentFiles))
 	for _, file := range currentFiles {
-		currentPaths[file.Path] = struct{}{}
-		previous, ok := previousByPath[file.Path]
-		if !ok || !sameFileManifest(previous, file) {
+		key := logicalFileKey(current.Name, file.Path)
+		currentPaths[key] = struct{}{}
+		previous, ok := previousByPath[key]
+		if !ok || !sameLogicalFileManifest(current.Name, previous, file) {
 			changed = append(changed, file)
 		}
 	}
 	for _, file := range previousFiles {
-		if _, ok := currentPaths[file.Path]; !ok {
+		if _, ok := currentPaths[logicalFileKey(current.Name, file.Path)]; !ok {
 			return TableImportPlan{Table: current, Mode: TableImportReplace, Files: currentFiles, Reason: "files removed"}
 		}
 	}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -426,7 +426,6 @@ func exportTable(ctx context.Context, tx *sql.Tx, root *os.Root, generation, tab
 		return TableManifest{}, fmt.Errorf("create table dir %s: %w", table, err)
 	}
 	defer writer.close()
-	enc := json.NewEncoder(writer)
 	count := 0
 	for rows.Next() {
 		values := make([]any, len(cols))
@@ -438,8 +437,12 @@ func exportTable(ctx context.Context, tx *sql.Tx, root *os.Root, generation, tab
 			return TableManifest{}, fmt.Errorf("scan table %s: %w", table, err)
 		}
 		row := make(map[string]any, len(cols))
+		blobs := make(map[string]string)
 		for i, col := range cols {
 			row[col] = exportValue(values[i])
+			if blob, ok := values[i].([]byte); ok {
+				blobs[col] = string(blob)
+			}
 		}
 		if filter != nil {
 			keep, err := filter(table, row)
@@ -459,11 +462,15 @@ func exportTable(ctx context.Context, tx *sql.Tx, root *os.Root, generation, tab
 				continue
 			}
 		}
+		data, err := encodeSnapshotRow(row, blobs)
+		if err != nil {
+			return TableManifest{}, fmt.Errorf("encode table %s: %w", table, err)
+		}
 		if err := writer.rotateIfNeeded(); err != nil {
 			return TableManifest{}, err
 		}
-		if err := enc.Encode(row); err != nil {
-			return TableManifest{}, fmt.Errorf("encode table %s: %w", table, err)
+		if _, err := writer.Write(data); err != nil {
+			return TableManifest{}, fmt.Errorf("write table %s: %w", table, err)
 		}
 		count++
 		if err := writer.finishRow(); err != nil {
@@ -526,8 +533,8 @@ func importJSONLGzip(ctx context.Context, tx *sql.Tx, reader io.Reader, table st
 	scanner.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)
 	rows := 0
 	for scanner.Scan() {
-		var row map[string]any
-		if err := json.Unmarshal(scanner.Bytes(), &row); err != nil {
+		row, err := decodeSnapshotRow(scanner.Bytes(), false)
+		if err != nil {
 			return rows, fmt.Errorf("decode %s row: %w", table, err)
 		}
 		if len(row) == 0 {

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -339,6 +339,16 @@ func ImportIncremental(ctx context.Context, opts IncrementalImportOptions) (Mani
 			return Manifest{}, ImportPlan{}, err
 		}
 	}
+	currentTables := make(map[string]TableManifest, len(current.Tables))
+	for _, table := range current.Tables {
+		if _, exists := currentTables[table.Name]; exists {
+			return Manifest{}, ImportPlan{}, fmt.Errorf("duplicate table %q in the current manifest", table.Name)
+		}
+		if _, err := importFileManifests(table); err != nil {
+			return Manifest{}, ImportPlan{}, err
+		}
+		currentTables[table.Name] = table
+	}
 	plan := opts.Plan
 	if len(plan.Tables) == 0 && !plan.Full && plan.Reason == "" {
 		plan = PlanIncrementalImport(opts.Previous, current)
@@ -348,6 +358,16 @@ func ImportIncremental(ctx context.Context, opts IncrementalImportOptions) (Mani
 	}
 	if !plan.Changed() {
 		return current, plan, nil
+	}
+	activeTables := make(map[string]bool, len(plan.Tables))
+	for _, tablePlan := range plan.Tables {
+		if tablePlan.Mode == TableImportSkip {
+			continue
+		}
+		if activeTables[tablePlan.Table.Name] {
+			return Manifest{}, plan, fmt.Errorf("duplicate active plan for table %q", tablePlan.Table.Name)
+		}
+		activeTables[tablePlan.Table.Name] = true
 	}
 	tx, err := opts.DB.BeginTx(ctx, nil)
 	if err != nil {
@@ -365,6 +385,14 @@ func ImportIncremental(ctx context.Context, opts IncrementalImportOptions) (Mani
 		}
 	}
 	for _, tablePlan := range plan.Tables {
+		if tablePlan.Mode != TableImportSkip {
+			table, ok := currentTables[tablePlan.Table.Name]
+			if !ok {
+				return Manifest{}, plan, fmt.Errorf("planned table %q is not in the current manifest", tablePlan.Table.Name)
+			}
+			// Plans select work; only the current manifest supplies integrity metadata.
+			tablePlan.Table = table
+		}
 		switch tablePlan.Mode {
 		case TableImportSkip:
 			continue
@@ -378,11 +406,10 @@ func ImportIncremental(ctx context.Context, opts IncrementalImportOptions) (Mani
 			}
 			reportImportProgress(opts.Progress, ImportProgress{Phase: "table_done", Table: tablePlan.Table.Name, Rows: rows, TotalRows: tablePlan.Table.Rows})
 		case TableImportFiles:
-			table := tablePlan.Table
-			table.File = ""
-			table.Files = fileManifestPaths(tablePlan.Files)
-			table.FileManifests = tablePlan.Files
-			table.Rows = fileManifestRows(tablePlan.Files)
+			table, err := selectImportFiles(tablePlan)
+			if err != nil {
+				return Manifest{}, plan, err
+			}
 			rows, err := importTable(ctx, tx, opts.RootDir, table, opts.Filter, opts.ImportRow, opts.Progress)
 			if err != nil {
 				return Manifest{}, plan, err
@@ -502,16 +529,17 @@ func exportTable(ctx context.Context, db *sql.DB, rootDir, table string, maxShar
 }
 
 func importTable(ctx context.Context, tx *sql.Tx, rootDir string, table TableManifest, filter RowFilter, importRow RowImportFunc, progress func(ImportProgress)) (int, error) {
-	files := table.Files
-	if len(files) == 0 && strings.TrimSpace(table.File) != "" {
-		files = []string{table.File}
+	files, err := importFileManifests(table)
+	if err != nil {
+		return 0, err
 	}
 	if len(files) == 0 {
 		return 0, nil
 	}
 	reportImportProgress(progress, ImportProgress{Phase: "table_start", Table: table.Name, FileCount: len(files), TotalRows: table.Rows})
 	totalRows := 0
-	for index, rel := range files {
+	for index, entry := range files {
+		rel := entry.Path
 		path, err := confinedSnapshotFile(rootDir, rel)
 		if err != nil {
 			return totalRows, err
@@ -522,10 +550,14 @@ func importTable(ctx context.Context, tx *sql.Tx, rootDir string, table TableMan
 		}
 		fileProgress := ImportProgress{Phase: "file_start", Table: table.Name, File: rel, FileIndex: index + 1, FileCount: len(files), TotalRows: table.Rows}
 		reportImportProgress(progress, fileProgress)
-		rows, err := importJSONLGzip(ctx, tx, file, table.Name, filter, importRow)
+		var expected *FileManifest
+		if len(table.FileManifests) > 0 {
+			expected = &entry
+		}
+		rows, err := importJSONLGzip(ctx, tx, file, table.Name, filter, importRow, expected)
 		if err != nil {
 			_ = file.Close()
-			return totalRows, err
+			return totalRows, fmt.Errorf("import %s: %w", rel, err)
 		}
 		if err := file.Close(); err != nil {
 			return totalRows, fmt.Errorf("close %s: %w", rel, err)
@@ -538,7 +570,12 @@ func importTable(ctx context.Context, tx *sql.Tx, rootDir string, table TableMan
 	return totalRows, nil
 }
 
-func importJSONLGzip(ctx context.Context, tx *sql.Tx, reader io.Reader, table string, filter RowFilter, importRow RowImportFunc) (int, error) {
+func importJSONLGzip(ctx context.Context, tx *sql.Tx, reader io.Reader, table string, filter RowFilter, importRow RowImportFunc, expected *FileManifest) (int, error) {
+	hasher := sha256.New()
+	counter := &countingWriter{w: hasher}
+	if expected != nil {
+		reader = io.TeeReader(reader, counter)
+	}
 	gz, err := gzip.NewReader(reader)
 	if err != nil {
 		return 0, fmt.Errorf("open gzip for %s: %w", table, err)
@@ -547,11 +584,13 @@ func importJSONLGzip(ctx context.Context, tx *sql.Tx, reader io.Reader, table st
 	scanner := bufio.NewScanner(gz)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)
 	rows := 0
+	decodedRows := 0
 	for scanner.Scan() {
 		var row map[string]any
 		if err := json.Unmarshal(scanner.Bytes(), &row); err != nil {
 			return rows, fmt.Errorf("decode %s row: %w", table, err)
 		}
+		decodedRows++
 		if len(row) == 0 {
 			continue
 		}
@@ -573,8 +612,20 @@ func importJSONLGzip(ctx context.Context, tx *sql.Tx, reader io.Reader, table st
 		}
 		rows++
 	}
+	// Scan through gzip EOF: Close alone does not verify the gzip checksum.
 	if err := scanner.Err(); err != nil {
 		return rows, fmt.Errorf("scan %s rows: %w", table, err)
+	}
+	if expected != nil {
+		if expected.Size != 0 && counter.n != expected.Size {
+			return rows, fmt.Errorf("compressed size mismatch: got %d, want %d", counter.n, expected.Size)
+		}
+		if expected.SHA256 != "" && !strings.EqualFold(hex.EncodeToString(hasher.Sum(nil)), expected.SHA256) {
+			return rows, errors.New("compressed SHA256 mismatch")
+		}
+		if decodedRows != expected.Rows {
+			return rows, fmt.Errorf("row count mismatch: got %d, want %d", decodedRows, expected.Rows)
+		}
 	}
 	return rows, nil
 }
@@ -841,6 +892,113 @@ func tableFileManifests(table TableManifest) []FileManifest {
 		out = append(out, FileManifest{Path: file})
 	}
 	return out
+}
+
+func importFileManifests(table TableManifest) ([]FileManifest, error) {
+	if table.Rows < 0 {
+		return nil, fmt.Errorf("table %s: negative row count", table.Name)
+	}
+	entries := tableFileManifests(table)
+	modern := len(table.FileManifests) > 0
+	remainingRows := table.Rows
+	byPath := make(map[string]FileManifest, len(entries))
+	for _, file := range entries {
+		// Use the same lexical path identity as opening the shard.
+		key, err := confinedSnapshotFile(".", file.Path)
+		if err != nil {
+			return nil, fmt.Errorf("table %s: %w", table.Name, err)
+		}
+		if _, exists := byPath[key]; exists {
+			return nil, fmt.Errorf("table %s: duplicate file manifest path %q", table.Name, file.Path)
+		}
+		byPath[key] = file
+		if modern {
+			if file.Rows < 0 {
+				return nil, fmt.Errorf("table %s: negative row count for %q", table.Name, file.Path)
+			}
+			// Subtract from the declared total to avoid overflowing a sum of rows.
+			if file.Rows > remainingRows {
+				return nil, fmt.Errorf("table %s: row count does not match file manifests", table.Name)
+			}
+			remainingRows -= file.Rows
+		}
+	}
+	if !modern {
+		// Legacy table totals remain advisory, including positive values.
+		return entries, nil
+	}
+	if remainingRows != 0 {
+		return nil, fmt.Errorf("table %s: row count does not match file manifests", table.Name)
+	}
+	paths := table.Files
+	if table.File != "" {
+		key, err := confinedSnapshotFile(".", table.File)
+		if err != nil {
+			return nil, fmt.Errorf("table %s: %w", table.Name, err)
+		}
+		if len(paths) == 0 {
+			paths = []string{table.File}
+		} else if len(paths) != 1 {
+			return nil, fmt.Errorf("table %s: inconsistent file paths", table.Name)
+		} else if listedKey, err := confinedSnapshotFile(".", paths[0]); err != nil || listedKey != key {
+			return nil, fmt.Errorf("table %s: inconsistent file paths", table.Name)
+		}
+	}
+	if len(paths) == 0 {
+		paths = fileManifestPaths(table.FileManifests)
+	}
+	files := make([]FileManifest, 0, len(paths))
+	for _, path := range paths {
+		key, err := confinedSnapshotFile(".", path)
+		if err != nil {
+			return nil, fmt.Errorf("table %s: %w", table.Name, err)
+		}
+		file, ok := byPath[key]
+		if !ok {
+			return nil, fmt.Errorf("table %s: missing file manifest for %q", table.Name, path)
+		}
+		file.Path = path
+		files = append(files, file)
+		delete(byPath, key)
+	}
+	if len(byPath) != 0 {
+		return nil, fmt.Errorf("table %s: file manifests do not match file paths", table.Name)
+	}
+	return files, nil
+}
+
+func selectImportFiles(plan TableImportPlan) (TableManifest, error) {
+	table := plan.Table
+	files, err := importFileManifests(table)
+	if err != nil {
+		return TableManifest{}, err
+	}
+	modern := len(table.FileManifests) > 0
+	byPath := make(map[string]FileManifest, len(files))
+	for _, file := range files {
+		key, _ := confinedSnapshotFile(".", file.Path) // Validated above.
+		byPath[key] = file
+	}
+	for _, file := range plan.Files {
+		key, err := confinedSnapshotFile(".", file.Path)
+		if err != nil {
+			return TableManifest{}, fmt.Errorf("table %s: %w", table.Name, err)
+		}
+		expected, ok := byPath[key]
+		expected.Path = file.Path
+		if !ok || (modern && !sameFileManifest(file, expected)) {
+			return TableManifest{}, fmt.Errorf("table %s: inconsistent planned file manifest for %q", table.Name, file.Path)
+		}
+		delete(byPath, key)
+	}
+	if modern {
+		table.FileManifests = plan.Files
+	}
+	// Legacy plans synthesize zero-valued metadata; those rows are unknown.
+	table.File = ""
+	table.Files = fileManifestPaths(plan.Files)
+	table.Rows = fileManifestRows(plan.Files)
+	return table, nil
 }
 
 func allFilesHaveFingerprints(files []FileManifest) bool {

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -326,6 +326,9 @@ func ImportIncremental(ctx context.Context, opts IncrementalImportOptions) (Mani
 			_ = tx.Rollback()
 		}
 	}()
+	if err := checkIncrementalDependencies(ctx, tx, plan, opts); err != nil {
+		return Manifest{}, plan, err
+	}
 	if opts.BeforeImport != nil {
 		if err := opts.BeforeImport(ctx, tx); err != nil {
 			return Manifest{}, plan, err

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -985,18 +985,6 @@ func allFilesHaveFingerprints(files []FileManifest) bool {
 	return true
 }
 
-func sameFileManifests(a, b []FileManifest) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if !sameFileManifest(a[i], b[i]) {
-			return false
-		}
-	}
-	return true
-}
-
 func sameFileManifest(a, b FileManifest) bool {
 	return a.Path == b.Path && a.Rows == b.Rows && a.Size == b.Size && a.SHA256 == b.SHA256
 }

--- a/snapshot/values.go
+++ b/snapshot/values.go
@@ -1,0 +1,213 @@
+package snapshot
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"reflect"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const maxExactJSONInteger = 1<<53 - 1
+
+// Decode with exact tokens first, then restore the ordinary legacy callback
+// types. Only integers that float64 cannot safely carry become native int64.
+func decodeSnapshotRow(data []byte, legacyWriter bool) (map[string]any, error) {
+	if !json.Valid(data) {
+		return nil, errors.New("invalid JSON row")
+	}
+	if err := validateJSONText(data); err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var row map[string]any
+	if err := decoder.Decode(&row); err != nil {
+		return nil, err
+	}
+	_, err := normalizeJSONValues(row, legacyWriter)
+	return row, err
+}
+
+func normalizeJSONValues(value any, legacyWriter bool) (any, error) {
+	switch v := value.(type) {
+	case json.Number:
+		return snapshotNumber(v.String(), legacyWriter)
+	case map[string]any:
+		for key, item := range v {
+			normalized, err := normalizeJSONValues(item, legacyWriter)
+			if err != nil {
+				return nil, err
+			}
+			v[key] = normalized
+		}
+	case []any:
+		for i, item := range v {
+			normalized, err := normalizeJSONValues(item, legacyWriter)
+			if err != nil {
+				return nil, err
+			}
+			v[i] = normalized
+		}
+	}
+	return value, nil
+}
+
+func snapshotNumber(token string, legacyWriter bool) (any, error) {
+	// Bound exact decimal work even for adversarial, otherwise valid JSON.
+	if len(token) > 4096 {
+		return nil, errors.New("JSON number exceeds supported precision")
+	}
+	f, err := strconv.ParseFloat(token, 64)
+	if err != nil || math.IsInf(f, 0) || math.IsNaN(f) {
+		return nil, errors.New("JSON number is outside float64 range")
+	}
+	if f == 0 {
+		mantissa, _, _ := strings.Cut(strings.ToLower(token), "e")
+		if strings.ContainsAny(mantissa, "123456789") {
+			return nil, errors.New("JSON number underflows float64")
+		}
+		return f, nil
+	}
+	exact, ok := new(big.Rat).SetString(token)
+	if !ok {
+		return nil, errors.New("unsupported JSON number")
+	}
+	if exact.IsInt() {
+		if !exact.Num().IsInt64() {
+			return nil, errors.New("JSON integer is outside int64 range")
+		}
+		n := exact.Num().Int64()
+		if n < -maxExactJSONInteger || n > maxExactJSONInteger {
+			if legacyWriter {
+				return nil, errors.New("v1 snapshot cannot safely export integers outside +/- (2^53-1); filter or explicitly encode the value as text")
+			}
+			return n, nil
+		}
+		return f, nil
+	}
+	if exact.Abs(exact).Cmp(new(big.Rat).SetInt64(maxExactJSONInteger)) > 0 {
+		return nil, errors.New("JSON fractional number exceeds safe float64 integer precision")
+	}
+	return f, nil
+}
+
+// encoding/json replaces invalid UTF-8 and unpaired UTF-16 escapes. A snapshot
+// must refuse them instead of committing replacement characters to the archive.
+func validateJSONText(data []byte) error {
+	if !utf8.Valid(data) {
+		return errors.New("snapshot text is not valid UTF-8")
+	}
+	for i := 0; i < len(data); i++ {
+		if data[i] != '\\' {
+			continue
+		}
+		i++
+		if data[i] != 'u' {
+			continue
+		}
+		code, _ := strconv.ParseUint(string(data[i+1:i+5]), 16, 16)
+		i += 4
+		if code >= 0xdc00 && code <= 0xdfff {
+			return errors.New("snapshot text contains an unpaired UTF-16 surrogate")
+		}
+		if code < 0xd800 || code > 0xdbff {
+			continue
+		}
+		if i+6 >= len(data) || data[i+1] != '\\' || data[i+2] != 'u' {
+			return errors.New("snapshot text contains an unpaired UTF-16 surrogate")
+		}
+		low, _ := strconv.ParseUint(string(data[i+3:i+7]), 16, 16)
+		if low < 0xdc00 || low > 0xdfff {
+			return errors.New("snapshot text contains an unpaired UTF-16 surrogate")
+		}
+		i += 6
+	}
+	return nil
+}
+
+func encodeSnapshotRow(row map[string]any, blobs map[string]string) ([]byte, error) {
+	for col, original := range blobs {
+		if text, ok := row[col].(string); ok && text == original {
+			return nil, fmt.Errorf("v1 snapshot cannot safely export BLOB column %s; filter or explicitly replace its representation", col)
+		}
+	}
+	data, err := json.Marshal(row)
+	if err != nil {
+		return nil, err
+	}
+	// Marshal detects cycles/unsupported values first. Inspect original strings
+	// before accepting its output, since the encoder silently repairs UTF-8.
+	if err := validateExportValue(reflect.ValueOf(row), 0); err != nil {
+		return nil, err
+	}
+	if _, err := decodeSnapshotRow(data, true); err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func validateExportValue(value reflect.Value, depth int) error {
+	if !value.IsValid() {
+		return nil
+	}
+	if depth > 1000 {
+		return errors.New("snapshot value exceeds supported nesting")
+	}
+	if value.CanInterface() {
+		// Explicit caller encoders own their transformation; their JSON output
+		// still passes the same numeric and text validation above.
+		if _, ok := value.Interface().(json.Marshaler); ok {
+			return nil
+		}
+		if _, ok := value.Interface().(encoding.TextMarshaler); ok {
+			return nil
+		}
+	}
+	switch value.Kind() {
+	case reflect.Interface, reflect.Pointer:
+		if !value.IsNil() {
+			return validateExportValue(value.Elem(), depth+1)
+		}
+	case reflect.String:
+		if !utf8.ValidString(value.String()) {
+			return errors.New("snapshot text is not valid UTF-8")
+		}
+	case reflect.Slice, reflect.Array:
+		if value.Kind() == reflect.Slice && value.Type().Elem().Kind() == reflect.Uint8 {
+			return errors.New("v1 snapshot cannot safely export BLOB values")
+		}
+		for i := 0; i < value.Len(); i++ {
+			if err := validateExportValue(value.Index(i), depth+1); err != nil {
+				return err
+			}
+		}
+	case reflect.Map:
+		iter := value.MapRange()
+		for iter.Next() {
+			if err := validateExportValue(iter.Key(), depth+1); err != nil {
+				return err
+			}
+			if err := validateExportValue(iter.Value(), depth+1); err != nil {
+				return err
+			}
+		}
+	case reflect.Struct:
+		for i := 0; i < value.NumField(); i++ {
+			field := value.Type().Field(i)
+			if !field.IsExported() || field.Tag.Get("json") == "-" {
+				continue
+			}
+			if err := validateExportValue(value.Field(i), depth+1); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/snapshot/values_test.go
+++ b/snapshot/values_test.go
@@ -1,0 +1,301 @@
+package snapshot
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func rawValuePack(t *testing.T, lines string) string {
+	t.Helper()
+	root := t.TempDir()
+	var data bytes.Buffer
+	gz := gzip.NewWriter(&data)
+	if _, err := gz.Write([]byte(lines)); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "rows.jsonl.gz"), data.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteManifest(root, Manifest{Version: 1, Tables: []TableManifest{{Name: "things", Files: []string{"rows.jsonl.gz"}}}}); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func TestSnapshotNumberCallbackTypes(t *testing.T) {
+	for _, tc := range []struct {
+		token string
+		want  any
+	}{
+		{"0", float64(0)},
+		{"-0.0", math.Copysign(0, -1)},
+		{"0e999999999", float64(0)},
+		{"1", float64(1)},
+		{"0.1", 0.1},
+		{"1e3", float64(1000)},
+		{"1e-100", 1e-100},
+		{"5e-324", math.SmallestNonzeroFloat64},
+		{"9007199254740991", float64(9007199254740991)},
+		{"-9007199254740991", float64(-9007199254740991)},
+		{"9007199254740992", int64(9007199254740992)},
+		{"9007199254740993", int64(9007199254740993)},
+		{"9007199254740993.0", int64(9007199254740993)},
+		{"9.007199254740993e15", int64(9007199254740993)},
+		{"-9.007199254740993E+15", int64(-9007199254740993)},
+		{"9223372036854775807", int64(math.MaxInt64)},
+		{"9223372036854775807.000", int64(math.MaxInt64)},
+		{"-9223372036854775808", int64(math.MinInt64)},
+	} {
+		t.Run(tc.token, func(t *testing.T) {
+			row, err := decodeSnapshotRow([]byte(`{"value":`+tc.token+`}`), false)
+			if err != nil || !reflect.DeepEqual(row["value"], tc.want) {
+				t.Fatalf("got %T(%v), err=%v; want %T(%v)", row["value"], row["value"], err, tc.want, tc.want)
+			}
+			if f, ok := tc.want.(float64); ok && f == 0 && math.Signbit(row["value"].(float64)) != math.Signbit(f) {
+				t.Fatal("zero sign changed")
+			}
+		})
+	}
+	row, err := decodeSnapshotRow([]byte(`{"nested":[1,{"id":9007199254740993}],"text":"9007199254740993"}`), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nested := row["nested"].([]any)
+	if nested[0] != float64(1) || nested[1].(map[string]any)["id"] != int64(9007199254740993) || row["text"] != "9007199254740993" {
+		t.Fatalf("nested callback types: %#v", row)
+	}
+}
+
+func TestImportExactIntegerBindings(t *testing.T) {
+	root := rawValuePack(t, `{"id":1,"value":7}
+{"id":9007199254740992,"value":9223372036854775807}
+{"id":9007199254740993.0,"value":-9223372036854775808}
+`)
+	db := exportTestDB(t, `create table things(id integer primary key, value integer);`)
+	calls := 0
+	_, err := Import(context.Background(), ImportOptions{DB: db, RootDir: root,
+		Filter: func(_ string, row map[string]any) (bool, error) {
+			if row["id"] == float64(1) && row["value"] != float64(7) {
+				t.Fatal("ordinary filter callback changed")
+			}
+			return true, nil
+		},
+		ImportRow: func(ctx context.Context, tx *sql.Tx, table string, row map[string]any) error {
+			calls++
+			if _, ok := row["id"].(json.Number); ok {
+				t.Fatal("json.Number escaped into caller")
+			}
+			return insertRow(ctx, tx, table, row)
+		}})
+	if err != nil || calls != 3 {
+		t.Fatalf("import calls=%d: %v", calls, err)
+	}
+	for id, expected := range map[int64]int64{1: 7, 9007199254740992: math.MaxInt64, 9007199254740993: math.MinInt64} {
+		var got int64
+		if err := db.QueryRow(`select value from things where id=?`, id).Scan(&got); err != nil || got != expected {
+			t.Fatalf("binding id=%d value=%d: %v", id, got, err)
+		}
+	}
+}
+
+func TestImportInvalidValuesRollBackCallbacksAndDeletes(t *testing.T) {
+	for _, value := range []string{
+		"9223372036854775808", "-9223372036854775809", "100000000000000000000",
+		"9007199254740993.1", "1e100", "1e9999999", "1e-10000",
+		`"\ud800"`, `"\udc00"`, `"\ud800x"`, `"\ud800\u0041"`,
+		"\"invalid\xfftext\"", "NaN", "Infinity", "01", "1 2",
+	} {
+		t.Run(value, func(t *testing.T) {
+			root := rawValuePack(t, "{\"id\":1,\"value\":7}\n{\"id\":2,\"value\":"+value+"}\n")
+			db := exportTestDB(t, `create table things(id integer primary key, value);
+create table hooks(value text); insert into things values(5,'retained');`)
+			_, err := Import(context.Background(), ImportOptions{DB: db, RootDir: root,
+				BeforeImport: func(ctx context.Context, tx *sql.Tx) error {
+					_, err := tx.ExecContext(ctx, `insert into hooks values('before')`)
+					return err
+				},
+				ImportRow: func(ctx context.Context, tx *sql.Tx, table string, row map[string]any) error {
+					return insertRow(ctx, tx, table, row)
+				}})
+			if err == nil {
+				t.Fatal("invalid/unrepresentable value imported")
+			}
+			var value string
+			var count, hooks int
+			if err := db.QueryRow(`select count(*), max(value) from things`).Scan(&count, &value); err != nil || count != 1 || value != "retained" {
+				t.Fatalf("destination not rolled back: count=%d value=%q err=%v", count, value, err)
+			}
+			if err := db.QueryRow(`select count(*) from hooks`).Scan(&hooks); err != nil || hooks != 0 {
+				t.Fatalf("callback transaction not rolled back: %d %v", hooks, err)
+			}
+		})
+	}
+}
+
+func TestSnapshotTextValidation(t *testing.T) {
+	for _, text := range []string{`"plain"`, `"valid\u00e9"`, `"\ud83d\ude00"`, `"\\ud800"`, `"\\\""`} {
+		if _, err := decodeSnapshotRow([]byte(`{"value":`+text+`}`), false); err != nil {
+			t.Fatalf("valid text %s: %v", text, err)
+		}
+	}
+	for _, line := range []string{`{} {}`, `[]`, `1`, `{"value":1,}`, `{"value":1e}`} {
+		if _, err := decodeSnapshotRow([]byte(line), false); err == nil {
+			t.Fatalf("invalid row accepted: %s", line)
+		}
+	}
+	if _, err := decodeSnapshotRow([]byte(`{"value":0.`+strings.Repeat("0", 4096)+`1}`), false); err == nil {
+		t.Fatal("unbounded number accepted")
+	}
+}
+
+func TestExportUnsupportedValuesPreservePack(t *testing.T) {
+	for name, value := range map[string]any{
+		"large integer":    int64(9007199254740993),
+		"negative integer": int64(-9007199254740992),
+		"large real":       float64(1e20),
+		"blob":             []byte{0xff, 0},
+		"empty blob":       []byte{},
+		"text blob":        []byte("ascii"),
+		"text":             "invalid\xfftext",
+	} {
+		t.Run(name, func(t *testing.T) {
+			db := exportTestDB(t, `create table things(id integer primary key, value); insert into things values(1,'old');`)
+			opts := ExportOptions{DB: db, RootDir: t.TempDir(), Tables: []string{"things"}}
+			first, err := Export(context.Background(), opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			before := packBytes(t, opts.RootDir, first)
+			if _, err := db.Exec(`insert into things values(2,?)`, value); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Export(context.Background(), opts); err == nil {
+				t.Fatal("unsupported legacy value published")
+			}
+			if !reflect.DeepEqual(before, packBytes(t, opts.RootDir, first)) {
+				t.Fatal("refused value damaged prior pack")
+			}
+			opts.Filter = func(_ string, row map[string]any) (bool, error) { return row["id"] == int64(1), nil }
+			if _, err := Export(context.Background(), opts); err != nil {
+				t.Fatalf("excluded value should not fail: %v", err)
+			}
+		})
+	}
+}
+
+func TestExportExplicitFilterTransformations(t *testing.T) {
+	db := exportTestDB(t, `create table things(id integer, blob, large integer, text);`)
+	if _, err := db.Exec(`insert into things values(1,?,?,?)`, []byte{0xff, 0}, int64(9007199254740993), "bad\xff"); err != nil {
+		t.Fatal(err)
+	}
+	opts := ExportOptions{DB: db, RootDir: t.TempDir(), Tables: []string{"things"},
+		Filter: func(_ string, row map[string]any) (bool, error) {
+			if _, ok := row["blob"].(string); !ok {
+				t.Fatal("legacy export BLOB callback type changed")
+			}
+			row["blob"] = "base64:" + base64.StdEncoding.EncodeToString([]byte(row["blob"].(string)))
+			row["large"] = fmt.Sprint(row["large"])
+			row["text"] = "explicit replacement"
+			return true, nil
+		}}
+	if _, err := Export(context.Background(), opts); err != nil {
+		t.Fatal(err)
+	}
+	dst := exportTestDB(t, `create table things(id integer, blob, large, text);`)
+	if _, err := Import(context.Background(), ImportOptions{DB: dst, RootDir: opts.RootDir}); err != nil {
+		t.Fatal(err)
+	}
+	var blob, large, text string
+	if err := dst.QueryRow(`select blob,large,text from things`).Scan(&blob, &large, &text); err != nil || blob != "base64:/wA=" || large != "9007199254740993" || text != "explicit replacement" {
+		t.Fatalf("explicit representation: %q %q %q %v", blob, large, text, err)
+	}
+	opts.Filter = nil
+	opts.FilterTx = func(context.Context, *sql.Tx, string, map[string]any) (bool, error) { return false, nil }
+	if manifest, err := Export(context.Background(), opts); err != nil || manifest.Tables[0].Rows != 0 {
+		t.Fatalf("transaction filter exclusion: %+v %v", manifest, err)
+	}
+	opts.FilterTx = func(_ context.Context, _ *sql.Tx, _ string, row map[string]any) (bool, error) {
+		delete(row, "blob")
+		delete(row, "large")
+		delete(row, "text")
+		return true, nil
+	}
+	if _, err := Export(context.Background(), opts); err != nil {
+		t.Fatalf("transaction filter removal: %v", err)
+	}
+}
+
+func TestSnapshotWriterReaderNumericAgreement(t *testing.T) {
+	for _, value := range []any{float64(0), math.Copysign(0, -1), float64(7), 0.1, 1e-100, math.SmallestNonzeroFloat64, int64(maxExactJSONInteger)} {
+		data, err := encodeSnapshotRow(map[string]any{"value": value}, nil)
+		if err != nil {
+			t.Fatalf("encode %v: %v", value, err)
+		}
+		row, err := decodeSnapshotRow(data, false)
+		if err != nil {
+			t.Fatalf("reader rejected writer output: %v", err)
+		}
+		got, ok := row["value"].(float64)
+		want := reflect.ValueOf(value).Convert(reflect.TypeFor[float64]()).Float()
+		if !ok || got != want || math.Signbit(got) != math.Signbit(want) {
+			t.Fatalf("roundtrip %T(%v) -> %T(%v)", value, value, row["value"], row["value"])
+		}
+	}
+	for _, value := range []any{
+		int64(maxExactJSONInteger + 1), uint64(math.MaxUint64), float64(1e20),
+		float64(1e100), math.MaxFloat64, math.Inf(1), math.NaN(),
+		json.Number("9007199254740993.0"), json.Number("1e-10000"),
+		[]byte{}, "bad\xff", []any{"bad\xff"}, map[string]any{"bad\xff": 1},
+		struct{ Text string }{"bad\xff"}, json.RawMessage(`"\ud800"`),
+	} {
+		if _, err := encodeSnapshotRow(map[string]any{"value": value}, nil); err == nil {
+			t.Fatalf("writer accepted unsupported %T(%v)", value, value)
+		}
+	}
+}
+
+func TestSnapshotFractionalBoundary(t *testing.T) {
+	for _, token := range []string{
+		"9007199254740991.1", "-9007199254740991.1",
+		"9.0071992547409911e15", "-9.0071992547409911E+15",
+		"90071992547409911e-1", "-90071992547409911e-1",
+	} {
+		t.Run(token, func(t *testing.T) {
+			if _, err := decodeSnapshotRow([]byte(`{"value":`+token+`}`), false); err == nil {
+				t.Error("reader checked rounded magnitude instead of exact fractional bound")
+			}
+			if _, err := encodeSnapshotRow(map[string]any{"value": json.Number(token)}, nil); err == nil {
+				t.Error("writer checked rounded magnitude instead of exact fractional bound")
+			}
+		})
+	}
+	for token, want := range map[string]float64{
+		"9007199254740990.9":      9007199254740991,
+		"-9007199254740990.9":     -9007199254740991,
+		"9.0071992547409909e15":   9007199254740991,
+		"-9.0071992547409909E+15": -9007199254740991,
+	} {
+		data, err := encodeSnapshotRow(map[string]any{"value": json.Number(token)}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		row, err := decodeSnapshotRow(data, false)
+		if err != nil || row["value"] != want {
+			t.Fatalf("ordinary in-range fractional float64 contract changed: %T(%v), %v", row["value"], row["value"], err)
+		}
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -57,6 +58,17 @@ func Open(ctx context.Context, opts Options) (*Store, error) {
 		return nil, err
 	}
 	store := &Store{db: db, path: path}
+	if opts.SchemaVersion > 0 {
+		current, err := store.SchemaVersion(ctx)
+		if err != nil {
+			_ = db.Close()
+			return nil, err
+		}
+		if current > opts.SchemaVersion {
+			_ = db.Close()
+			return nil, fmt.Errorf("database schema version %d is newer than supported version %d", current, opts.SchemaVersion)
+		}
+	}
 	if opts.Schema != "" {
 		if _, err := db.ExecContext(ctx, opts.Schema); err != nil {
 			_ = db.Close()
@@ -121,8 +133,8 @@ func (s *Store) WithTx(ctx context.Context, fn func(*sql.Tx) error) error {
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
+	defer tx.Rollback()
 	if err := fn(tx); err != nil {
-		_ = tx.Rollback()
 		return err
 	}
 	if err := tx.Commit(); err != nil {
@@ -224,7 +236,7 @@ func readOnlyDSN(path string) string {
 
 func dsn(path, pragmas string) string {
 	if path == ":memory:" {
-		return "file::memory:?cache=shared&" + pragmas
+		return "file:crawlkit-" + rand.Text() + "?mode=memory&cache=shared&" + pragmas
 	}
 	if strings.HasPrefix(path, "file:") {
 		sep := "?"

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -3,12 +3,167 @@ package store
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestOpenRejectsNewerVersionBeforeSchema(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "archive.db")
+	st, err := Open(ctx, Options{Path: path, SchemaVersion: 9, Schema: `
+		create table retained(value text);
+		insert into retained values('original');
+	`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+	rejected, err := Open(ctx, Options{Path: path, SchemaVersion: 8, Schema: `drop table retained;`})
+	if rejected != nil {
+		rejected.Close()
+	}
+	if err == nil || !strings.Contains(err.Error(), "newer than supported") {
+		t.Fatalf("Open error = %v", err)
+	}
+	ro, err := OpenReadOnly(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ro.Close()
+	var value string
+	if err := ro.DB().QueryRowContext(ctx, `select value from retained`).Scan(&value); err != nil {
+		t.Fatal(err)
+	}
+	if value != "original" {
+		t.Fatalf("retained value = %q", value)
+	}
+}
+
+func TestOpenSchemaFailureDoesNotAdvanceVersion(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "archive.db")
+	st, err := Open(ctx, Options{Path: path, SchemaVersion: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Close()
+	if _, err := Open(ctx, Options{Path: path, SchemaVersion: 3, Schema: `invalid SQL`}); err == nil {
+		t.Fatal("expected schema failure")
+	}
+	st, err = Open(ctx, Options{Path: path, SchemaVersion: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	version, err := st.SchemaVersion(ctx)
+	if err != nil || version != 2 {
+		t.Fatalf("version = %d, error = %v", version, err)
+	}
+}
+
+func TestWithTxRollsBackPanicAndReleasesConnection(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, Options{Path: filepath.Join(t.TempDir(), "archive.db"), Schema: `create table things(value text)`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	sentinel := errors.New("callback panic")
+	func() {
+		defer func() {
+			if got := recover(); got != sentinel {
+				t.Errorf("panic = %v, want original sentinel", got)
+			}
+		}()
+		_ = st.WithTx(ctx, func(tx *sql.Tx) error {
+			if _, err := tx.ExecContext(ctx, `insert into things values('uncommitted')`); err != nil {
+				t.Fatal(err)
+			}
+			panic(sentinel)
+		})
+	}()
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	var count int
+	if err := st.DB().QueryRowContext(queryCtx, `select count(*) from things`).Scan(&count); err != nil {
+		t.Fatalf("connection not reusable: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("panic committed %d rows", count)
+	}
+	if err := st.WithTx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `insert into things values('error')`); err != nil {
+			return err
+		}
+		return sentinel
+	}); err != sentinel {
+		t.Fatalf("callback error = %v", err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from things`).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("callback error count = %d, error = %v", count, err)
+	}
+}
+
+func TestAnonymousMemoryStoresAreIndependent(t *testing.T) {
+	ctx := context.Background()
+	a, err := Open(ctx, Options{Path: ":memory:", Schema: `create table things(value text); insert into things values('a');`, MaxOpenConns: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	b, err := Open(ctx, Options{Path: ":memory:", Schema: `create table things(value text); insert into things values('b');`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Close()
+	for _, tc := range []struct {
+		store *Store
+		want  string
+	}{{a, "a"}, {b, "b"}} {
+		if tc.store.Path() != ":memory:" {
+			t.Fatalf("Path = %q", tc.store.Path())
+		}
+		var value string
+		if err := tc.store.DB().QueryRowContext(ctx, `select value from things`).Scan(&value); err != nil || value != tc.want {
+			t.Fatalf("value = %q, error = %v, want %q", value, err, tc.want)
+		}
+	}
+	held, err := a.DB().Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer held.Close()
+	var value string
+	if err := a.DB().QueryRowContext(ctx, `select value from things`).Scan(&value); err != nil || value != "a" {
+		t.Fatalf("second pooled connection value = %q, error = %v", value, err)
+	}
+}
+
+func TestExplicitNamedMemoryStoresRemainShared(t *testing.T) {
+	ctx := context.Background()
+	path := "file:explicit-store-test?mode=memory&cache=shared"
+	a, err := Open(ctx, Options{Path: path, Schema: `create table things(value text); insert into things values('shared');`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	b, err := Open(ctx, Options{Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Close()
+	var value string
+	if err := b.DB().QueryRowContext(ctx, `select value from things`).Scan(&value); err != nil || value != "shared" {
+		t.Fatalf("shared value = %q, error = %v", value, err)
+	}
+}
 
 func TestOpenAppliesSchemaPragmasAndPermissions(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## What Problem This Solves

Prepares v0.15.0 with shared archive correctness and credential-handling fixes.
Interrupted publication, unsafe numeric conversion, incremental replacement,
and overlapping local runners must not silently discard or corrupt archive
data.

## Why This Change Was Made

Snapshot exports and encrypted backups publish immutable generations before
replacing the manifest. Incremental imports validate effective work before
mutation, preserve exact supported integers, and reject unsupported v1 exports
before promotion. Shared locks, SQLite capture replacement, token transport,
mirror updates, configuration permissions, and store lifecycle handling are
hardened without introducing provider schemas or a new snapshot format.

This builds on the already-landed integrity work in
https://github.com/openclaw/crawlkit/pull/110, preserving it in the local
integration history. The release workflow remains unchanged; v0.15.0 is
prepared, not yet published.

## User Impact

- Failed snapshot or backup publication preserves the previous manifest and
  its owned data. Post-commit cleanup failures are reported separately.
- Snapshot import retains ordinary numeric callback behavior and exact
  supported signed integers. Default v1 export explicitly refuses unsafe
  integers, BLOBs, invalid text, and unrepresentable numbers; this is not new
  BLOB export support.
- ReadTx and FilterTx are additive; logical incremental identities survive
  generation-specific physical paths.
- Stop all older scheduler runners before upgrading. Mixed old/new runner
  mutual exclusion is not supported.
- Raw SQLite file copies still require a quiescent source or an app-owned
  coherent snapshot. Staging does not make a live raw copy transactional.
- No downstream module pins or public release artifacts are changed by this PR.

## Evidence

- The integrated source at eebdf453 passed isolated Go 1.27.1 Linux/amd64
  tidy/no-diff, module verification, build, vet, full uncached tests, and full
  race: 18 packages, 405 top-level tests and 376 subtests passed per test run.
  Two explicit skips were Windows-only URI behavior and opt-in real
  TurboVec/Python integration.
- Ten downstream app integrations exercised immutable source snapshots with
  temporary module overrides and isolated temporary data. These included real
  Discrawl/Grain binding and snapshot-consumer probes. Published pins were not
  changed, and platform-specific unsupported CLI outcomes were recorded rather
  than relabeled as success.
- Release readiness found one unused private helper after generation-aware
  planning replaced its caller. The final product-source delta from eebdf453 is
  only its 12-line deletion. Final-source deadcode v0.49.0 and the snapshot
  package passed: 66 top-level tests, 264 subtests, no skips or failures.
- The release metadata was reviewed independently. The exact helper deletion
  plus metadata also passed scoped structured review. Formatting, 25 Node
  dispatch-guard tests, actionlint v1.7.12, and govulncheck v1.7.0 passed.
  Those earlier non-deadcode gates preceded the helper deletion; they are not
  presented as reruns on the final revision. Govulncheck reported no called
  vulnerabilities; one required-module advisory was outside called code.
- Hosted CI must validate the actual final candidate and landed source before
  release dispatch. Earlier full/race proof is not relabeled as a final-head
  execution. Local Linux execution does not establish macOS/Windows lock
  runtime proof or release artifact signing/notarization.

Unchanged limits remain explicit: manifest hashes are not authentication;
reused encrypted objects are not reverified by every backup; generic file
restore is not whole-batch atomic or comprehensively size-bounded; permissive
HTTP success/retry contracts are not redesigned in this release.
