### PR TITLE
fix: prevent minute-long worker shutdown during retry cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v0.16.1 - 2026-09-11
+
+- Bound worker shutdown when cancellation arrives during retry or completion
+  persistence. Remaining claims share one cleanup deadline instead of waiting
+  a separate storage timeout per job; rejected batches use the same bound.
+
 ## v0.16.0 - 2026-09-11
 
 - Add the generic `worker` runtime for continuous processing over application-owned

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -248,9 +248,7 @@ func (r *Runner[P, R]) loop(ctx context.Context) {
 		}
 		if len(jobs) > r.opts.BatchSize { // A broken adapter must not bypass the bound.
 			r.problem("queue_batch_limit_exceeded")
-			for _, job := range jobs {
-				r.release(job)
-			}
+			r.releaseBatch(jobs)
 			if !r.wait(ctx, r.opts.PollEvery, false) {
 				return
 			}
@@ -264,9 +262,7 @@ func (r *Runner[P, R]) loop(ctx context.Context) {
 		}
 		if !valid {
 			r.problem("queue_invalid_claim")
-			for _, job := range jobs {
-				r.release(job)
-			}
+			r.releaseBatch(jobs)
 			if !r.wait(ctx, r.opts.PollEvery, false) {
 				return
 			}
@@ -315,6 +311,10 @@ func (r *Runner[P, R]) process(ctx context.Context, jobs []Job[P]) {
 		cancel()
 		if err != nil {
 			r.problem("queue_complete_failed")
+			if ctx.Err() != nil {
+				r.releaseBatch(jobs[i:])
+				return
+			}
 			r.release(job)
 			continue
 		}
@@ -354,7 +354,11 @@ func (r *Runner[P, R]) fail(ctx context.Context, jobs []Job[P], cause error) {
 		code = "handler_failed"
 	}
 	r.problem(code)
-	for _, job := range jobs {
+	for i, job := range jobs {
+		if ctx.Err() != nil {
+			r.releaseBatch(jobs[i:])
+			return
+		}
 		delay := r.backoff(job.Attempts)
 		if failure.RetryAfter > delay {
 			delay = failure.RetryAfter
@@ -375,6 +379,10 @@ func (r *Runner[P, R]) fail(ctx context.Context, jobs []Job[P], cause error) {
 		cancel()
 		if err != nil {
 			r.problem("queue_retry_failed")
+			if ctx.Err() != nil {
+				r.releaseBatch(jobs[i:])
+				return
+			}
 			r.release(job)
 			continue
 		}

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -572,3 +572,128 @@ func TestCancellationCleanupHasOneBatchBudget(t *testing.T) {
 		}
 	})
 }
+
+type cancelPersistenceQueue struct {
+	budgetQueue
+	cancel      context.CancelFunc
+	stage       string
+	outcome     string
+	unavailable bool
+	writes      int
+	released    []string
+	canceledAt  time.Time
+}
+
+func (q *cancelPersistenceQueue) Claim(ctx context.Context, req ClaimRequest) ([]Job[string], error) {
+	jobs, err := q.budgetQueue.Claim(ctx, req)
+	switch q.stage {
+	case "oversize":
+		jobs = append(jobs, Job[string]{Key: "extra", Revision: "1", Token: "dummy"})
+	case "invalid":
+		jobs[0].Revision = ""
+	}
+	return jobs, err
+}
+
+func (q *cancelPersistenceQueue) persist(ctx context.Context) (bool, error) {
+	q.writes++
+	if q.writes > 1 {
+		return false, ctx.Err()
+	}
+	q.canceledAt = time.Now()
+	q.cancel()
+	switch q.outcome {
+	case "accepted":
+		return true, nil
+	case "superseded":
+		return false, nil
+	default:
+		return false, ctx.Err()
+	}
+}
+
+func (q *cancelPersistenceQueue) Complete(ctx context.Context, _ Job[string], _ string, _ time.Time) (bool, error) {
+	return q.persist(ctx)
+}
+
+func (q *cancelPersistenceQueue) Retry(ctx context.Context, _ Job[string], _ Retry) (bool, error) {
+	return q.persist(ctx)
+}
+
+func (q *cancelPersistenceQueue) Release(ctx context.Context, job Job[string], _ time.Time) (bool, error) {
+	q.released = append(q.released, job.Key)
+	if q.canceledAt.IsZero() {
+		q.canceledAt = time.Now()
+		q.cancel()
+	}
+	if q.unavailable {
+		<-ctx.Done()
+		return false, ctx.Err()
+	}
+	return true, nil
+}
+
+func TestCancellationDuringPersistenceBoundsRunShutdown(t *testing.T) {
+	for _, stage := range []string{"retry", "complete", "oversize", "invalid"} {
+		for _, outcome := range []string{"error", "accepted", "superseded"} {
+			if (stage == "oversize" || stage == "invalid") && outcome != "error" {
+				continue
+			}
+			for _, unavailable := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/%s/unavailable=%t", stage, outcome, unavailable), func(t *testing.T) {
+					synctest.Test(t, func(t *testing.T) {
+						ctx, cancel := context.WithCancel(context.Background())
+						defer cancel()
+						q := &cancelPersistenceQueue{cancel: cancel, stage: stage, outcome: outcome, unavailable: unavailable}
+						opts := Options{Kind: "documents", Concurrency: 1}
+						handler := func(ctx context.Context, jobs []Job[string]) ([]string, error) {
+							if stage == "retry" {
+								return nil, errors.New("provider unavailable")
+							}
+							return upper(ctx, jobs)
+						}
+						r, err := New[string, string](q, handler, opts)
+						if err != nil {
+							t.Fatal(err)
+						}
+						if err := r.Run(ctx); err != nil {
+							t.Fatal(err)
+						}
+						wantTime := time.Duration(0)
+						wantReleases, wantWrites := r.opts.BatchSize, 1
+						if stage == "oversize" {
+							wantReleases++
+						}
+						if stage == "oversize" || stage == "invalid" {
+							wantWrites = 0
+						} else if outcome != "error" {
+							wantReleases--
+						}
+						if unavailable {
+							wantTime = r.opts.StoreTimeout
+							wantReleases = 1
+						}
+						if elapsed := time.Since(q.canceledAt); elapsed != wantTime {
+							t.Errorf("shutdown after cancellation took %s; want %s", elapsed, wantTime)
+						}
+						if q.writes != wantWrites || len(q.released) != wantReleases {
+							t.Errorf("writes=%d releases=%d; want %d and %d", q.writes, len(q.released), wantWrites, wantReleases)
+						}
+						s := r.Status()
+						var completed, retried, superseded int64
+						if outcome == "accepted" && stage == "complete" {
+							completed = 1
+						} else if outcome == "accepted" && stage == "retry" {
+							retried = 1
+						} else if outcome == "superseded" {
+							superseded = 1
+						}
+						if s.State != "stopped" || s.InFlight != 0 || s.Completed != completed || s.Retried != retried || s.Superseded != superseded || s.Failed != 0 {
+							t.Fatalf("unexpected final status: %+v", s)
+						}
+					})
+				})
+			}
+		}
+	}
+}


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

Related: #115, specifically [the final ClawSweeper cancellation finding](https://github.com/openclaw/crawlkit/pull/115#issuecomment-5639937590).

## What Problem This Solves

Fixes an issue where users stopping a crawler could wait over five minutes for its background worker to exit when cancellation interrupted saving retries and cleanup storage was unavailable. With the default 64-job batch and five-second storage timeout, v0.16.0 waited 320 seconds because each remaining job started another cleanup timeout.

## Why This Change Was Made

Stop persisting retries after cancellation and release unfinished claims using one shared cleanup deadline. Apply the same bounded cleanup to interrupted completion and rejected batches. Durable leases recover claims that cannot be released. Include dated v0.16.1 notes so the patch can ship through the existing official release workflow.

## User Impact

Shutdown during retry persistence now takes at most one cleanup timeout for the remaining batch when adapters honor cancellation: five seconds at default settings. The shared API, queue schema, normal retry accounting, and provider behavior remain compatible with v0.16.0.

## Evidence

- A controlled-clock regression failed on v0.16.0 with 320 seconds for interrupted retry persistence, 10 seconds for interrupted completion, and up to 325 seconds for rejected-batch cleanup. It passes after the fix with five seconds when cleanup storage is unavailable.
- Sixteen cases cover retry/completion cancellation, accepted/superseded/error outcomes, invalid/oversized claims, available/unavailable cleanup storage, preserved outcome accounting, and Runner.Run returning with zero in-flight work.
- Full Go tests, full race suite, vet, and module-tidy checks passed locally. Tests use temporary data only.
- Discrawl live-embedding store and CLI integration tests passed with the candidate worker under the race detector.
- Structured autoreview (Codex) completed with no actionable findings.
