### PR TITLE
fix(remote): preserve warnings in archive metadata

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,0 +1,32 @@
+# CI Helpers
+
+`downstream-compat.sh` compares the complete Gitcrawl CLI test suite against a
+pinned Crawlkit baseline and the candidate checkout. The source pins live in
+`ci.yml`. Update pins deliberately, with exact-head review.
+
+The Linux job has a 20-minute ceiling. It prepares dependencies with Go 1.27.1
+and the public Go proxy, then runs baseline and candidate serially with
+`GOPROXY=off`. Each uses native `lsof`, private HOME/XDG/temp directories, a
+private test modfile, and a network/PID namespace with loopback only. The
+package test timeout remains three minutes; the outer six-minute ceiling also
+covers compilation. There are no retries or provider collector commands.
+
+Checkouts and source archives remain unchanged. Only private test inputs receive
+the temporary Crawlkit replacement and native Go dependency normalization.
+Source/module hashes, module resolution, native tool versions, complete test
+output, exit codes, and log hashes are retained in the Actions log. Both phase
+exit codes also appear in the job summary. A failing baseline is not a pass.
+
+The namespace requires native `sudo`, `unshare`, `ip`, and `setpriv`; missing
+capabilities fail the job. It does not alter the runner's host network. This
+helper neither installs app binaries nor accesses live archives, credentials,
+deployments, signing, tags, or releases.
+
+Before dependency preparation, a cancellation probe uses the same privileged
+`sudo timeout unshare` chain and UID/GID drop as the suites. `setpriv --pdeathsig
+keep` restores the parent-death signal after the credential change. The probe
+requires that signal to remain `SIGKILL`, creates a detached descendant, and
+checks both owned processes exit when the eight-second timeout escalates after
+one second. Private namespace/PID markers and pidfds bind cleanup to those exact
+processes. Missing native capabilities, failed cancellation, or failed drainage
+stop the job before Go phases; they are not compatibility passes.

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -30,3 +30,45 @@ checks both owned processes exit when the eight-second timeout escalates after
 one second. Private namespace/PID markers and pidfds bind cleanup to those exact
 processes. Missing native capabilities, failed cancellation, or failed drainage
 stop the job before Go phases; they are not compatibility passes.
+
+## Selected App Qualification
+
+The same `ci.yml` also accepts a manual `app` choice: `slacrawl`, `discrawl`, or
+`notcrawl`. It checks out only that public app at its reviewed SHA, the pinned
+Crawlkit baseline, and the exact dispatch head. No cross-repository credentials
+are used. A manual run skips the ordinary library and Gitcrawl jobs; its single
+Ubuntu job is serialized with other manual app runs and capped at 20 minutes.
+
+The four-argument harness path prepares the complete app dependency graph, then
+runs `go test -count=1 -timeout=3m ./...` and `go build ./cmd/<app>` against
+baseline and candidate in order. The original three-argument Gitcrawl path
+still selects only `./internal/cli`. Both use the same cancellation probe,
+private module files, source integrity checks, native tools, and offline
+namespace. Builds have a two-minute outer ceiling; test compilation and
+execution retain the six-minute outer ceiling and unchanged package timeout.
+No phase is retried.
+
+`downstream-smoke.py` runs six commands against each successful build:
+`--help`, `--version`, `tui --help`, `metadata --json`, `status --json`, and
+`tui --json`. Each command has a 30-second ceiling; the complete smoke phase
+has a two-minute outer ceiling. Smoke HOME/XDG/temp directories are separate
+from the test runtime. Slacrawl uses native `init --db` and Notcrawl uses native
+`init` to create local configuration. Discrawl uses its native absent-config
+and absent-archive path: its authenticated `init` is never called.
+
+Every successful smoke requires nonempty help/version output, valid JSON, and
+unchanged runtime file contents, modes, and symlinks after fixture setup.
+Baseline/candidate JSON must match after normalizing only private runtime path
+prefixes and the top-level status `generated_at` clock. Commands, outputs,
+binary build information, file digests, snapshots, and result JSON are printed
+to the Actions log. A failed test, build, smoke, or comparison fails the job;
+an unchanged baseline failure remains a limitation, not a pass.
+
+For pre-merge qualification, dispatch this existing workflow by file name and
+the reviewed PR branch ref. GitHub's
+[event contract](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch)
+allows API/CLI dispatch against a branch or tag once the workflow has run.
+The file already exists on the default branch; this does not require merging
+the candidate first. Check the exact branch head before every dispatch and
+bind the returned run to that head. Finish one selected app before dispatching
+the next; do not enqueue multiple runs or automatically retry failures.

--- a/.github/scripts/downstream-compat.sh
+++ b/.github/scripts/downstream-compat.sh
@@ -67,7 +67,19 @@ PY
 fi
 
 [[ $(uname -s) == Linux ]] || { echo "Linux is required" >&2; exit 2; }
-[[ $# == 3 ]] || { echo "usage: $0 CANDIDATE BASELINE GITCRAWL" >&2; exit 2; }
+[[ $# == 3 || $# == 4 ]] ||
+  { echo "usage: $0 CANDIDATE BASELINE DOWNSTREAM [slacrawl|discrawl|notcrawl]" >&2; exit 2; }
+app=${4:-gitcrawl}
+suite=./internal/cli
+downstream_sha=${GITCRAWL_SHA:-}
+if [[ $# == 4 ]]; then
+  case "$app" in
+    slacrawl|discrawl|notcrawl) ;;
+    *) echo "unsupported downstream app: $app" >&2; exit 2 ;;
+  esac
+  suite=./...
+  downstream_sha=${DOWNSTREAM_SHA:?}
+fi
 for tool in go git lsof tar sha256sum sudo unshare ip setpriv timeout python3; do
   command -v "$tool" >/dev/null || { echo "missing required tool: $tool" >&2; exit 2; }
 done
@@ -81,7 +93,7 @@ timeout --version
 
 candidate=$(realpath "$1")
 baseline=$(realpath "$2")
-gitcrawl=$(realpath "$3")
+downstream=$(realpath "$3")
 script=$(realpath "$0")
 work=$(mktemp -d "${RUNNER_TEMP:?}/crawlkit-downstream.XXXXXX")
 mkdir -p "$work/gomodcache" "$work/gopath" "$work/gocache"
@@ -98,7 +110,7 @@ verify_checkout() {
 
 verify_checkout "$candidate" "${CRAWLKIT_CANDIDATE_SHA:?}"
 verify_checkout "$baseline" "${CRAWLKIT_BASELINE_SHA:?}"
-verify_checkout "$gitcrawl" "${GITCRAWL_SHA:?}"
+verify_checkout "$downstream" "$downstream_sha"
 go version
 lsof -v 2>&1
 sha256sum "$(command -v go)" "$(command -v lsof)"
@@ -246,7 +258,7 @@ for name in baseline candidate; do
   [[ $name == baseline ]] || library=$candidate
   mkdir -p "$phase"/{source,library,modules,home,config,cache,data,state,tmp}
   mkdir -m 700 "$phase/runtime"
-  git -C "$gitcrawl" archive HEAD | tar -xf - -C "$phase/source"
+  git -C "$downstream" archive HEAD | tar -xf - -C "$phase/source"
   git -C "$library" archive HEAD | tar -xf - -C "$phase/library"
   fingerprint "$phase" > "$phase/source.sha256"
   cp "$phase/source/go.mod" "$phase/modules/go.mod"
@@ -259,40 +271,87 @@ for name in baseline candidate; do
     # Normalize only private test inputs for the linked library's requirements.
     phase_env "$phase" GOPROXY=https://proxy.golang.org \
       GOFLAGS="-modfile=$phase/modules/go.mod -mod=mod -p=2" \
-      go list -deps -test ./internal/cli > "$phase/packages.txt"
+      go list -deps -test "$suite" > "$phase/packages.txt"
     phase_env "$phase" GOPROXY=off \
       GOFLAGS="-modfile=$phase/modules/go.mod -mod=readonly -p=2" \
-      go list -m -json github.com/openclaw/crawlkit
+      go list -m -json github.com/openclaw/crawlkit > "$phase/crawlkit.json"
+    cat "$phase/crawlkit.json"
+    phase_env "$phase" python3 - "$phase/library" "$phase/crawlkit.json" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+library = Path(sys.argv[1]).resolve()
+module = json.loads(Path(sys.argv[2]).read_text())
+assert module["Path"] == "github.com/openclaw/crawlkit", "wrong module identity"
+assert Path(module["Dir"]).resolve() == library, "wrong Crawlkit source directory"
+assert Path(module["Replace"]["Dir"]).resolve() == library, "wrong test replacement"
+assert Path(module["GoMod"]).resolve() == library / "go.mod", "wrong Crawlkit modfile"
+PY
     phase_env "$phase" GOPROXY=off \
       GOFLAGS="-modfile=$phase/modules/go.mod -mod=readonly -p=2" \
       go list -deps -test -f '{{with .Module}}{{.Path}} {{.Version}}{{end}}' \
-      ./internal/cli | sort -u > "$phase/modules.txt"
+      "$suite" | sort -u > "$phase/modules.txt"
   )
   sha256sum "$phase/modules/go.mod" "$phase/modules/go.sum" > "$phase/modules.sha256"
   printf '%s dependency inputs:\n' "$name"
   cat "$phase/modules.txt" "$phase/modules.sha256" "$phase/source.sha256"
+  if [[ $app != gitcrawl ]]; then
+    printf '::group::%s private module inputs\n' "$name"
+    cat "$phase/modules/go.mod" "$phase/modules/go.sum"
+    printf '::endgroup::\n'
+  fi
 done
 
 result=0
-for name in baseline candidate; do
-  phase="$work/$name"
-  printf '::group::%s unchanged CLI suite\n' "$name"
-  if run_isolated "$phase" 6m 10s go test -count=1 -timeout=3m ./internal/cli \
-    2>&1 | tee "$phase/tests.log"; then
+run_step() {
+  local phase=$1 label=$2 duration=$3
+  local log="$work/$name/$label.log"
+  shift 3
+  printf '::group::%s %s\n' "$name" "$label"
+  printf '%q ' "$@"
+  printf '\n'
+  if run_isolated "$phase" "$duration" 10s "$@" 2>&1 | tee "$log"; then
     status=0
   else
     status=$?
     result=1
   fi
-  printf '::endgroup::\n%s CLI exit: %s\n' "$name" "$status"
+  printf '::endgroup::\n%s %s exit: %s\n' "$name" "$label" "$status"
+  sha256sum "$log"
+  printf '%s %s exit: %s\n' "$name" "$label" "$status" >> "${GITHUB_STEP_SUMMARY:?}"
+}
+
+for name in baseline candidate; do
+  phase="$work/$name"
+  run_step "$phase" tests 6m go test -count=1 -timeout=3m "$suite"
+  if [[ $app != gitcrawl ]]; then
+    mkdir -p "$phase/bin"
+    run_step "$phase" build 2m go build -o "$phase/bin/$app" "./cmd/$app"
+    if [[ $status == 0 ]]; then
+      phase_env "$phase" GOPROXY=off go version -m "$phase/bin/$app"
+      sha256sum "$phase/bin/$app"
+      smoke="$phase/smoke"
+      mkdir -p "$smoke"/{source,home,config,cache,data,state,tmp}
+      mkdir -m 700 "$smoke/runtime"
+      run_step "$smoke" smokes 2m python3 "$candidate/.github/scripts/downstream-smoke.py" \
+        run "$app" "$phase/bin/$app" "$smoke" "$phase/smoke-evidence"
+    else
+      echo "$name smokes unavailable: build failed" >> "${GITHUB_STEP_SUMMARY:?}"
+    fi
+  fi
   fingerprint "$phase" > "$phase/source-after.sha256"
   cmp "$phase/source.sha256" "$phase/source-after.sha256"
   sha256sum --check "$phase/modules.sha256"
-  sha256sum "$phase/tests.log"
-  printf '%s CLI exit: %s\n' "$name" "$status" >> "${GITHUB_STEP_SUMMARY:?}"
 done
 
+if [[ $app != gitcrawl ]]; then
+  if ! phase_env "$work/candidate" python3 "$candidate/.github/scripts/downstream-smoke.py" \
+    compare "$work/baseline/smoke-evidence/result.json" "$work/candidate/smoke-evidence/result.json"; then
+    result=1
+  fi
+fi
 verify_checkout "$candidate" "$CRAWLKIT_CANDIDATE_SHA"
 verify_checkout "$baseline" "$CRAWLKIT_BASELINE_SHA"
-verify_checkout "$gitcrawl" "$GITCRAWL_SHA"
+verify_checkout "$downstream" "$downstream_sha"
 exit "$result"

--- a/.github/scripts/downstream-compat.sh
+++ b/.github/scripts/downstream-compat.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ${1:-} == --probe-child ]]; then
+  exec python3 - <<'PY'
+import ctypes
+import json
+import os
+from pathlib import Path
+import signal
+import time
+
+assert os.getpid() == 1, "cancellation probe requires PID namespace init"
+assert os.getuid() == int(os.environ["RUN_UID"]), "probe UID drop failed"
+assert os.getgid() == int(os.environ["RUN_GID"]), "probe GID drop failed"
+pdeathsig = ctypes.c_int()
+PR_GET_PDEATHSIG = 2
+assert ctypes.CDLL(None).prctl(PR_GET_PDEATHSIG, ctypes.byref(pdeathsig), 0, 0, 0) == 0, \
+    "PR_GET_PDEATHSIG is unavailable"
+assert pdeathsig.value == signal.SIGKILL, \
+    "setpriv did not preserve unshare's SIGKILL parent-death signal"
+os.setsid()
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+child = os.fork()
+if child == 0:
+    os.setsid()
+role = "init" if child else "descendant"
+marker = {
+    "pid": os.getpid(), "uid": os.getuid(), "gid": os.getgid(),
+    "namespace": os.readlink("/proc/self/ns/pid"),
+    "pdeathsig_before_fork": pdeathsig.value,
+}
+target = Path(os.environ["PHASE_DIR"]) / (role + ".json")
+temporary = target.with_suffix(".tmp")
+temporary.write_text(json.dumps(marker))
+temporary.replace(target)
+while True:
+    time.sleep(1)
+PY
+fi
+
+if [[ ${1:-} == --offline ]]; then
+  shift
+  ip link set dev lo up
+  python3 - <<'PY'
+import errno
+import socket
+
+with socket.socket() as listener, socket.socket() as client:
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    client.settimeout(2)
+    client.connect(listener.getsockname())
+    connection, _ = listener.accept()
+    connection.close()
+with socket.socket() as external:
+    external.settimeout(2)
+    assert external.connect_ex(("192.0.2.1", 443)) in (
+        errno.ENETUNREACH, errno.EHOSTUNREACH
+    ), "external networking is not isolated"
+print("network preflight: loopback available; external route unavailable")
+PY
+  cd "$PHASE_DIR/source"
+  # Changing UID/GID clears PDEATHSIG; restore it before replacing namespace init.
+  exec setpriv --reuid="$RUN_UID" --regid="$RUN_GID" --init-groups \
+    --pdeathsig keep --no-new-privs "$@"
+fi
+
+[[ $(uname -s) == Linux ]] || { echo "Linux is required" >&2; exit 2; }
+[[ $# == 3 ]] || { echo "usage: $0 CANDIDATE BASELINE GITCRAWL" >&2; exit 2; }
+for tool in go git lsof tar sha256sum sudo unshare ip setpriv timeout python3; do
+  command -v "$tool" >/dev/null || { echo "missing required tool: $tool" >&2; exit 2; }
+done
+[[ $(go env GOVERSION) == go1.27.1 ]] || { echo "Go 1.27.1 is required" >&2; exit 2; }
+sudo -n true
+[[ $(setpriv --help) == *"--pdeathsig"* ]] ||
+  { echo "setpriv --pdeathsig keep is required for descendant cleanup" >&2; exit 2; }
+setpriv --version
+unshare --version
+timeout --version
+
+candidate=$(realpath "$1")
+baseline=$(realpath "$2")
+gitcrawl=$(realpath "$3")
+script=$(realpath "$0")
+work=$(mktemp -d "${RUNNER_TEMP:?}/crawlkit-downstream.XXXXXX")
+mkdir -p "$work/gomodcache" "$work/gopath" "$work/gocache"
+
+verify_checkout() {
+  local checkout=$1 expected=$2
+  [[ $expected =~ ^[0-9a-f]{40}$ ]]
+  [[ $(git -C "$checkout" rev-parse HEAD) == "$expected" ]] ||
+    { echo "source head mismatch: $checkout" >&2; exit 1; }
+  [[ -z $(git -C "$checkout" status --porcelain) ]] ||
+    { echo "source checkout is dirty: $checkout" >&2; exit 1; }
+  printf 'source %s tree %s\n' "$expected" "$(git -C "$checkout" rev-parse 'HEAD^{tree}')"
+}
+
+verify_checkout "$candidate" "${CRAWLKIT_CANDIDATE_SHA:?}"
+verify_checkout "$baseline" "${CRAWLKIT_BASELINE_SHA:?}"
+verify_checkout "$gitcrawl" "${GITCRAWL_SHA:?}"
+go version
+lsof -v 2>&1
+sha256sum "$(command -v go)" "$(command -v lsof)"
+uname -srmo
+printf 'cpus %s\n' "$(getconf _NPROCESSORS_ONLN)"
+
+fingerprint() {
+  tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
+    -C "$1" -cf - source library | sha256sum
+}
+
+phase_env() {
+  local phase=$1
+  env -i PATH="$PATH" HOME="$phase/home" \
+    XDG_CONFIG_HOME="$phase/config" XDG_CACHE_HOME="$phase/cache" \
+    XDG_DATA_HOME="$phase/data" XDG_STATE_HOME="$phase/state" \
+    XDG_RUNTIME_DIR="$phase/runtime" \
+    TMPDIR="$phase/tmp" TMP="$phase/tmp" TEMP="$phase/tmp" \
+    GOWORK=off GOTOOLCHAIN=local GOMAXPROCS=2 \
+    GOPATH="$work/gopath" GOMODCACHE="$work/gomodcache" GOCACHE="$work/gocache" \
+    GOSUMDB=sum.golang.org GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null \
+    GIT_NO_LAZY_FETCH=1 "${@:2}"
+}
+
+run_isolated() {
+  local phase=$1 duration=$2 kill_after=$3
+  shift 3
+  # timeout must share unshare's privileges to kill its blocked supervisor.
+  sudo -n timeout --signal=TERM --kill-after="$kill_after" "$duration" \
+    unshare --net --pid --fork --mount-proc --kill-child=KILL \
+    env -i PATH="$PATH" HOME="$phase/home" \
+    XDG_CONFIG_HOME="$phase/config" XDG_CACHE_HOME="$phase/cache" \
+    XDG_DATA_HOME="$phase/data" XDG_STATE_HOME="$phase/state" \
+    XDG_RUNTIME_DIR="$phase/runtime" \
+    TMPDIR="$phase/tmp" TMP="$phase/tmp" TEMP="$phase/tmp" \
+    GOWORK=off GOPROXY=off GOTOOLCHAIN=local GOMAXPROCS=2 \
+    GOPATH="$work/gopath" GOMODCACHE="$work/gomodcache" GOCACHE="$work/gocache" \
+    GOSUMDB=sum.golang.org GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null \
+    GIT_NO_LAZY_FETCH=1 GOFLAGS="-modfile=$phase/modules/go.mod -mod=readonly -p=2" \
+    RUN_UID="$(id -u)" RUN_GID="$(id -g)" PHASE_DIR="$phase" \
+    bash "$script" --offline "$@"
+}
+
+probe="$work/cancellation"
+mkdir -p "$probe"/{source,home,config,cache,data,state,tmp}
+mkdir -m 700 "$probe/runtime"
+run_isolated "$probe" 8s 1s bash "$script" --probe-child > "$probe/output.log" 2>&1 &
+probe_job=$!
+if phase_env "$probe" python3 - "$probe" <<'PY'
+import json
+import os
+from pathlib import Path
+import select
+import signal
+import sys
+import time
+
+root = Path(sys.argv[1])
+handles = {}
+try:
+    assert hasattr(os, "pidfd_open") and hasattr(signal, "pidfd_send_signal"), \
+        "Python pidfd support is required for owned-process cleanup"
+    ready = time.monotonic() + 5
+    while not all((root / (role + ".json")).exists() for role in ("init", "descendant")):
+        assert time.monotonic() < ready, "probe did not start; inspect cancellation/output.log"
+        time.sleep(0.05)
+    markers = [json.loads((root / (role + ".json")).read_text())
+               for role in ("init", "descendant")]
+    namespace = markers[0]["namespace"]
+    assert namespace != os.readlink("/proc/self/ns/pid"), "probe shares host PID namespace"
+    assert all(m["namespace"] == namespace and m["uid"] == os.getuid()
+               and m["gid"] == os.getgid() for m in markers), "probe ownership mismatch"
+    expected = {m["pid"] for m in markers}
+    owned = []
+    for proc in Path("/proc").iterdir():
+        if not proc.name.isdigit():
+            continue
+        try:
+            if os.readlink(proc / "ns/pid") != namespace:
+                continue
+            status = dict(line.split(":", 1) for line in (proc / "status").read_text().splitlines())
+            inner = int(status["NSpid"].split()[-1])
+            assert inner in expected, "unexpected process in owned probe namespace"
+            pid = int(proc.name)
+            fd = os.pidfd_open(pid)
+            try:
+                assert os.readlink(proc / "ns/pid") == namespace, "probe PID identity changed"
+            except BaseException:
+                os.close(fd)
+                raise
+            handles[fd] = pid
+            owned.append({"host_pid": pid, "namespace_pid": inner, "namespace": namespace})
+        except (FileNotFoundError, PermissionError):
+            continue
+    assert {p["namespace_pid"] for p in owned} == expected, \
+        "cannot resolve both owned probe PIDs from host /proc"
+    (root / "owned-pids.json").write_text(json.dumps(owned, indent=2) + "\n")
+    print(json.dumps({"owned_probe_pids": owned}), flush=True)
+    poll = select.poll()
+    for fd in handles:
+        poll.register(fd, select.POLLIN)
+    pending = set(handles)
+    deadline = time.monotonic() + 10
+    while pending and time.monotonic() < deadline:
+        pending.difference_update(fd for fd, events in poll.poll(100)
+                                  if events & (select.POLLIN | select.POLLHUP))
+    assert not pending, "cancellation left an owned namespace process alive"
+    print("cancellation probe: namespace init and detached descendant exited")
+finally:
+    # pidfds can signal only the exact owned processes, never reused numeric PIDs.
+    drain = select.poll()
+    for fd in handles:
+        try:
+            signal.pidfd_send_signal(fd, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        drain.register(fd, select.POLLIN)
+    pending = set(handles)
+    deadline = time.monotonic() + 3
+    while pending and time.monotonic() < deadline:
+        pending.difference_update(fd for fd, events in drain.poll(100)
+                                  if events & (select.POLLIN | select.POLLHUP))
+    for fd in handles:
+        os.close(fd)
+    assert not pending, "failed to drain pidfd-bound probe processes"
+PY
+then
+  probe_verified=1
+else
+  probe_verified=0
+fi
+if wait "$probe_job"; then
+  probe_status=0
+else
+  probe_status=$?
+fi
+cat "$probe/output.log"
+[[ $probe_verified == 1 && $probe_status == 137 ]] ||
+  { echo "cancellation probe failed (exit $probe_status); refusing Go phases" >&2; exit 1; }
+printf 'cancellation probe: PASS (native KILL exit %s)\n' "$probe_status"
+
+for name in baseline candidate; do
+  phase="$work/$name"
+  library=$baseline
+  [[ $name == baseline ]] || library=$candidate
+  mkdir -p "$phase"/{source,library,modules,home,config,cache,data,state,tmp}
+  mkdir -m 700 "$phase/runtime"
+  git -C "$gitcrawl" archive HEAD | tar -xf - -C "$phase/source"
+  git -C "$library" archive HEAD | tar -xf - -C "$phase/library"
+  fingerprint "$phase" > "$phase/source.sha256"
+  cp "$phase/source/go.mod" "$phase/modules/go.mod"
+  sort -u "$phase/source/go.sum" "$phase/library/go.sum" > "$phase/modules/go.sum"
+  (
+    cd "$phase/source"
+    phase_env "$phase" GOPROXY=https://proxy.golang.org \
+      GOFLAGS="-modfile=$phase/modules/go.mod -mod=mod -p=2" \
+      go mod edit "-replace=github.com/openclaw/crawlkit=$phase/library"
+    # Normalize only private test inputs for the linked library's requirements.
+    phase_env "$phase" GOPROXY=https://proxy.golang.org \
+      GOFLAGS="-modfile=$phase/modules/go.mod -mod=mod -p=2" \
+      go list -deps -test ./internal/cli > "$phase/packages.txt"
+    phase_env "$phase" GOPROXY=off \
+      GOFLAGS="-modfile=$phase/modules/go.mod -mod=readonly -p=2" \
+      go list -m -json github.com/openclaw/crawlkit
+    phase_env "$phase" GOPROXY=off \
+      GOFLAGS="-modfile=$phase/modules/go.mod -mod=readonly -p=2" \
+      go list -deps -test -f '{{with .Module}}{{.Path}} {{.Version}}{{end}}' \
+      ./internal/cli | sort -u > "$phase/modules.txt"
+  )
+  sha256sum "$phase/modules/go.mod" "$phase/modules/go.sum" > "$phase/modules.sha256"
+  printf '%s dependency inputs:\n' "$name"
+  cat "$phase/modules.txt" "$phase/modules.sha256" "$phase/source.sha256"
+done
+
+result=0
+for name in baseline candidate; do
+  phase="$work/$name"
+  printf '::group::%s unchanged CLI suite\n' "$name"
+  if run_isolated "$phase" 6m 10s go test -count=1 -timeout=3m ./internal/cli \
+    2>&1 | tee "$phase/tests.log"; then
+    status=0
+  else
+    status=$?
+    result=1
+  fi
+  printf '::endgroup::\n%s CLI exit: %s\n' "$name" "$status"
+  fingerprint "$phase" > "$phase/source-after.sha256"
+  cmp "$phase/source.sha256" "$phase/source-after.sha256"
+  sha256sum --check "$phase/modules.sha256"
+  sha256sum "$phase/tests.log"
+  printf '%s CLI exit: %s\n' "$name" "$status" >> "${GITHUB_STEP_SUMMARY:?}"
+done
+
+verify_checkout "$candidate" "$CRAWLKIT_CANDIDATE_SHA"
+verify_checkout "$baseline" "$CRAWLKIT_BASELINE_SHA"
+verify_checkout "$gitcrawl" "$GITCRAWL_SHA"
+exit "$result"

--- a/.github/scripts/downstream-smoke.py
+++ b/.github/scripts/downstream-smoke.py
@@ -1,0 +1,116 @@
+"""Read-only CLI proof; invoked inside downstream-compat.sh's PID/network namespace."""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+
+
+SMOKES = {
+    "help": ["--help"],
+    "version": ["--version"],
+    "tui-help": ["tui", "--help"],
+    "metadata": ["metadata", "--json"],
+    "status": ["status", "--json"],
+    "tui": ["tui", "--json"],
+}
+
+
+def digest(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def snapshot(root):
+    result = {}
+    for path in sorted(root.rglob("*")):
+        mode = path.lstat().st_mode
+        value = {"mode": mode}
+        if stat.S_ISLNK(mode):
+            value["target"] = os.readlink(path)
+        elif stat.S_ISREG(mode):
+            value["sha256"] = digest(path.read_bytes())
+        elif not stat.S_ISDIR(mode):
+            raise ValueError(f"unexpected runtime file type: {path}")
+        result[str(path.relative_to(root))] = value
+    return result
+
+
+def normalized(value, runtime):
+    if isinstance(value, str):
+        if value == runtime or value.startswith(runtime + "/"):
+            return "<runtime>" + value[len(runtime):]
+        return value
+    if isinstance(value, list):
+        return [normalized(item, runtime) for item in value]
+    if isinstance(value, dict):
+        return {key: normalized(item, runtime) for key, item in value.items()}
+    return value
+
+
+def comparable(result):
+    assert result["passed"], "cannot compare an incomplete or failing smoke"
+    values = normalized(result["json"], result["runtime"])
+    # control.NewStatus records wall time; no other field may be ignored.
+    timestamp = values["status"]["generated_at"]
+    assert isinstance(timestamp, str) and timestamp, "missing status timestamp"
+    values["status"]["generated_at"] = "<generated-at>"
+    return values
+
+
+def run(app, binary, runtime, evidence):
+    assert app in ("slacrawl", "discrawl", "notcrawl"), "unsupported app"
+    runtime, evidence = Path(runtime), Path(evidence)
+    evidence.mkdir()
+    result = {"app": app, "runtime": str(runtime), "steps": [], "json": {}, "passed": False}
+    prefix = [binary, "--config", str(runtime / "config" / (app + ".toml"))]
+
+    def command(name, args):
+        argv = prefix + args
+        print(json.dumps({"command": argv}), flush=True)
+        completed = subprocess.run(argv, cwd=runtime, input=b"", capture_output=True, timeout=30)
+        step = {"name": name, "argv": argv, "exit": completed.returncode}
+        for stream in ("stdout", "stderr"):
+            data = getattr(completed, stream)
+            (evidence / (name + "." + stream)).write_bytes(data)
+            step[stream + "_sha256"] = digest(data)
+            print(data.decode("utf-8", errors="replace"), end="", flush=True)
+        result["steps"].append(step)
+        assert completed.returncode == 0, f"{name} exited {completed.returncode}"
+        return completed.stdout.decode("utf-8")
+
+    try:
+        if app == "slacrawl":
+            command("fixture-init", ["init", "--db", str(runtime / "runtime" / "archive.db")])
+        elif app == "notcrawl":
+            command("fixture-init", ["init"])
+        else:
+            print("Discrawl: native absent-config/archive path; no authenticated init", flush=True)
+        result["before"] = snapshot(runtime)
+        for name, args in SMOKES.items():
+            text = command(name, args)
+            if name in ("metadata", "status", "tui"):
+                result["json"][name] = json.loads(text)
+            else:
+                assert text.strip(), f"{name} returned empty output"
+        result["after"] = snapshot(runtime)
+        assert result["before"] == result["after"], "read-only smokes changed runtime files"
+        result["passed"] = True
+    finally:
+        data = (json.dumps(result, indent=2, sort_keys=True) + "\n").encode()
+        (evidence / "result.json").write_bytes(data)
+        print(json.dumps({"smoke_result": result, "sha256": digest(data)}), flush=True)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 6 and sys.argv[1] == "run":
+        run(*sys.argv[2:])
+    elif len(sys.argv) == 4 and sys.argv[1] == "compare":
+        baseline, candidate = [json.loads(Path(name).read_text()) for name in sys.argv[2:]]
+        assert baseline["app"] == candidate["app"], "app identity mismatch"
+        assert comparable(baseline) == comparable(candidate), "baseline/candidate JSON differs"
+        print("baseline/candidate metadata, status, and TUI JSON match")
+    else:
+        sys.exit("usage: downstream-smoke.py run APP BINARY RUNTIME EVIDENCE | compare BASELINE CANDIDATE")

--- a/.github/scripts/downstream-smoke.test.cjs
+++ b/.github/scripts/downstream-smoke.test.cjs
@@ -30,7 +30,7 @@ test('manual qualification selects one pinned app without repeating ordinary CI'
   assert.match(workflow, /group: crawlkit-downstream-manual\n      cancel-in-progress: false/);
   for (const sha of [
     'ffaff3a72d91c5a1c2c6bf882412ef6e73e6dc78',
-    '9e8a981f39563aa73fb096eb903e801ac625fb84',
+    '2aef26b2df8a11d16a1e8d2d611a7082b6b7ba71',
     '5b2af061b057618eee38e322d801d54ca9ffba36',
   ]) assert.ok(workflow.includes(sha));
 });

--- a/.github/scripts/downstream-smoke.test.cjs
+++ b/.github/scripts/downstream-smoke.test.cjs
@@ -1,0 +1,139 @@
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const { readFileSync } = require('node:fs');
+const { test } = require('node:test');
+
+function python(code) {
+  const result = spawnSync('python3', ['-B', '-c', `
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+from unittest.mock import patch
+
+spec = importlib.util.spec_from_file_location("smoke", "downstream-smoke.py")
+smoke = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(smoke)
+${code}
+`], { cwd: __dirname, encoding: 'utf8', timeout: 10000 });
+  assert.ifError(result.error);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+}
+
+test('manual qualification selects one pinned app without repeating ordinary CI', () => {
+  const workflow = readFileSync(`${__dirname}/../workflows/ci.yml`, 'utf8');
+  assert.match(workflow, /options: \[slacrawl, discrawl, notcrawl\]/);
+  for (const job of ['test', 'downstream', 'windows-test']) {
+    assert.ok(workflow.includes(`  ${job}:\n    if: github.event_name != 'workflow_dispatch'\n`));
+  }
+  assert.match(workflow, /  downstream-app:\n    if: github.event_name == 'workflow_dispatch'\n    runs-on: ubuntu-latest\n    timeout-minutes: 20/);
+  assert.match(workflow, /group: crawlkit-downstream-manual\n      cancel-in-progress: false/);
+  for (const sha of [
+    'ffaff3a72d91c5a1c2c6bf882412ef6e73e6dc78',
+    '9e8a981f39563aa73fb096eb903e801ac625fb84',
+    '5b2af061b057618eee38e322d801d54ca9ffba36',
+  ]) assert.ok(workflow.includes(sha));
+});
+
+test('normalization preserves values except runtime paths and the top-level status clock', () => {
+  python(`
+original = {
+    "passed": True, "runtime": "/proof/baseline",
+    "json": {
+        "metadata": {"path": "/proof/baseline/home", "text": "prefix /proof/baseline"},
+        "status": {"generated_at": "2026-09-09T00:00:00Z", "nested": {"generated_at": "retained"}},
+        "tui": [{"id": 9007199254740993, "path": "/proof/baseline-other"}],
+    },
+}
+value = smoke.comparable(original)
+assert value["metadata"] == {"path": "<runtime>/home", "text": "prefix /proof/baseline"}
+assert value["status"] == {"generated_at": "<generated-at>", "nested": {"generated_at": "retained"}}
+assert value["tui"] == original["json"]["tui"]
+assert original["json"]["status"]["generated_at"] == "2026-09-09T00:00:00Z"
+original["passed"] = False
+try:
+    smoke.comparable(original)
+except AssertionError:
+    pass
+else:
+    raise AssertionError("a failed phase was accepted")
+`);
+});
+
+test('runtime snapshots detect content, mode, and symlink changes', () => {
+  python(`
+with tempfile.TemporaryDirectory() as directory:
+    root = Path(directory)
+    file = root / "archive.db"
+    file.write_bytes(b"before")
+    before = smoke.snapshot(root)
+    file.write_bytes(b"after")
+    assert smoke.snapshot(root) != before
+    before = smoke.snapshot(root)
+    file.chmod(0o400)
+    assert smoke.snapshot(root) != before
+    before = smoke.snapshot(root)
+    (root / "link").symlink_to("archive.db")
+    assert smoke.snapshot(root) != before
+`);
+});
+
+for (const app of ['slacrawl', 'discrawl', 'notcrawl']) {
+  test(`${app} smoke contract uses six readonly commands and only its native local fixture`, () => {
+    python(`
+from types import SimpleNamespace
+with tempfile.TemporaryDirectory() as directory:
+    root = Path(directory)
+    runtime = root / "runtime"
+    runtime.mkdir()
+    calls = []
+    def command(argv, **kwargs):
+        assert kwargs["timeout"] == 30 and kwargs["input"] == b""
+        assert kwargs["cwd"] == runtime
+        calls.append(argv[3:])
+        name = argv[3]
+        if name == "init":
+            (runtime / "fixture").write_text("local init")
+        text = '{"generated_at":"2026-09-09T00:00:00Z"}' if name == "status" else '{}'
+        return SimpleNamespace(returncode=0, stdout=text.encode(), stderr=b"")
+    with patch.object(smoke.subprocess, "run", command):
+        smoke.run("${app}", "/test/bin/${app}", str(runtime), str(root / "evidence"))
+    expected = list(smoke.SMOKES.values())
+    if "${app}" == "slacrawl":
+        expected.insert(0, ["init", "--db", str(runtime / "runtime" / "archive.db")])
+    elif "${app}" == "notcrawl":
+        expected.insert(0, ["init"])
+    assert calls == expected
+    result = json.loads((root / "evidence/result.json").read_text())
+    assert result["passed"] and result["before"] == result["after"]
+    assert len(list((root / "evidence").glob("*.stdout"))) == len(expected)
+`);
+  });
+}
+
+test('failed commands and runtime writes leave a failed receipt, never a pass', () => {
+  python(`
+from types import SimpleNamespace
+for failure in ("exit", "mutation", "empty", "json"):
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        runtime = root / "runtime"
+        runtime.mkdir()
+        def command(argv, **kwargs):
+            if failure == "mutation":
+                (runtime / "unexpected").write_text("write")
+            text = b"" if failure == "empty" else b"{}"
+            if failure == "json" and argv[3] == "metadata":
+                text = b"invalid"
+            return SimpleNamespace(returncode=1 if failure == "exit" else 0, stdout=text, stderr=b"")
+        with patch.object(smoke.subprocess, "run", command):
+            try:
+                smoke.run("discrawl", "/test/bin/discrawl", str(runtime), str(root / "evidence"))
+            except (AssertionError, ValueError):
+                pass
+            else:
+                raise AssertionError(f"{failure} was accepted")
+        result = json.loads((root / "evidence/result.json").read_text())
+        assert not result["passed"]
+`);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,20 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      app:
+        description: Pinned downstream app to qualify
+        required: true
+        type: choice
+        options: [slacrawl, discrawl, notcrawl]
 
 permissions:
   contents: read
 
 jobs:
   test:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -33,6 +41,7 @@ jobs:
       - run: GOWORK=off go test -race ./...
 
   downstream:
+    if: github.event_name != 'workflow_dispatch'
     needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -64,7 +73,55 @@ jobs:
       - name: Compare pinned downstream CLI suites
         run: bash candidate/.github/scripts/downstream-compat.sh candidate baseline gitcrawl
 
+  downstream-app:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: crawlkit-downstream-manual
+      cancel-in-progress: false
+    env:
+      CRAWLKIT_BASELINE_SHA: 26a574e53b485cd2191df603f02d17fab6d3c4af
+      CRAWLKIT_CANDIDATE_SHA: ${{ github.sha }}
+      DOWNSTREAM_APP: ${{ inputs.app }}
+    steps:
+      - name: Resolve pinned public app
+        id: app
+        run: |
+          case "$DOWNSTREAM_APP" in
+            slacrawl) sha=ffaff3a72d91c5a1c2c6bf882412ef6e73e6dc78 ;;
+            discrawl) sha=9e8a981f39563aa73fb096eb903e801ac625fb84 ;;
+            notcrawl) sha=5b2af061b057618eee38e322d801d54ca9ffba36 ;;
+            *) echo "unsupported downstream app" >&2; exit 2 ;;
+          esac
+          printf 'sha=%s\n' "$sha" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ env.CRAWLKIT_CANDIDATE_SHA }}
+          path: candidate
+          persist-credentials: false
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ env.CRAWLKIT_BASELINE_SHA }}
+          path: baseline
+          persist-credentials: false
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: openclaw/${{ inputs.app }}
+          ref: ${{ steps.app.outputs.sha }}
+          path: downstream
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.27.1'
+          cache: false
+      - name: Compare pinned app tests, builds, and read-only smokes
+        env:
+          DOWNSTREAM_SHA: ${{ steps.app.outputs.sha }}
+        run: bash candidate/.github/scripts/downstream-compat.sh candidate baseline downstream "$DOWNSTREAM_APP"
+
   windows-test:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,38 @@ jobs:
       - run: GOWORK=off go test ./...
       - run: GOWORK=off go test -race ./...
 
+  downstream:
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CRAWLKIT_BASELINE_SHA: 26a574e53b485cd2191df603f02d17fab6d3c4af
+      CRAWLKIT_CANDIDATE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      GITCRAWL_SHA: dab4d849f9562306da41267cda2b2fd6868a41a8
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ env.CRAWLKIT_CANDIDATE_SHA }}
+          path: candidate
+          persist-credentials: false
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ env.CRAWLKIT_BASELINE_SHA }}
+          path: baseline
+          persist-credentials: false
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: openclaw/gitcrawl
+          ref: ${{ env.GITCRAWL_SHA }}
+          path: gitcrawl
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.27.1'
+          cache: false
+      - name: Compare pinned downstream CLI suites
+        run: bash candidate/.github/scripts/downstream-compat.sh candidate baseline gitcrawl
+
   windows-test:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           case "$DOWNSTREAM_APP" in
             slacrawl) sha=ffaff3a72d91c5a1c2c6bf882412ef6e73e6dc78 ;;
-            discrawl) sha=9e8a981f39563aa73fb096eb903e801ac625fb84 ;;
+            discrawl) sha=2aef26b2df8a11d16a1e8d2d611a7082b6b7ba71 ;;
             notcrawl) sha=5b2af061b057618eee38e322d801d54ca9ffba36 ;;
             *) echo "unsupported downstream app" >&2; exit 2 ;;
           esac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## v0.15.1 - 2026-09-09
+
+- Preserve optional caller-owned warnings in remote ingest manifests and archive
+  snapshot metadata without changing the v1 protocol or legacy JSON payloads.
+
 ## v0.15.0 - 2026-09-08
 
 - Reject unsupported cascading foreign keys and triggers before generic

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -226,6 +226,7 @@ type ArchiveSnapshot struct {
 	CoverageComplete   bool     `json:"coverage_complete,omitempty"`
 	PublishedAt        string   `json:"published_at,omitempty"`
 	CutoverAt          string   `json:"cutover_at,omitempty"`
+	Warnings           []string `json:"warnings,omitempty"`
 }
 
 type ArchivePublish struct {
@@ -339,6 +340,7 @@ type IngestManifest struct {
 	SnapshotID    string   `json:"snapshot_id,omitempty"`
 	SourceSHA256  string   `json:"source_sha256,omitempty"`
 	Capabilities  []string `json:"capabilities,omitempty"`
+	Warnings      []string `json:"warnings,omitempty"`
 }
 
 type IngestRequest struct {

--- a/remote/warnings_test.go
+++ b/remote/warnings_test.go
@@ -1,0 +1,141 @@
+package remote
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestArchiveWarningsJSONCompatibility(t *testing.T) {
+	warnings := []string{"source note", "note with \"quotes\"\nand a newline", "source note"}
+	for _, tc := range []struct {
+		name         string
+		legacyJSON   string
+		without      any
+		empty        any
+		withWarnings any
+		newValue     func() any
+	}{
+		{
+			name:         "manifest",
+			legacyJSON:   `{"app":"example","archive":"sample","schema_version":1,"schema_hash":"hash"}`,
+			without:      &IngestManifest{App: "example", Archive: "sample", SchemaVersion: 1, SchemaHash: "hash"},
+			empty:        &IngestManifest{App: "example", Archive: "sample", SchemaVersion: 1, SchemaHash: "hash", Warnings: []string{}},
+			withWarnings: &IngestManifest{App: "example", Archive: "sample", SchemaVersion: 1, SchemaHash: "hash", Warnings: warnings},
+			newValue:     func() any { return &IngestManifest{} },
+		},
+		{
+			name:         "snapshot",
+			legacyJSON:   `{"id":"snapshot-1","schema_version":1,"coverage_complete":true}`,
+			without:      &ArchiveSnapshot{ID: "snapshot-1", SchemaVersion: 1, CoverageComplete: true},
+			empty:        &ArchiveSnapshot{ID: "snapshot-1", SchemaVersion: 1, CoverageComplete: true, Warnings: []string{}},
+			withWarnings: &ArchiveSnapshot{ID: "snapshot-1", SchemaVersion: 1, CoverageComplete: true, Warnings: warnings},
+			newValue:     func() any { return &ArchiveSnapshot{} },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			legacy := tc.newValue()
+			if err := json.Unmarshal([]byte(tc.legacyJSON), legacy); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(legacy, tc.without) {
+				t.Fatalf("legacy decode = %#v, want %#v", legacy, tc.without)
+			}
+			for _, value := range []any{tc.without, tc.empty} {
+				data, err := json.Marshal(value)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if string(data) != tc.legacyJSON {
+					t.Fatalf("empty warnings changed legacy JSON: %s", data)
+				}
+			}
+
+			data, err := json.Marshal(tc.withWarnings)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var fields map[string]json.RawMessage
+			if err := json.Unmarshal(data, &fields); err != nil {
+				t.Fatal(err)
+			}
+			var gotWarnings []string
+			if err := json.Unmarshal(fields["warnings"], &gotWarnings); err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Equal(gotWarnings, warnings) {
+				t.Fatalf("warnings = %#v, want %#v", gotWarnings, warnings)
+			}
+			delete(fields, "warnings")
+			var legacyFields map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(tc.legacyJSON), &legacyFields); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(fields, legacyFields) {
+				t.Fatalf("warnings changed existing fields: %#v", fields)
+			}
+			decoded := tc.newValue()
+			if err := json.Unmarshal(data, decoded); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(decoded, tc.withWarnings) {
+				t.Fatalf("roundtrip = %#v, want %#v", decoded, tc.withWarnings)
+			}
+		})
+	}
+}
+
+func TestClientTransportsArchiveWarnings(t *testing.T) {
+	warnings := []string{"source note", "additional note"}
+	var received IngestRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/apps/example/archives/sample/ingest":
+			if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+				t.Error(err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(IngestResult{Complete: true})
+		case "/v1/apps/example/archives/sample/status":
+			_ = json.NewEncoder(w).Encode(Status{
+				App:      "example",
+				Archive:  "sample",
+				Warnings: []string{"request note"},
+				Snapshot: &ArchiveSnapshot{ID: "snapshot-1", Warnings: warnings},
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Options{Endpoint: server.URL, TokenProvider: StaticToken("test-token")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := client.Ingest(context.Background(), "example", "sample", IngestRequest{
+		Manifest: IngestManifest{Warnings: warnings},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Complete || received.Manifest.App != "example" || received.Manifest.Archive != "sample" ||
+		!slices.Equal(received.Manifest.Warnings, warnings) {
+		t.Fatalf("ingest = %#v, manifest = %#v", result, received.Manifest)
+	}
+	status, err := client.Status(context.Background(), "example", "sample")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Snapshot == nil || status.Snapshot.ID != "snapshot-1" ||
+		!slices.Equal(status.Snapshot.Warnings, warnings) ||
+		!slices.Equal(status.Warnings, []string{"request note"}) {
+		t.Fatalf("status = %#v, snapshot = %#v", status, status.Snapshot)
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where callers cannot carry optional warnings through remote
ingest manifests or retain warnings in archive snapshot metadata.

## Why This Change Was Made

Add optional `Warnings []string` fields to `remote.IngestManifest` and
`remote.ArchiveSnapshot`, using the existing JSON transport. Nil and empty
warnings stay omitted, so legacy payloads remain unchanged. Warning meaning and
policy remain caller-owned; top-level status warnings remain separate.

This also prepares the dated v0.15.1 release entry and adds bounded downstream
qualification to the existing CI workflow. Ordinary PR CI compares a pinned
Gitcrawl CLI suite against baseline and candidate Crawlkit source. A separate
manual-only path selects one pinned public Slacrawl, Discrawl, or Notcrawl
source for full tests, a build, and six read-only CLI smokes.

Both paths use separate native Git archives, private test-only modfiles, and
the same cancellation/descendant-drain probe. Each Linux job has a 20-minute
ceiling. Manual app runs are serialized and skip the ordinary library,
Windows, and Gitcrawl jobs. There are no additional paid runner tiers.

There are no persistent dependency, schema, wire-version, consumer runtime, or
deployment changes. No historical archive data is rewritten. The temporary
replacement exists only in CI test inputs, never in a published consumer or
release module.

## User Impact

Callers can send and receive snapshot-specific warnings without a custom
transport wrapper. Existing callers that do not supply warnings keep the same
JSON shape. Publication of a new module version remains a separate step after
full downstream and merge qualification.

## Evidence

### Current Head

Signed head: `74949074c626f84b96f4db74656aaa930ff4ba8c`; GitHub verifies the signature.
The last commit changes only the Discrawl source SHA and its matching verifier
assertion. The warning implementation, warning tests, runtime harness, smoke
verifier, dependency declarations, permissions, and timeouts are unchanged.
The original warning-only head remains
`7c10ef2537034e818dd8a2bc6e2024aa20704ab9`.

[CI run 34376231168, attempt 1](https://github.com/openclaw/crawlkit/actions/runs/34376231168)
passed library tidy/lockfile integrity, vet, deadcode, vulnerability checks,
tests/race, Windows tests, and the automatic Gitcrawl comparison.
CodeQL and secret scanning passed. The manual app job was intentionally skipped.
All 32 local Node helper tests, actionlint and whitespace checks also passed.

[Gitcrawl comparison job](https://github.com/openclaw/crawlkit/actions/runs/34376231168/job/102550436863):
baseline and candidate `go test -count=1 -timeout=3m ./internal/cli` passed
in 29.524s and 29.651s respectively. The native cancellation/descendant-drain
probe passed with KILL exit 137; all source and private module integrity checks
passed. Gitcrawl source remains
`dab4d849f9562306da41267cda2b2fd6868a41a8`.

All current comparisons use Crawlkit baseline
`26a574e53b485cd2191df603f02d17fab6d3c4af` and candidate `74949074c626f84b96f4db74656aaa930ff4ba8c`.

### Repaired Discrawl Qualification

[Discrawl run 34376916483, attempt 1](https://github.com/openclaw/crawlkit/actions/runs/34376916483)
passed at the current signed head. Its sole executed job finished in
148s. The ordinary library, Windows and Gitcrawl
jobs were intentionally skipped on this manual event.
Discrawl source: `2aef26b2df8a11d16a1e8d2d611a7082b6b7ba71`.

| Phase | Full tests | Build | Read-only smokes |
| --- | --- | --- | --- |
| Baseline | 11 packages passed; 1 without tests | Passed | All six passed |
| Candidate | 11 packages passed; 1 without tests | Passed | All six passed |

Both phases ran unchanged `go test -count=1 -timeout=3m ./...` and
`go build ./cmd/discrawl`. The complete suites, including `internal/share`,
passed with no failed packages. Both native binaries reported
`devel`.
No release binary was installed.

The six commands were `--help`, `--version`, `tui --help`,
`metadata --json`, `status --json` and `tui --json`.
Discrawl used its native absent-config/archive path; authenticated `init`
was never run. All 8 runtime filesystem
entries remained unchanged in each phase, including contents, modes and symlinks.
Metadata/status/TUI JSON matched after normalizing only the private runtime path
prefix and top-level status generation timestamp.

The native cancellation/descendant-drain probe passed with exit 137.
All seven network preflights proved loopback available and external routes
unavailable. Both source archives, original checkouts and private module inputs
passed integrity checks after execution. Exact source trees, private modfile/sum
bytes, module resolution, tool versions, commands, outputs and binary hashes
are retained in the job log. Complete job log SHA256:
`74d7e92dba1a6574eca1bec02adc642d9307033aa63a45acb665da09963a7249`.

This is a changed-source qualification, not a retry of the failed old pin.
Discrawl's already-landed [owner repair, PR 200](https://github.com/openclaw/discrawl/pull/200)
separates raw integrity metadata from inferred planning fingerprints and corrects
the hostile-DM fixture. The current source retains the three formerly failing
tests. No Discrawl source fix, test skip, timeout increase, Crawlkit validation
weakening, or published dependency replacement was introduced here.

### Preserved Old-Pin Discrawl Failure

[Old Discrawl run 34357652320, attempt 1](https://github.com/openclaw/crawlkit/actions/runs/34357652320)
remains a failure at Crawlkit head `c862208d8b7009d41bc41bdfa61c59d93a7665fc` and Discrawl source
`9e8a981f39563aa73fb096eb903e801ac625fb84`. It is not relabeled as a pass.
Both phases failed the same three `internal/share` tests:

| Test | Old-pin result in both phases |
| --- | --- |
| `TestMergeIfChangedInfersLegacyManifestFilesFromGit` | Compressed SHA256 mismatch |
| `TestSnapshotExcludesAndPreservesDirectMessages` | Message row count did not match file manifests |
| `TestImportAtRestoresTaggedSnapshotWithoutMovingCheckout` | Compressed SHA256 mismatch |

Ten packages passed, one failed, and one had no test files per phase.
Both builds and all six smokes passed; version was `0.11.2`.
Eight runtime entries remained unchanged; JSON parity, cancellation, networking
and integrity checks passed. Those partial successes did not qualify that old
source. Its 20-minute allocation remains consumed, without a refund or retry.

### Reused App Evidence

These runs retain their actual original Crawlkit candidate
`c862208d8b7009d41bc41bdfa61c59d93a7665fc` and the same baseline above. They are reused evidence,
not new runs attributed to the current head. Library and runtime harness bytes,
and their app pins, are unchanged by the two-literal Discrawl update.

| App | Pinned public source | Original successful run |
| --- | --- | --- |
| Slacrawl | `ffaff3a72d91c5a1c2c6bf882412ef6e73e6dc78` | [34357016125](https://github.com/openclaw/crawlkit/actions/runs/34357016125) |
| Notcrawl | `5b2af061b057618eee38e322d801d54ca9ffba36` | [34358275654](https://github.com/openclaw/crawlkit/actions/runs/34358275654) |

Slacrawl passed both full suites (14 tested packages, three without tests),
both builds and all six smokes per phase in a 94-second job. Notcrawl passed
both full suites (ten packages), both builds and all six smokes per phase in
a 65-second job. Both used native local fixture initialization, kept all nine
runtime entries unchanged, and passed normalized JSON parity, native
cancellation, loopback-only networking and source/module integrity checks.
Notcrawl's development binary reported `dev`.

### Isolation And Accounting

Native Go 1.27.1 and native lsof; serial baseline/candidate execution with
`GOWORK=off`, `GOTOOLCHAIN=local`, `GOMAXPROCS=2` and `-p=2`.
HOME/XDG/temp/runtime and Go caches are private. Test/build/smoke phases use
`GOPROXY=off`, readonly private modfiles and loopback-only network/PID namespaces.
Preparation uses the official Go proxy/checksum database and normalizes only
private test inputs. The temporary Crawlkit replacement never enters any
published consumer, source lockfile or release module.

The three earlier manual allocations remain consumed (60 minutes). The one
additional changed-pin Discrawl allowance is now consumed (20 minutes).
All four manual attempts are terminal, serial and unretried. No larger runner,
new paid tier, provider credential, collector/auth command, live archive,
Cloud operation, local Go run, tag or release was used for this continuation.

### Earlier Proof And Remaining Gates

[Original c862208d CI](https://github.com/openclaw/crawlkit/actions/runs/34356181536)
and [first Linux harness CI](https://github.com/openclaw/crawlkit/actions/runs/34354089591)
remain preserved at their original heads.
[Earlier downstream proof](https://github.com/openclaw/crawlkit/pull/113#issuecomment-5601396600)
records Gitcrawl's other package tests, builds and isolated CLI smokes.
[The continuation](https://github.com/openclaw/crawlkit/pull/113#issuecomment-5601648426)
retains the macOS CLI timeout limitation. Neither history nor failure is rewritten.

Warning tests cover legacy decoding, nil/empty omission, ordering, duplicates,
escaping, existing fields and distinct status/snapshot warnings through the real
HTTP client. These establish library transport compatibility, not deployed
service persistence.

The [exact-head review](https://github.com/openclaw/crawlkit/pull/113#issuecomment-5601155906)
found no code/security defect and requested this repaired-pin qualification
and refreshed source bindings; those requested proof steps are recorded above.
No redundant manual re-review was requested for this unchanged head.
**Remaining gates:** independent exact-head landing clearance, explicit ready
and merge authorization, then exact-main qualification and the native signed
release workflow. This proof does not claim or authorize merge or release.

Runtime Go delta remains +2/-0; warning tests +141/-0; verifier tests +139/-0;
changelog +5/-0. Validation automation remains +357 harness lines,
+116 smoke-verifier lines, +89 workflow lines and +74 helper-documentation lines.
The latest commit adds/removes one CI pin line and one test expectation line;
no additional runtime behavior or dependency change.
