### PR TITLE
ci: share local validation and cancel superseded runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,30 +15,23 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
 jobs:
   test:
     if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - run: node --test .github/scripts/*.test.cjs
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
-      - run: GOWORK=off go mod tidy
-      - run: git diff --exit-code -- go.mod go.sum
-      - run: GOWORK=off go vet ./...
-      - run: |
-          output_file=$(mktemp)
-          GOWORK=off go run golang.org/x/tools/cmd/deadcode@v0.50.0 -test ./... > "$output_file"
-          if [ -s "$output_file" ]; then
-            cat "$output_file"
-            exit 1
-          fi
-      - run: GOWORK=off go run golang.org/x/vuln/cmd/govulncheck@v1.8.0 ./...
-      - run: GOWORK=off go test ./...
-      - run: GOWORK=off go test -race ./...
+      - name: Run local validation gates
+        run: make check
 
   downstream:
     if: github.event_name != 'workflow_dispatch'
@@ -123,6 +116,7 @@ jobs:
   windows-test:
     if: github.event_name != 'workflow_dispatch'
     runs-on: windows-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Run the same validation gates locally and in Linux CI, including formatting, and cancel superseded automatic CI runs.
+
 ## 0.16.2 - 2026-09-11
 
 **Highlights:** Updated runtime dependencies and refreshed analysis tooling.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,11 @@ make help
 make check
 ```
 
+Linux CI runs the same `make check` target, including formatting, analysis,
+unit/race tests, and release-script tests. Automatic runs cancel superseded
+runs for the same PR or branch; manual downstream qualification retains its
+existing job-level serialization.
+
 Keep public APIs small. `crawlkit` should own reusable local archive mechanics,
 not provider-specific Slack, Discord, Notion, or GitHub behavior.
 


### PR DESCRIPTION
## What Problem This Solves

Linux CI duplicates the local validation commands and omits formatting. Superseded automatic runs keep consuming runners.

## User Impact

Local and Linux CI validation use the same `make check` target. Automatic runs cancel older runs for the same PR or branch; manual downstream qualification retains its existing serialization. Linux and Windows jobs have a 20-minute ceiling.

## Why This Change Was Made

Use the existing Makefile as the validation source of truth and give manual dispatches unique workflow-level concurrency groups. Preserve all existing analysis, unit/race, release-script, Windows, and downstream gates.

The separate dependency audit checked 66 modules plus actually imported test/runtime packages. Imported modules are already current except libc v1.75.7, which must remain at v1.75.6 to match SQLite v1.58.0's explicit requirement. Other newer graph modules are not imported and do not warrant adding requirements. Go 1.27.1, deadcode v0.50.0, govulncheck v1.8.0, and all seven pinned marketplace Actions are current. No module, Action, or runtime-floor bump is warranted. New selections were assessed against a 48-hour release-age cutoff.

## Evidence

- `actionlint` 1.7.12 and `git diff --check` pass. `make -n check` includes tidiness, formatting, vet, deadcode, govulncheck, unit tests, race tests, and all 32 Node release/helper tests. The final cleanup's full `make check` passes.
- Isolated Codex autoreview found the single-pending-run concurrency edge in the first draft. Manual dispatches now use their run ID; re-review reports `scoped-clean` through P2.
- Live proof: build `crawlctl` from this checkout, then execute `run`, `status --json`, `logs`, and cron `install --dry-run` with a temporary synthetic config; all pass.
- Dependency evidence: `GOWORK=off go list -m -u -json all`, `go list -deps -test`, tool module queries, the Go downloads API, and GitHub release/tag lookups. Existing Action SHA pins match the latest action versions; CodeQL's bundle release was distinguished from action v4.38.0.

All applicable checks pass at `f52684ca4f2b0b42fa3eeae6bbcde0c542f70424`, including the [new make-check CI job, Windows tests, and downstream suite](https://github.com/openclaw/crawlkit/actions/runs/34728486907), CodeQL, and verified-secret scans. The opt-in real Python turbovec integration also passes with eligible turbovec 1.0.0 and numpy 2.5.3 in an isolated environment.
