### PR TITLE
fix(cache): preserve captures at maximum byte limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve file and SQLite capture contents when `MaxFileBytes` is the maximum signed 64-bit value; keep overflow-free bounded reads for growing sources.
 - Run the same validation gates locally and in Linux CI, including formatting, and cancel superseded automatic CI runs.
 
 ## 0.16.2 - 2026-09-11

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -74,15 +73,9 @@ func SnapshotFile(opts SnapshotOptions) (Snapshot, error) {
 		_ = tmp.Close()
 		return Snapshot{}, fmt.Errorf("chmod snapshot: %w", err)
 	}
-	var copied int64
-	if opts.MaxFileBytes > 0 {
-		limited := &io.LimitedReader{R: src, N: opts.MaxFileBytes + 1}
-		copied, err = io.Copy(tmp, limited)
-		if err == nil && copied > opts.MaxFileBytes {
-			err = fmt.Errorf("source file exceeds limit %d", opts.MaxFileBytes)
-		}
-	} else {
-		copied, err = io.Copy(tmp, src)
+	copied, exceeded, err := copyLimited(tmp, src, opts.MaxFileBytes)
+	if err == nil && exceeded {
+		err = fmt.Errorf("source file exceeds limit %d", opts.MaxFileBytes)
 	}
 	if err != nil {
 		_ = tmp.Close()

--- a/cache/copy.go
+++ b/cache/copy.go
@@ -1,0 +1,23 @@
+package cache
+
+import (
+	"errors"
+	"io"
+)
+
+func copyLimited(dst io.Writer, src io.Reader, limit int64) (copied int64, exceeded bool, err error) {
+	if limit <= 0 {
+		copied, err = io.Copy(dst, src)
+		return copied, false, err
+	}
+	copied, err = io.Copy(dst, io.LimitReader(src, limit))
+	if err != nil || copied < limit {
+		return copied, false, err
+	}
+	// Probe separately so a MaxInt64 limit never overflows.
+	extra, err := io.CopyN(io.Discard, src, 1)
+	if errors.Is(err, io.EOF) {
+		err = nil
+	}
+	return copied, extra != 0, err
+}

--- a/cache/limits_test.go
+++ b/cache/limits_test.go
@@ -1,0 +1,53 @@
+package cache
+
+import (
+	"bytes"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSnapshotsPreserveDataAtMaximumLimit(t *testing.T) {
+	for _, kind := range []string{"file", "sqlite"} {
+		t.Run(kind, func(t *testing.T) {
+			source := filepath.Join(t.TempDir(), "source.db")
+			payload := []byte("synthetic snapshot payload")
+			if err := os.WriteFile(source, payload, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			var path string
+			var size int64
+			if kind == "file" {
+				result, err := SnapshotFile(SnapshotOptions{SourcePath: source, CacheDir: t.TempDir(), MaxFileBytes: math.MaxInt64})
+				if err != nil {
+					t.Fatal(err)
+				}
+				path, size = result.Path, result.SizeBytes
+			} else {
+				result, err := SnapshotSQLite(SQLiteSnapshotOptions{SourcePath: source, DestinationDir: t.TempDir(), MaxFileBytes: math.MaxInt64})
+				if err != nil {
+					t.Fatal(err)
+				}
+				path, size = result.Path, result.SizeBytes
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(data) != string(payload) || size != int64(len(payload)) {
+				t.Fatalf("captured %q (%d bytes), want %q", data, size, payload)
+			}
+		})
+	}
+}
+
+func TestCopyLimitedStopsAfterOverflowProbe(t *testing.T) {
+	source := strings.NewReader("abcdef")
+	var target bytes.Buffer
+	copied, exceeded, err := copyLimited(&target, source, 3)
+	if err != nil || !exceeded || copied != 3 || target.String() != "abc" || source.Len() != 2 {
+		t.Fatalf("copy = %d, %t, %v, %q; unread = %d", copied, exceeded, err, target.String(), source.Len())
+	}
+}

--- a/cache/sqlite.go
+++ b/cache/sqlite.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -198,15 +197,9 @@ func copyOptionalFile(source, target string, maxBytes int64) (int64, bool, error
 		_ = tmp.Close()
 		return 0, false, err
 	}
-	var copied int64
-	if maxBytes > 0 {
-		limited := &io.LimitedReader{R: in, N: maxBytes + 1}
-		copied, err = io.Copy(tmp, limited)
-		if err == nil && copied > maxBytes {
-			err = fmt.Errorf("sqlite snapshot file %s exceeds limit %d", source, maxBytes)
-		}
-	} else {
-		copied, err = io.Copy(tmp, in)
+	copied, exceeded, err := copyLimited(tmp, in, maxBytes)
+	if err == nil && exceeded {
+		err = fmt.Errorf("sqlite snapshot file %s exceeds limit %d", source, maxBytes)
 	}
 	if err != nil {
 		_ = tmp.Close()

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -9,6 +9,9 @@
 - `state` provides generic crawler cursors and freshness records, including mapped adapters for existing app table layouts.
 - `cache` provides read-only local cache files and staged SQLite database, WAL, and SHM captures. Callers must supply a quiescent source or an application-owned coherent snapshot; copying files from a live writer does not provide a transactional snapshot.
 
+A positive `MaxFileBytes` bounds each captured source file, including SQLite
+sidecars. Nonpositive limits leave file size unbounded.
+
 ## Portable archives
 
 - `snapshot` exports and imports manifest-based JSONL/Gzip table packs, fingerprints files, plans exact or monotonic incremental imports, and synchronizes managed sidecar trees.


### PR DESCRIPTION
## What Problem This Solves

Both cache capture APIs silently publish empty files when `MaxFileBytes` is `math.MaxInt64`.

## User Impact

Valid maximum-size limits preserve captured data. Positive limits still bound each file, and nonpositive limits retain their existing unbounded behavior.

## Why This Change Was Made

The two copy paths added one to the signed limit before constructing a limited reader. Overflow made that reader immediately return EOF. Share a bounded-copy helper that copies up to the limit and probes one additional byte separately; keep staging, rollback, and error handling intact.

## Evidence

The new public-API regression fails on the baseline for both file and SQLite capture: each returns an empty payload and zero bytes. After the fix, the complete cache tests, race tests, vet, module tidiness, and `git diff --check` pass. A streaming regression confirms only one overflow-probe byte is consumed. Isolated Codex autoreview reports `scoped-clean` through P2.

A compiled program invokes both public APIs with a temporary 17-byte synthetic source:

```text
Before: SnapshotFile(MaxInt64): source=17 captured=0
Before: SnapshotSQLite(MaxInt64): source=17 captured=0
After:  SnapshotFile(MaxInt64): source=17 captured=17
After:  SnapshotSQLite(MaxInt64): source=17 captured=17
```

All applicable checks pass at `a7bcf3b0b3650276d39ba0f90209378ac6a18d5a`, including [Linux/race, Windows, and downstream CI](https://github.com/openclaw/crawlkit/actions/runs/34728973590), CodeQL, and verified-secret scans.
