### PR TITLE
feat: process durable background work without pausing ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ first crawl
 | Search | `embed`, `vector` | Embedding providers, vector encoding, exact search, and result fusion |
 | App contracts | `control`, `output`, `progress` | Machine-readable metadata, output formats, and CI-safe progress logs |
 | Remote archives | `remote` | Provider-neutral HTTP client and versioned archive protocol |
+| Background processing | `worker` | Bounded continuous workers over application-owned durable queues |
 | User surfaces | `scheduler`, `tui`, `releasecheck` | Refresh jobs, terminal browsing, and release notices |
 
 See the [package guide](docs/packages.md) for the complete inventory and [Go package reference](https://pkg.go.dev/github.com/openclaw/crawlkit) for exported APIs.
@@ -122,6 +123,8 @@ If a write is interrupted, history reads ignore a truncated final JSON value and
 | `uninstall` | Remove an installed periodic schedule |
 
 Scheduling uses launchd on macOS, systemd user units on Linux, Task Scheduler on Windows, and cron rendering as the portable fallback.
+
+See [Background workers](docs/background-workers.md) for content-triggered processing alongside ingestion.
 
 ## Boundaries
 

--- a/docs/background-workers.md
+++ b/docs/background-workers.md
@@ -1,0 +1,58 @@
+# Background workers
+
+`worker` supplies continuous bounded execution, not another cron scheduler.
+Use `scheduler`/`crawlctl` for periodic commands and `worker.Runner` within a
+long-running app for content-triggered work. Separate runners isolate task kinds.
+
+The generic `Queue[P, R]` adapter owns durable claims, completion, retries and
+release. `Handler[P, R]` performs expensive work on the bounded background pool,
+outside all database transactions. It must honor context cancellation. The
+runtime catches handler panics but cannot forcibly terminate a Go goroutine that
+ignores cancellation. Apps retain content selection, schema and privacy rules.
+
+## Required storage contract
+
+- Save source content and enqueue its job in the same transaction. Notify only
+  after commit; notification is a coalesced hint and polling recovers lost hints.
+- Give jobs stable keys and opaque input revisions. Increment a generation or use
+  a content hash when meaningful input changes. A latest-value job can replace
+  pending work; an event-processing app can use a distinct key for every event.
+- Claim ready work atomically with a fresh random token and an expiry. Enforce
+  the requested batch bound and priority class using indexed queries.
+- Fence **every** completion, retry and release by key, revision, token, pending
+  state and an unexpired lease. Recheck current source eligibility at completion.
+  Persist the result and successful job state atomically. A stale lease returns
+  false without mutating data, including after a source is deleted/recreated.
+- A process crash leaves recoverable leases. External side effects require
+  application idempotency keys; execution is at least once, not exactly once.
+- Use independent read connections for costly preparation. Claims and result
+  commits must be small and bounded so they do not monopolize ingestion's writer.
+
+Discrawl can adapt message generations and embedding rows; Gitcrawl can adapt
+thread content hashes and vectors without renaming its existing schema. The
+SQLite test adapter exercises lease recovery, stale edits, deletion/recreation,
+duplicate completion and the hash-revision shape. Independent task-kind tests
+verify that a stalled handler does not block another runner.
+
+## Defaults and operation
+
+Two workers, up to 64 items per batch, a 250 ms collection window and one-second
+fallback polling. Claims prefer fresh work four times then catch-up once, with
+unused capacity borrowed. Each kind has its own resource bounds. The default
+handler deadline is two minutes; storage calls have five-second deadlines.
+Leases must cover the full handler plus bounded completion budget; explicit
+shorter leases are rejected. No unbounded in-memory backlog is accumulated.
+
+Failures carry safe error codes, never raw inputs or provider responses. Unknown
+errors retry with exponential backoff and jitter (one second to one minute), up
+to three attempts. `Failure.Pause` represents an unavailable dependency, pauses
+that runner and preserves the attempt budget. `RetryAfter` is a minimum delay;
+permanent errors mark jobs failed. Apps can resume failed work through their own
+retry/rebuild contract. Queue failures are reported and retried while leases
+remain recoverable. Cancellation releases unfinished claims when storage permits.
+
+`Status` reports lifecycle, in-flight count, outcomes, retry time, last success and
+a safe error code. Apps combine it with indexed pending counts and queue ages in
+their status surface. Ten-second embedding freshness is a downstream acceptance
+target under a measured workload and healthy provider, not a scheduling guarantee
+during outages or sustained overload. Report lag rather than silently dropping work.

--- a/docs/background-workers.md
+++ b/docs/background-workers.md
@@ -40,7 +40,7 @@ Two workers, up to 64 items per batch, a 250 ms collection window and one-second
 fallback polling. Claims prefer fresh work four times then catch-up once, with
 unused capacity borrowed. Each kind has its own resource bounds. The default
 handler deadline is two minutes; storage calls have five-second deadlines.
-Leases must cover the full handler plus bounded completion budget; explicit
+Leases must cover the full handler plus bounded completion and failure-cleanup budget; explicit
 shorter leases are rejected. No unbounded in-memory backlog is accumulated.
 
 Failures carry safe error codes, never raw inputs or provider responses. Unknown

--- a/docs/boundary.md
+++ b/docs/boundary.md
@@ -63,6 +63,8 @@ parsers, and product-specific ranking in the apps.
 - Stable cross-crawler interchange DTOs such as the narrow contact-export
   envelope. Apps still own contact selection, normalization, and ranking.
 
+- Generic continuous worker lifecycle and bounded execution over app-owned durable queue adapters; applications retain source revisions, transactions, eligibility and result persistence.
+
 ## does not own
 
 `crawlkit` should not own these surfaces:

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -93,6 +93,10 @@ reader lease or a power-loss durability guarantee.
 
 The service boundary is defined in [Remote Contract](remote-contract.md). The Cloudflare Worker and D1 deployment remain outside this module.
 
+## Background processing
+
+- `worker` runs generic batched handlers over app-owned durable queues with revision fencing, expiring leases, priority, retries, cancellation, and status. See [Background workers](background-workers.md).
+
 ## User surfaces
 
 - `scheduler` discovers crawl apps, expands job config, prevents concurrent runs, records JSONL history, and renders or installs native schedules.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -295,9 +295,7 @@ func (r *Runner[P, R]) process(ctx context.Context, jobs []Job[P]) {
 	}
 	cancel()
 	if ctx.Err() != nil {
-		for _, job := range jobs {
-			r.release(job)
-		}
+		r.releaseBatch(jobs)
 		return
 	}
 	if err == nil && len(results) != len(jobs) {
@@ -309,8 +307,8 @@ func (r *Runner[P, R]) process(ctx context.Context, jobs []Job[P]) {
 	}
 	for i, job := range jobs {
 		if ctx.Err() != nil {
-			r.release(job)
-			continue
+			r.releaseBatch(jobs[i:])
+			return
 		}
 		call, cancel := context.WithTimeout(ctx, r.opts.StoreTimeout)
 		accepted, err := r.queue.Complete(call, job, results[i], time.Now().UTC())
@@ -408,6 +406,23 @@ func (r *Runner[P, R]) backoff(attempt int) time.Duration {
 	}
 	return delay
 }
+
+// Cancellation gets one bounded cleanup budget for the batch. If storage is
+// unavailable, remaining claims are recovered by lease expiry rather than
+// delaying process shutdown by one timeout per job.
+func (r *Runner[P, R]) releaseBatch(jobs []Job[P]) {
+	ctx, cancel := context.WithTimeout(context.Background(), r.opts.StoreTimeout)
+	defer cancel()
+	for _, job := range jobs {
+		if ctx.Err() != nil {
+			return
+		}
+		if _, err := r.queue.Release(ctx, job, time.Now().UTC()); err != nil {
+			r.problem("queue_release_failed")
+		}
+	}
+}
+
 func (r *Runner[P, R]) release(job Job[P]) {
 	ctx, cancel := context.WithTimeout(context.Background(), r.opts.StoreTimeout)
 	defer cancel()

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -142,9 +142,13 @@ func New[P, R any](queue Queue[P, R], handler Handler[P, R], opts Options) (*Run
 	if opts.StoreTimeout == 0 {
 		opts.StoreTimeout = 5 * time.Second
 	}
-	// A batch may need a bounded store operation for every result. No heartbeat
+	// Every result may need both a bounded store operation and failure cleanup. No heartbeat
 	// is necessary: the lease covers processing plus the entire completion budget.
-	minimumLease := opts.TaskTimeout + time.Duration(opts.BatchSize+2)*opts.StoreTimeout
+	availableOperations := (time.Duration(1<<63-1) - opts.TaskTimeout) / opts.StoreTimeout
+	if availableOperations < 2 || uint64(opts.BatchSize) > uint64((availableOperations-2)/2) {
+		return nil, errors.New("worker lease budget overflows duration")
+	}
+	minimumLease := opts.TaskTimeout + (2*time.Duration(opts.BatchSize)+2)*opts.StoreTimeout
 	if opts.LeaseDuration == 0 {
 		opts.LeaseDuration = minimumLease
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1,0 +1,444 @@
+// Package worker runs bounded background work against application-owned durable
+// queues. It does not own source schemas, content selection, or result storage.
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Class separates fresh input from catch-up work. A queue may implement both
+// classes in one table; classification must survive process restarts.
+type Class string
+
+const (
+	Fresh   Class = "fresh"
+	CatchUp Class = "catch_up"
+)
+
+// Job is an immutable claimed input. Token must be unique per claim, including
+// after a delete/recreate of Key. Revision is opaque (a generation or input hash).
+type Job[P any] struct {
+	Key      string
+	Revision string
+	Token    string
+	Attempts int
+	Payload  P
+}
+
+type ClaimRequest struct {
+	Kind       string
+	Class      Class
+	Limit      int
+	Now        time.Time
+	LeaseUntil time.Time
+}
+
+type Retry struct {
+	Now          time.Time
+	At           time.Time
+	Code         string
+	Permanent    bool
+	CountAttempt bool
+}
+
+// Queue implementations must atomically claim jobs and fence EVERY mutation by
+// key, revision, token and an unexpired lease. Complete must verify current source
+// eligibility/revision and commit the result and job completion in one transaction.
+// False means superseded/lost lease, not a failure. Enqueue belongs in the source
+// transaction; clearing a lease on a new revision invalidates in-flight work.
+// Implementations must be safe for concurrent calls and honor context cancellation.
+type Queue[P, R any] interface {
+	Claim(context.Context, ClaimRequest) ([]Job[P], error)
+	Complete(context.Context, Job[P], R, time.Time) (bool, error)
+	Retry(context.Context, Job[P], Retry) (bool, error)
+	Release(context.Context, Job[P], time.Time) (bool, error)
+}
+
+// Handler processes a bounded batch with no database transaction held. Results
+// correspond positionally to jobs. External side effects need their own stable
+// idempotency keys: execution is at least once, not exactly once.
+type Handler[P, R any] func(context.Context, []Job[P]) ([]R, error)
+
+// Failure classifies safe, content-free error codes. Pause describes an unavailable
+// dependency (credentials, provider outage or throttling): pause this runner and
+// reschedule without consuming per-job attempts. RetryAfter is a minimum delay.
+type Failure struct {
+	Code       string
+	RetryAfter time.Duration
+	Permanent  bool
+	Pause      bool
+}
+
+func (e *Failure) Error() string { return e.Code }
+
+type Options struct {
+	Kind          string
+	Concurrency   int
+	BatchSize     int
+	BatchWait     time.Duration
+	PollEvery     time.Duration
+	TaskTimeout   time.Duration
+	StoreTimeout  time.Duration
+	LeaseDuration time.Duration
+	RetryBase     time.Duration
+	RetryMax      time.Duration
+	MaxAttempts   int
+}
+
+// Status contains no payloads or provider error bodies. Apps may persist snapshots
+// and combine them with indexed queue counts/ages in their existing status surface.
+type Status struct {
+	Kind          string    `json:"kind"`
+	State         string    `json:"state"`
+	InFlight      int       `json:"in_flight"`
+	Completed     int64     `json:"completed"`
+	Superseded    int64     `json:"superseded"`
+	Retried       int64     `json:"retried"`
+	Failed        int64     `json:"failed"`
+	LastSuccessAt time.Time `json:"last_success_at,omitzero"`
+	LastError     string    `json:"last_error,omitempty"`
+	RetryAt       time.Time `json:"retry_at,omitzero"`
+}
+
+type Runner[P, R any] struct {
+	queue   Queue[P, R]
+	handler Handler[P, R]
+	opts    Options
+	wake    chan struct{}
+	mu      sync.Mutex
+	running bool
+	claims  uint64
+	status  Status
+}
+
+func New[P, R any](queue Queue[P, R], handler Handler[P, R], opts Options) (*Runner[P, R], error) {
+	if queue == nil || handler == nil || strings.TrimSpace(opts.Kind) == "" {
+		return nil, errors.New("worker requires a queue, handler and kind")
+	}
+	if opts.Concurrency < 0 || opts.BatchSize < 0 || opts.BatchWait < 0 || opts.PollEvery < 0 || opts.TaskTimeout < 0 || opts.StoreTimeout < 0 || opts.LeaseDuration < 0 || opts.RetryBase < 0 || opts.RetryMax < 0 || opts.MaxAttempts < 0 {
+		return nil, errors.New("worker limits must not be negative")
+	}
+	if opts.Concurrency == 0 {
+		opts.Concurrency = 2
+	}
+	if opts.BatchSize == 0 {
+		opts.BatchSize = 64
+	}
+	if opts.BatchWait == 0 {
+		opts.BatchWait = 250 * time.Millisecond
+	}
+	if opts.PollEvery == 0 {
+		opts.PollEvery = time.Second
+	}
+	if opts.TaskTimeout == 0 {
+		opts.TaskTimeout = 2 * time.Minute
+	}
+	if opts.StoreTimeout == 0 {
+		opts.StoreTimeout = 5 * time.Second
+	}
+	// A batch may need a bounded store operation for every result. No heartbeat
+	// is necessary: the lease covers processing plus the entire completion budget.
+	minimumLease := opts.TaskTimeout + time.Duration(opts.BatchSize+2)*opts.StoreTimeout
+	if opts.LeaseDuration == 0 {
+		opts.LeaseDuration = minimumLease
+	}
+	if opts.LeaseDuration < minimumLease {
+		return nil, errors.New("worker lease is shorter than its processing and completion budget")
+	}
+	if opts.RetryBase == 0 {
+		opts.RetryBase = time.Second
+	}
+	if opts.RetryMax == 0 {
+		opts.RetryMax = time.Minute
+	}
+	if opts.RetryMax < opts.RetryBase {
+		return nil, errors.New("worker retry maximum is below base")
+	}
+	if opts.MaxAttempts == 0 {
+		opts.MaxAttempts = 3
+	}
+	return &Runner[P, R]{queue: queue, handler: handler, opts: opts, wake: make(chan struct{}, 1), status: Status{Kind: opts.Kind, State: "stopped"}}, nil
+}
+
+// Notify is a coalesced wake-up hint; durable polling recovers lost notifications.
+// It never blocks an ingestion transaction. Call it after that transaction commits.
+func (r *Runner[P, R]) Notify() {
+	select {
+	case r.wake <- struct{}{}:
+	default:
+	}
+}
+func (r *Runner[P, R]) Status() Status { r.mu.Lock(); defer r.mu.Unlock(); return r.status }
+
+// Run starts this kind's worker pool. Multiple kinds use independent runners,
+// avoiding a slow handler's head-of-line blocking of unrelated task kinds.
+func (r *Runner[P, R]) Run(ctx context.Context) error {
+	r.mu.Lock()
+	if r.running {
+		r.mu.Unlock()
+		return errors.New("worker is already running")
+	}
+	r.running = true
+	r.status.State = "running"
+	r.mu.Unlock()
+	var wg sync.WaitGroup
+	for i := 0; i < r.opts.Concurrency; i++ {
+		wg.Go(func() { r.loop(ctx) })
+	}
+	wg.Wait()
+	r.mu.Lock()
+	r.running = false
+	r.status.State = "stopped"
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *Runner[P, R]) loop(ctx context.Context) {
+	for ctx.Err() == nil {
+		s := r.Status()
+		if delay := time.Until(s.RetryAt); delay > 0 {
+			if !r.wait(ctx, delay, false) {
+				return
+			}
+		}
+		if !r.wait(ctx, r.opts.BatchWait, false) {
+			return
+		}
+		if time.Now().Before(r.Status().RetryAt) {
+			continue
+		}
+		r.mu.Lock()
+		r.claims++
+		class := Fresh
+		if r.claims%5 == 0 {
+			class = CatchUp
+		}
+		r.mu.Unlock()
+		jobs, err := r.claim(ctx, class)
+		if err == nil && len(jobs) == 0 {
+			if class == Fresh {
+				class = CatchUp
+			} else {
+				class = Fresh
+			}
+			jobs, err = r.claim(ctx, class)
+		}
+		if err != nil {
+			r.problem("queue_claim_failed")
+			if !r.wait(ctx, r.opts.PollEvery, false) {
+				return
+			}
+			continue
+		}
+		if len(jobs) == 0 {
+			if !r.wait(ctx, r.opts.PollEvery, true) {
+				return
+			}
+			continue
+		}
+		if len(jobs) > r.opts.BatchSize { // A broken adapter must not bypass the bound.
+			r.problem("queue_batch_limit_exceeded")
+			for _, job := range jobs {
+				r.release(job)
+			}
+			if !r.wait(ctx, r.opts.PollEvery, false) {
+				return
+			}
+			continue
+		}
+		valid := true
+		for _, job := range jobs {
+			if ValidateJob(job) != nil {
+				valid = false
+			}
+		}
+		if !valid {
+			r.problem("queue_invalid_claim")
+			for _, job := range jobs {
+				r.release(job)
+			}
+			if !r.wait(ctx, r.opts.PollEvery, false) {
+				return
+			}
+			continue
+		}
+		r.process(ctx, jobs)
+	}
+}
+
+func (r *Runner[P, R]) claim(ctx context.Context, class Class) ([]Job[P], error) {
+	call, cancel := context.WithTimeout(ctx, r.opts.StoreTimeout)
+	defer cancel()
+	now := time.Now().UTC()
+	return r.queue.Claim(call, ClaimRequest{Kind: r.opts.Kind, Class: class, Limit: r.opts.BatchSize, Now: now, LeaseUntil: now.Add(r.opts.LeaseDuration)})
+}
+
+func (r *Runner[P, R]) process(ctx context.Context, jobs []Job[P]) {
+	r.mu.Lock()
+	r.status.InFlight += len(jobs)
+	r.mu.Unlock()
+	defer func() { r.mu.Lock(); r.status.InFlight -= len(jobs); r.mu.Unlock() }()
+	call, cancel := context.WithTimeout(ctx, r.opts.TaskTimeout)
+	results, err := invoke(call, r.handler, jobs)
+	if err == nil {
+		err = call.Err()
+	}
+	cancel()
+	if ctx.Err() != nil {
+		for _, job := range jobs {
+			r.release(job)
+		}
+		return
+	}
+	if err == nil && len(results) != len(jobs) {
+		err = &Failure{Code: "handler_result_count", Permanent: true}
+	}
+	if err != nil {
+		r.fail(ctx, jobs, err)
+		return
+	}
+	for i, job := range jobs {
+		if ctx.Err() != nil {
+			r.release(job)
+			continue
+		}
+		call, cancel := context.WithTimeout(ctx, r.opts.StoreTimeout)
+		accepted, err := r.queue.Complete(call, job, results[i], time.Now().UTC())
+		cancel()
+		if err != nil {
+			r.problem("queue_complete_failed")
+			r.release(job)
+			continue
+		}
+		r.mu.Lock()
+		if accepted {
+			r.status.Completed++
+			r.status.LastSuccessAt = time.Now().UTC()
+			r.status.LastError = ""
+			if !time.Now().Before(r.status.RetryAt) {
+				r.status.State = "running"
+			}
+		} else {
+			r.status.Superseded++
+		}
+		r.mu.Unlock()
+	}
+}
+
+func invoke[P, R any](ctx context.Context, handler Handler[P, R], jobs []Job[P]) (results []R, err error) {
+	defer func() {
+		if recover() != nil {
+			results = nil
+			err = &Failure{Code: "handler_panic", Permanent: true}
+		}
+	}()
+	return handler(ctx, jobs)
+}
+
+func (r *Runner[P, R]) fail(ctx context.Context, jobs []Job[P], cause error) {
+	failure := &Failure{Code: "handler_failed"}
+	var classified *Failure
+	if errors.As(cause, &classified) {
+		failure = classified
+	}
+	code := failure.Code
+	if strings.TrimSpace(code) == "" {
+		code = "handler_failed"
+	}
+	r.problem(code)
+	for _, job := range jobs {
+		delay := r.backoff(job.Attempts)
+		if failure.RetryAfter > delay {
+			delay = failure.RetryAfter
+		}
+		now := time.Now().UTC()
+		at := now.Add(delay)
+		permanent := failure.Permanent || (!failure.Pause && job.Attempts+1 >= r.opts.MaxAttempts)
+		if failure.Pause {
+			r.mu.Lock()
+			if at.After(r.status.RetryAt) {
+				r.status.RetryAt = at
+			}
+			r.status.State = "paused"
+			r.mu.Unlock()
+		}
+		call, cancel := context.WithTimeout(ctx, r.opts.StoreTimeout)
+		accepted, err := r.queue.Retry(call, job, Retry{Now: now, At: at, Code: code, Permanent: permanent, CountAttempt: !failure.Pause})
+		cancel()
+		if err != nil {
+			r.problem("queue_retry_failed")
+			r.release(job)
+			continue
+		}
+		r.mu.Lock()
+		if !accepted {
+			r.status.Superseded++
+		} else if permanent {
+			r.status.Failed++
+		} else {
+			r.status.Retried++
+		}
+		r.mu.Unlock()
+	}
+}
+
+func (r *Runner[P, R]) backoff(attempt int) time.Duration {
+	delay := r.opts.RetryBase
+	for i := 0; i < attempt && delay < r.opts.RetryMax; i++ {
+		if delay > r.opts.RetryMax/2 {
+			delay = r.opts.RetryMax
+		} else {
+			delay *= 2
+		}
+	}
+	// Bounded additive jitter; an explicit provider retry delay is never shortened.
+	delay += time.Duration(float64(delay) * 0.2 * rand.Float64())
+	if delay > r.opts.RetryMax {
+		delay = r.opts.RetryMax
+	}
+	return delay
+}
+func (r *Runner[P, R]) release(job Job[P]) {
+	ctx, cancel := context.WithTimeout(context.Background(), r.opts.StoreTimeout)
+	defer cancel()
+	if _, err := r.queue.Release(ctx, job, time.Now().UTC()); err != nil {
+		r.problem("queue_release_failed")
+	}
+}
+func (r *Runner[P, R]) problem(code string) {
+	r.mu.Lock()
+	r.status.LastError = code
+	r.status.State = "retrying"
+	r.mu.Unlock()
+}
+func (r *Runner[P, R]) wait(ctx context.Context, d time.Duration, wake bool) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	var hint <-chan struct{}
+	if wake {
+		hint = r.wake
+	}
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return ctx.Err() == nil
+	case <-hint:
+		return ctx.Err() == nil
+	}
+}
+
+// ValidateJob is available to adapters and contract tests. Tokens and revisions
+// are mandatory even for a task with only one current worker.
+func ValidateJob[P any](job Job[P]) error {
+	if job.Key == "" || job.Revision == "" || job.Token == "" || job.Attempts < 0 {
+		return fmt.Errorf("invalid worker claim identity")
+	}
+	return nil
+}

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -132,7 +133,7 @@ func fastOpts() Options {
 }
 func eventually(t *testing.T, f func() bool) {
 	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for !f() {
 		if time.Now().After(deadline) {
 			t.Fatal("condition timed out")
@@ -284,7 +285,7 @@ func TestFreshnessWhileCatchupAndSlowWork(t *testing.T) {
 		_ = q.db.QueryRow(`select state from tasks where key='fresh'`).Scan(&s)
 		return s == "done"
 	})
-	if time.Since(before) > time.Second {
+	if time.Since(before) > 10*time.Second {
 		t.Fatal("fresh input waited behind catch-up")
 	}
 	eventually(t, func() bool { return q.count("done") > 5 })
@@ -461,94 +462,113 @@ func TestIndependentTaskKinds(t *testing.T) {
 	stop()
 }
 
-type slowCleanupQueue struct {
-	*testQueue
+// This adapter models slow storage without real filesystem timing. The durable
+// adapter above separately covers SQLite claims and revision/lease fencing.
+type budgetQueue struct {
+	leaseUntil         time.Time
+	completed, retried int
+	jobs               int
 }
 
-func (q *slowCleanupQueue) Complete(ctx context.Context, j Job[string], r string, now time.Time) (bool, error) {
+func (q *budgetQueue) Claim(_ context.Context, r ClaimRequest) ([]Job[string], error) {
+	q.leaseUntil = r.LeaseUntil
+	q.jobs = r.Limit
+	out := make([]Job[string], r.Limit)
+	for i := range out {
+		key := fmt.Sprint(i)
+		if i == len(out)-1 {
+			key = "z"
+		}
+		out[i] = Job[string]{Key: key, Revision: "1", Token: key + "/token", Payload: "input"}
+	}
+	return out, nil
+}
+func (q *budgetQueue) Complete(ctx context.Context, j Job[string], _ string, now time.Time) (bool, error) {
 	if j.Key != "z" {
 		<-ctx.Done()
 		return false, ctx.Err()
 	}
-	return q.testQueue.Complete(ctx, j, r, now)
+	if !now.Before(q.leaseUntil) {
+		return false, nil
+	}
+	q.completed++
+	return true, nil
 }
-func (q *slowCleanupQueue) Retry(ctx context.Context, j Job[string], r Retry) (bool, error) {
+func (q *budgetQueue) Retry(ctx context.Context, j Job[string], r Retry) (bool, error) {
 	if j.Key != "z" {
 		<-ctx.Done()
 		return false, ctx.Err()
 	}
-	return q.testQueue.Retry(ctx, j, r)
+	if !r.Now.Before(q.leaseUntil) {
+		return false, nil
+	}
+	q.retried++
+	return true, nil
 }
-func (q *slowCleanupQueue) Release(ctx context.Context, j Job[string], now time.Time) (bool, error) {
+func (q *budgetQueue) Release(ctx context.Context, _ Job[string], _ time.Time) (bool, error) {
 	<-ctx.Done()
 	return false, ctx.Err()
 }
+
 func TestLeaseBudgetIncludesSlowFailureCleanup(t *testing.T) {
 	for _, failRetry := range []bool{false, true} {
 		t.Run(fmt.Sprint(failRetry), func(t *testing.T) {
-			q := &slowCleanupQueue{testQueue: newQueue(t)}
-			for _, key := range []string{"a", "b", "c", "d", "e", "f", "g", "z"} {
-				q.put(t, key, "1", "input", Fresh)
-			}
-			opts := fastOpts()
-			opts.BatchSize = 8
-			opts.StoreTimeout = 20 * time.Millisecond
-			opts.TaskTimeout = 200 * time.Millisecond
-			handler := func(ctx context.Context, j []Job[string]) ([]string, error) {
-				select {
-				case <-time.After(150 * time.Millisecond):
-				case <-ctx.Done():
-					return nil, ctx.Err()
+			synctest.Test(t, func(t *testing.T) {
+				q := &budgetQueue{}
+				opts := fastOpts()
+				opts.BatchSize = 8
+				opts.StoreTimeout = 20 * time.Millisecond
+				opts.TaskTimeout = 200 * time.Millisecond
+				handler := func(ctx context.Context, j []Job[string]) ([]string, error) {
+					time.Sleep(150 * time.Millisecond)
+					if failRetry {
+						return nil, &Failure{Code: "retry"}
+					}
+					return upper(ctx, j)
 				}
+				r, err := New[string, string](q, handler, opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+				jobs, err := r.claim(context.Background(), Fresh)
+				if err != nil || len(jobs) != 8 {
+					t.Fatal(jobs, err)
+				}
+				r.process(context.Background(), jobs)
 				if failRetry {
-					return nil, &Failure{Code: "retry"}
+					if q.retried != 1 {
+						t.Fatal("late retry lost its lease during earlier cleanup:", r.Status())
+					}
+				} else if q.completed != 1 {
+					t.Fatal("late result lost its lease during earlier cleanup:", r.Status())
 				}
-				return upper(ctx, j)
-			}
-			r, err := New[string, string](q, handler, opts)
-			if err != nil {
-				t.Fatal(err)
-			}
-			jobs, err := r.claim(context.Background(), Fresh)
-			if err != nil || len(jobs) != 8 {
-				t.Fatal(jobs, err)
-			}
-			r.process(context.Background(), jobs)
-			if failRetry {
-				if r.Status().Retried != 1 {
-					t.Fatal("late retry lost its lease during earlier cleanup:", r.Status())
-				}
-			} else if q.count("done") != 1 {
-				t.Fatal("late result lost its lease during earlier cleanup:", r.Status())
-			}
+			})
 		})
 	}
 }
-
 func TestCancellationCleanupHasOneBatchBudget(t *testing.T) {
-	q := &slowCleanupQueue{testQueue: newQueue(t)}
-	for i := 0; i < 8; i++ {
-		q.put(t, fmt.Sprint(i), "1", "payload", Fresh)
-	}
-	opts := fastOpts()
-	opts.BatchSize = 8
-	opts.StoreTimeout = 20 * time.Millisecond
-	r, err := New[string, string](q, upper, opts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	jobs, err := r.claim(context.Background(), Fresh)
-	if err != nil {
-		t.Fatal(err)
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	start := time.Now()
-	r.process(ctx, jobs)
-	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
-		t.Fatalf("shutdown cleanup used per-job deadlines: %s", elapsed)
-	}
-	if q.count("pending") != 8 {
-		t.Fatal("cancellation lost work")
-	}
+	synctest.Test(t, func(t *testing.T) {
+		q := &budgetQueue{}
+		opts := fastOpts()
+		opts.BatchSize = 8
+		opts.StoreTimeout = 20 * time.Millisecond
+		r, err := New[string, string](q, upper, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		jobs, err := r.claim(context.Background(), Fresh)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		start := time.Now()
+		r.process(ctx, jobs)
+		if elapsed := time.Since(start); elapsed != opts.StoreTimeout {
+			t.Fatalf("shutdown cleanup exceeded one budget: %s", elapsed)
+		}
+		if q.completed != 0 || q.retried != 0 {
+			t.Fatal("cancellation changed job outcome")
+		}
+	})
 }

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -1,0 +1,462 @@
+package worker
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"errors"
+	"fmt"
+	_ "modernc.org/sqlite"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type testQueue struct {
+	db            *sql.DB
+	path          string
+	claimError    atomic.Bool
+	completeError atomic.Bool
+	retryError    atomic.Bool
+	releaseError  atomic.Bool
+	oversize      atomic.Bool
+}
+
+func queueAt(t *testing.T, path string) *testQueue {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+	_, err = db.Exec(`create table if not exists tasks(key text primary key, revision text, payload text, result text default '', state text default 'pending', class text, token text default '', until_ns integer default 0, ready_ns integer default 0, attempts integer default 0)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &testQueue{db: db, path: path}
+}
+func newQueue(t *testing.T) *testQueue { return queueAt(t, filepath.Join(t.TempDir(), "jobs.sqlite")) }
+func (q *testQueue) put(t *testing.T, key, rev, payload string, class Class) {
+	t.Helper()
+	_, e := q.db.Exec(`insert into tasks(key,revision,payload,class)values(?,?,?,?) on conflict(key) do update set revision=excluded.revision,payload=excluded.payload,state='pending',token='',until_ns=0,ready_ns=0,attempts=0,class=excluded.class`, key, rev, payload, string(class))
+	if e != nil {
+		t.Fatal(e)
+	}
+}
+func (q *testQueue) Claim(ctx context.Context, r ClaimRequest) ([]Job[string], error) {
+	if q.claimError.Load() {
+		return nil, errors.New("fixture")
+	}
+	tx, e := q.db.BeginTx(ctx, nil)
+	if e != nil {
+		return nil, e
+	}
+	defer tx.Rollback()
+	rows, e := tx.QueryContext(ctx, `select key,revision,payload,attempts from tasks where state='pending' and class=? and ready_ns<=? and until_ns<=? order by key limit ?`, string(r.Class), r.Now.UnixNano(), r.Now.UnixNano(), r.Limit)
+	if e != nil {
+		return nil, e
+	}
+	var jobs []Job[string]
+	for rows.Next() {
+		var j Job[string]
+		if e = rows.Scan(&j.Key, &j.Revision, &j.Payload, &j.Attempts); e != nil {
+			rows.Close()
+			return nil, e
+		}
+		j.Token = rand.Text()
+		jobs = append(jobs, j)
+	}
+	e = rows.Err()
+	rows.Close()
+	if e != nil {
+		return nil, e
+	}
+	for _, j := range jobs {
+		if _, e = tx.ExecContext(ctx, `update tasks set token=?,until_ns=? where key=?`, j.Token, r.LeaseUntil.UnixNano(), j.Key); e != nil {
+			return nil, e
+		}
+	}
+	if e = tx.Commit(); e != nil {
+		return nil, e
+	}
+	if q.oversize.Load() && len(jobs) > 0 {
+		jobs = append(jobs, jobs[0])
+	}
+	return jobs, nil
+}
+func (q *testQueue) mutate(ctx context.Context, j Job[string], now time.Time, set string, args ...any) (bool, error) {
+	args = append(args, j.Key, j.Revision, j.Token, now.UnixNano())
+	r, e := q.db.ExecContext(ctx, `update tasks set `+set+` where key=? and revision=? and token=? and until_ns>? and state='pending'`, args...)
+	if e != nil {
+		return false, e
+	}
+	n, e := r.RowsAffected()
+	return n == 1, e
+}
+func (q *testQueue) Complete(ctx context.Context, j Job[string], result string, now time.Time) (bool, error) {
+	if q.completeError.Load() {
+		return false, errors.New("fixture")
+	}
+	return q.mutate(ctx, j, now, `result=?,state='done',token='',until_ns=0`, result)
+}
+func (q *testQueue) Retry(ctx context.Context, j Job[string], r Retry) (bool, error) {
+	if q.retryError.Load() {
+		return false, errors.New("fixture")
+	}
+	state := "pending"
+	if r.Permanent {
+		state = "failed"
+	}
+	inc := 0
+	if r.CountAttempt {
+		inc = 1
+	}
+	return q.mutate(ctx, j, r.Now, `state=?,ready_ns=?,attempts=attempts+?,token='',until_ns=0`, state, r.At.UnixNano(), inc)
+}
+func (q *testQueue) Release(ctx context.Context, j Job[string], now time.Time) (bool, error) {
+	if q.releaseError.Load() {
+		return false, errors.New("fixture")
+	}
+	return q.mutate(ctx, j, now, `token='',until_ns=0`)
+}
+func (q *testQueue) count(state string) int {
+	var n int
+	_ = q.db.QueryRow(`select count(*) from tasks where state=?`, state).Scan(&n)
+	return n
+}
+func fastOpts() Options {
+	return Options{Kind: "documents", Concurrency: 2, BatchSize: 4, BatchWait: time.Millisecond, PollEvery: 2 * time.Millisecond, TaskTimeout: time.Second, StoreTimeout: time.Second, RetryBase: time.Millisecond, RetryMax: 10 * time.Millisecond}
+}
+func eventually(t *testing.T, f func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for !f() {
+		if time.Now().After(deadline) {
+			t.Fatal("condition timed out")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+func run(t *testing.T, q *testQueue, h Handler[string, string], opts Options) (*Runner[string, string], context.CancelFunc) {
+	t.Helper()
+	r, e := New[string, string](q, h, opts)
+	if e != nil {
+		t.Fatal(e)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case e := <-done:
+			if e != nil {
+				t.Error(e)
+			}
+		case <-time.After(3 * time.Second):
+			t.Error("worker failed to stop")
+		}
+	})
+	return r, cancel
+}
+func upper(_ context.Context, jobs []Job[string]) ([]string, error) {
+	out := make([]string, len(jobs))
+	for i, j := range jobs {
+		out[i] = strings.ToUpper(j.Payload)
+	}
+	return out, nil
+}
+
+func TestDurableQueueRevisionDeleteAndReclaim(t *testing.T) {
+	q := newQueue(t)
+	ctx := context.Background()
+	q.put(t, "message", "v1", "old", Fresh)
+	now := time.Now()
+	req := ClaimRequest{Kind: "documents", Class: Fresh, Limit: 1, Now: now, LeaseUntil: now.Add(time.Second)}
+	jobs, e := q.Claim(ctx, req)
+	if e != nil || len(jobs) != 1 {
+		t.Fatal(jobs, e)
+	}
+	old := jobs[0]
+	if e = ValidateJob(old); e != nil {
+		t.Fatal(e)
+	}
+	q.put(t, "message", "v2", "new", Fresh)
+	if ok, e := q.Complete(ctx, old, "STALE", now); ok || e != nil {
+		t.Fatal("stale completion", ok, e)
+	}
+	if ok, e := q.Retry(ctx, old, Retry{Now: now, Permanent: true}); ok || e != nil {
+		t.Fatal("stale retry", ok, e)
+	}
+	if ok, e := q.Release(ctx, old, now); ok || e != nil {
+		t.Fatal("stale release", ok, e)
+	}
+	jobs, e = q.Claim(ctx, req)
+	if e != nil || len(jobs) != 1 {
+		t.Fatal(jobs, e)
+	}
+	crashed := jobs[0]
+	reopened := queueAt(t, q.path)
+	req.Now = now.Add(2 * time.Second)
+	req.LeaseUntil = now.Add(3 * time.Second)
+	jobs, e = reopened.Claim(ctx, req)
+	if e != nil || len(jobs) != 1 || jobs[0].Token == crashed.Token {
+		t.Fatal(jobs, e)
+	}
+	if ok, _ := q.Complete(ctx, crashed, "STALE", req.Now); ok {
+		t.Fatal("expired owner committed")
+	}
+	if ok, e := q.Complete(ctx, jobs[0], "NEW", req.Now); !ok || e != nil {
+		t.Fatal(ok, e)
+	}
+	if ok, _ := q.Complete(ctx, jobs[0], "DUPLICATE", req.Now); ok {
+		t.Fatal("duplicate completion")
+	}
+	q.put(t, "message", "v3", "deleted", Fresh)
+	req.Now = time.Now()
+	req.LeaseUntil = req.Now.Add(time.Second)
+	jobs, e = q.Claim(ctx, req)
+	if e != nil || len(jobs) != 1 {
+		t.Fatal(jobs, e)
+	}
+	if _, e = q.db.Exec(`delete from tasks where key='message'`); e != nil {
+		t.Fatal(e)
+	}
+	q.put(t, "message", "v3", "recreated", Fresh)
+	if ok, _ := q.Complete(ctx, jobs[0], "DELETED", time.Now()); ok {
+		t.Fatal("deleted lease resurrected result")
+	}
+}
+func TestRunBatchesAndGitcrawlHashRevision(t *testing.T) {
+	q := newQueue(t)
+	for i := 0; i < 20; i++ {
+		q.put(t, fmt.Sprint(i), "sha256:gitcrawl-title_original", fmt.Sprint(i), Fresh)
+	}
+	var peak atomic.Int64
+	r, cancel := run(t, q, func(ctx context.Context, j []Job[string]) ([]string, error) {
+		if len(j) > 4 {
+			t.Error("unbounded batch")
+		}
+		peak.Add(1)
+		defer peak.Add(-1)
+		return upper(ctx, j)
+	}, fastOpts())
+	eventually(t, func() bool { return q.count("done") == 20 })
+	cancel()
+	eventually(t, func() bool { return r.Status().State == "stopped" })
+	if r.Status().Completed != 20 || r.Status().LastSuccessAt.IsZero() {
+		t.Fatal(r.Status())
+	}
+}
+func TestFreshnessWhileCatchupAndSlowWork(t *testing.T) {
+	q := newQueue(t)
+	for i := 0; i < 100; i++ {
+		q.put(t, fmt.Sprintf("old-%03d", i), "1", "old", CatchUp)
+	}
+	opts := fastOpts()
+	opts.BatchSize = 1
+	started := make(chan struct{}, 2)
+	unblock := make(chan struct{})
+	r, _ := run(t, q, func(ctx context.Context, j []Job[string]) ([]string, error) {
+		if j[0].Payload == "old" {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			select {
+			case <-unblock:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+		return upper(ctx, j)
+	}, opts)
+	<-started
+	before := time.Now()
+	q.put(t, "fresh", "1", "new", Fresh)
+	r.Notify()
+	close(unblock)
+	eventually(t, func() bool {
+		var s string
+		_ = q.db.QueryRow(`select state from tasks where key='fresh'`).Scan(&s)
+		return s == "done"
+	})
+	if time.Since(before) > time.Second {
+		t.Fatal("fresh input waited behind catch-up")
+	}
+	eventually(t, func() bool { return q.count("done") > 5 })
+}
+func TestRetryPauseAndPermanentFailure(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		failure *Failure
+		want    string
+	}{{"retry", &Failure{Code: "temporary"}, "done"}, {"pause", &Failure{Code: "throttled", Pause: true, RetryAfter: 30 * time.Millisecond}, "done"}, {"permanent", &Failure{Code: "bad_input", Permanent: true}, "failed"}} {
+		t.Run(test.name, func(t *testing.T) {
+			q := newQueue(t)
+			q.put(t, "a", "1", "a", Fresh)
+			var calls atomic.Int32
+			var first time.Time
+			r, _ := run(t, q, func(ctx context.Context, j []Job[string]) ([]string, error) {
+				if calls.Add(1) == 1 {
+					first = time.Now()
+					return nil, test.failure
+				}
+				if test.failure.Pause && time.Since(first) < test.failure.RetryAfter {
+					t.Error("ignored retry-after")
+				}
+				return upper(ctx, j)
+			}, fastOpts())
+			eventually(t, func() bool { return q.count(test.want) == 1 })
+			if test.want == "failed" {
+				eventually(t, func() bool { return r.Status().Failed == 1 })
+			} else {
+				eventually(t, func() bool { return r.Status().Retried == 1 })
+			}
+		})
+	}
+}
+func TestHandlerCancellationReleasesClaim(t *testing.T) {
+	q := newQueue(t)
+	q.put(t, "a", "1", "a", Fresh)
+	entered := make(chan struct{})
+	r, cancel := run(t, q, func(ctx context.Context, _ []Job[string]) ([]string, error) {
+		close(entered)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}, fastOpts())
+	<-entered
+	if e := r.Run(context.Background()); e == nil {
+		t.Fatal("allowed duplicate runner")
+	}
+	cancel()
+	eventually(t, func() bool { return r.Status().State == "stopped" })
+	var token string
+	_ = q.db.QueryRow(`select token from tasks where key='a'`).Scan(&token)
+	if token != "" || q.count("pending") != 1 {
+		t.Fatal("claim not released")
+	}
+}
+func TestInputEditDuringHandlerDiscardsOldResult(t *testing.T) {
+	q := newQueue(t)
+	q.put(t, "a", "1", "old", Fresh)
+	entered := make(chan struct{})
+	proceed := make(chan struct{})
+	var once atomic.Bool
+	r, _ := run(t, q, func(ctx context.Context, j []Job[string]) ([]string, error) {
+		if once.CompareAndSwap(false, true) {
+			close(entered)
+			<-proceed
+		}
+		return upper(ctx, j)
+	}, fastOpts())
+	<-entered
+	q.put(t, "a", "2", "new", Fresh)
+	r.Notify()
+	close(proceed)
+	eventually(t, func() bool { return q.count("done") == 1 && r.Status().Superseded == 1 })
+	var result string
+	_ = q.db.QueryRow(`select result from tasks where key='a'`).Scan(&result)
+	if result != "NEW" {
+		t.Fatal(result)
+	}
+}
+func TestErrorsDoNotKillRunner(t *testing.T) {
+	for _, mode := range []string{"claim", "complete", "retry", "release", "oversize", "panic", "count", "unknown"} {
+		t.Run(mode, func(t *testing.T) {
+			q := newQueue(t)
+			q.put(t, "a", "1", "a", Fresh)
+			opts := fastOpts()
+			opts.BatchSize = 1
+			opts.MaxAttempts = 1
+			switch mode {
+			case "claim":
+				q.claimError.Store(true)
+			case "complete":
+				q.completeError.Store(true)
+			case "retry":
+				q.retryError.Store(true)
+			case "release":
+				q.completeError.Store(true)
+				q.releaseError.Store(true)
+			case "oversize":
+				q.oversize.Store(true)
+			}
+			r, cancel := run(t, q, func(ctx context.Context, j []Job[string]) ([]string, error) {
+				switch mode {
+				case "panic":
+					panic("private body")
+				case "count":
+					return nil, nil
+				case "retry":
+					return nil, &Failure{Code: "fixture"}
+				case "unknown":
+					return nil, errors.New("secret body")
+				}
+				return upper(ctx, j)
+			}, opts)
+			eventually(t, func() bool { return r.Status().LastError != "" })
+			if strings.Contains(r.Status().LastError, "body") {
+				t.Fatal("leaked handler text")
+			}
+			cancel()
+		})
+	}
+}
+func TestOptionsAndBackoff(t *testing.T) {
+	q := newQueue(t)
+	if _, e := New[string, string](nil, upper, Options{Kind: "x"}); e == nil {
+		t.Fatal("nil queue")
+	}
+	if _, e := New[string, string](q, nil, Options{Kind: "x"}); e == nil {
+		t.Fatal("nil handler")
+	}
+	for _, opts := range []Options{{}, {Kind: "x", Concurrency: -1}, {Kind: "x", LeaseDuration: time.Nanosecond}, {Kind: "x", RetryBase: time.Second, RetryMax: time.Millisecond}} {
+		if _, e := New[string, string](q, upper, opts); e == nil {
+			t.Fatal(opts)
+		}
+	}
+	r, e := New[string, string](q, upper, Options{Kind: "x"})
+	if e != nil {
+		t.Fatal(e)
+	}
+	for i := 0; i < 100; i++ {
+		r.Notify()
+	}
+	if r.backoff(100) != time.Minute {
+		t.Fatal("uncapped backoff")
+	}
+	if e = ValidateJob(Job[string]{}); e == nil {
+		t.Fatal("invalid claim")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if e = r.Run(ctx); e != nil {
+		t.Fatal(e)
+	}
+}
+
+func TestIndependentTaskKinds(t *testing.T) {
+	blocked := newQueue(t)
+	blocked.put(t, "message", "revision-2", "text", Fresh)
+	available := newQueue(t)
+	available.put(t, "issue", "sha256:gitcrawl-content", "title and body", Fresh)
+	entered := make(chan struct{})
+	_, stop := run(t, blocked, func(ctx context.Context, j []Job[string]) ([]string, error) {
+		close(entered)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}, fastOpts())
+	<-entered
+	opts := fastOpts()
+	opts.Kind = "document_hash"
+	other, _ := run(t, available, upper, opts)
+	eventually(t, func() bool { return available.count("done") == 1 })
+	if other.Status().Kind != "document_hash" {
+		t.Fatal(other.Status())
+	}
+	stop()
+}

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -524,3 +524,31 @@ func TestLeaseBudgetIncludesSlowFailureCleanup(t *testing.T) {
 		})
 	}
 }
+
+func TestCancellationCleanupHasOneBatchBudget(t *testing.T) {
+	q := &slowCleanupQueue{testQueue: newQueue(t)}
+	for i := 0; i < 8; i++ {
+		q.put(t, fmt.Sprint(i), "1", "payload", Fresh)
+	}
+	opts := fastOpts()
+	opts.BatchSize = 8
+	opts.StoreTimeout = 20 * time.Millisecond
+	r, err := New[string, string](q, upper, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jobs, err := r.claim(context.Background(), Fresh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	r.process(ctx, jobs)
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("shutdown cleanup used per-job deadlines: %s", elapsed)
+	}
+	if q.count("pending") != 8 {
+		t.Fatal("cancellation lost work")
+	}
+}

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -460,3 +460,67 @@ func TestIndependentTaskKinds(t *testing.T) {
 	}
 	stop()
 }
+
+type slowCleanupQueue struct {
+	*testQueue
+}
+
+func (q *slowCleanupQueue) Complete(ctx context.Context, j Job[string], r string, now time.Time) (bool, error) {
+	if j.Key != "z" {
+		<-ctx.Done()
+		return false, ctx.Err()
+	}
+	return q.testQueue.Complete(ctx, j, r, now)
+}
+func (q *slowCleanupQueue) Retry(ctx context.Context, j Job[string], r Retry) (bool, error) {
+	if j.Key != "z" {
+		<-ctx.Done()
+		return false, ctx.Err()
+	}
+	return q.testQueue.Retry(ctx, j, r)
+}
+func (q *slowCleanupQueue) Release(ctx context.Context, j Job[string], now time.Time) (bool, error) {
+	<-ctx.Done()
+	return false, ctx.Err()
+}
+func TestLeaseBudgetIncludesSlowFailureCleanup(t *testing.T) {
+	for _, failRetry := range []bool{false, true} {
+		t.Run(fmt.Sprint(failRetry), func(t *testing.T) {
+			q := &slowCleanupQueue{testQueue: newQueue(t)}
+			for _, key := range []string{"a", "b", "c", "d", "e", "f", "g", "z"} {
+				q.put(t, key, "1", "input", Fresh)
+			}
+			opts := fastOpts()
+			opts.BatchSize = 8
+			opts.StoreTimeout = 20 * time.Millisecond
+			opts.TaskTimeout = 200 * time.Millisecond
+			handler := func(ctx context.Context, j []Job[string]) ([]string, error) {
+				select {
+				case <-time.After(150 * time.Millisecond):
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+				if failRetry {
+					return nil, &Failure{Code: "retry"}
+				}
+				return upper(ctx, j)
+			}
+			r, err := New[string, string](q, handler, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			jobs, err := r.claim(context.Background(), Fresh)
+			if err != nil || len(jobs) != 8 {
+				t.Fatal(jobs, err)
+			}
+			r.process(context.Background(), jobs)
+			if failRetry {
+				if r.Status().Retried != 1 {
+					t.Fatal("late retry lost its lease during earlier cleanup:", r.Status())
+				}
+			} else if q.count("done") != 1 {
+				t.Fatal("late result lost its lease during earlier cleanup:", r.Status())
+			}
+		})
+	}
+}


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Crawler apps need to process newly ingested content without pausing collection while an embedding provider or another expensive task runs. Periodic command scheduling does not provide durable content-triggered execution, stale-result protection, or predictable fresh-data priority.

## Why This Change Was Made

Add a generic `worker` package with application-owned durable queue and handler interfaces. Bounded worker pools perform expensive processing outside database transactions; queue adapters fence completion, retries and release by revision and lease token. Source data and enqueue remain an app transaction. Fresh input receives four claim opportunities for each catch-up opportunity, with unused capacity borrowed.

Separate runners isolate task kinds. The interface fits Discrawl message generations and Gitcrawl content hashes without moving their schemas, privacy rules, content selection or result persistence into crawlkit. Existing `scheduler`/`crawlctl` remains responsible for periodic commands.

## User Impact

Downstream apps can add continuous background processing with bounded batching, cancellation, recoverable leases, provider backoff and safe status snapshots. Existing APIs and scheduling defaults are unchanged. Execution is explicitly at least once; adapters and external side effects must be idempotent.

## Evidence

- Full Go tests, race tests, vet and release-guard tests passed.
- New SQLite-backed contract tests cover edits during processing, delete/recreate, lease recovery, duplicate completion, throttling, cancellation, queue failures, fresh work amid catch-up, and independent task kinds.
- Worker package statement coverage exceeds 90%.
- Added regressions for slow failing completion/retry plus cleanup across a full batch, and bounded shutdown when storage is unavailable.
- Discrawl integration tests using this API measured 0.62 s p95 at 10 messages/second with 256 catch-up jobs and a simulated 200 ms provider. Gitcrawl provider/store tests and build also pass with the shared API.
- Module tidy leaves dependency files unchanged; dead-code and vulnerability checks passed.
