### PR TITLE
chore: prepare v0.16.0 background worker release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## v0.16.0 - 2026-09-11
+
+- Add the generic `worker` runtime for continuous processing over application-owned
+  durable queues, with bounded batches, fresh-input priority, cancellation,
+  retry/backoff, and safe status snapshots.
+- Define revision and lease fencing contracts so background results cannot
+  overwrite newer input; applications retain their schemas, eligibility rules,
+  transactions, and result persistence.
+- Budget leases for slow storage failure cleanup and bound shutdown cleanup for
+  the entire batch. SQLite-backed recovery tests and controlled-clock regressions
+  cover edits, deletes, expired ownership, duplicate completion, and slow cleanup.
+
 ## v0.15.1 - 2026-09-09
 
 - Preserve optional caller-owned warnings in remote ingest manifests and archive


### PR DESCRIPTION
## What Problem This Solves

The new shared background-worker API is merged, but downstream crawlers need a tagged module release. The release workflow requires a dated changelog section for the selected version.

## Why This Change Was Made

Prepare the v0.16.0 release notes for the worker API in #115. The official workflow will create the tag, build and verify assets, and publish the release.

## User Impact

Downstream apps can consume the worker API through a published Go module version. This preparation changes documentation only.

## Evidence

The worker PR passed tests, race, Windows, downstream compatibility, CodeQL and secret checks. The earlier v0.16.0 dispatch stopped before tag creation because this dated section was absent; no release tag or artifact was published.
