### PR TITLE
chore(release): prepare v0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## 0.16.2 - 2026-09-11
+
+**Highlights:** Updated runtime dependencies and refreshed analysis tooling.
 
 - Refresh operating-system support to x/sys v0.48.0, cryptography to x/crypto v0.57.0, Unicode text handling to x/text v0.42.0, and terminal character widths to go-runewidth v0.0.30 while retaining the Go 1.27.0 minimum. Thanks @dependabot.
 - Update deadcode to v0.50.0, govulncheck to v1.8.0, and the pinned CodeQL action to v4.38.0.


### PR DESCRIPTION
Prepare the authorized v0.16.2 maintenance release by dating the changelog and adding its Highlights lead-in. The two dependency-maintenance bullets remain ordered and unchanged. GoReleaser supplies the CLI version through linker flags.

Validation: all 25 release-preflight tests passed; local autoreview is scoped-clean. The runtime changes landed in #118 with Linux/Windows/downstream CI and [real integration proof](https://github.com/openclaw/crawlkit/pull/118#issuecomment-5642252538). The unified workflow will run only after CI is green on the release commit.

Exact-head evidence for `1ab750ca1a9cd6b54cfed2b05942ac7d609ac1f9`:

- [Linux, Windows, and downstream CI passed](https://github.com/openclaw/crawlkit/actions/runs/34663077029).
- Both local and branch autoreview finished scoped-clean.
- Built the real CLI using the GoReleaser version injection (`GOWORK=off go build -trimpath -ldflags="-s -w -X main.version=0.16.2" ./cmd/crawlctl`). The resulting binary printed `0.16.2` for `--version` and the expected help text for `--help`.
- Extracted the dated section and verified one Highlights line and both unchanged maintenance bullets. The resulting release-note input is:

```markdown
## 0.16.2 - 2026-09-11

**Highlights:** Updated runtime dependencies and refreshed analysis tooling.

- Refresh operating-system support to x/sys v0.48.0, cryptography to x/crypto v0.57.0, Unicode text handling to x/text v0.42.0, and terminal character widths to go-runewidth v0.0.30 while retaining the Go 1.27.0 minimum. Thanks @dependabot.
- Update deadcode to v0.50.0, govulncheck to v1.8.0, and the pinned CodeQL action to v4.38.0.
```
