### PR TITLE
fix(backup): preserve zero-valued counter identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Preserve file and SQLite capture contents when `MaxFileBytes` is the maximum signed 64-bit value; keep overflow-free bounded reads for growing sources.
+- Publish changes to zero-row backup counter keys while reusing unchanged encrypted shards.
 - Run the same validation gates locally and in Linux CI, including formatting, and cancel superseded automatic CI runs.
 
 ## 0.16.2 - 2026-09-11

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
@@ -506,8 +507,10 @@ func (m Manifest) Entry(path string) (ShardEntry, bool) {
 	return ShardEntry{}, false
 }
 
+// EquivalentManifest compares contents and counter keys, ignoring export times
+// and encrypted object sizes.
 func EquivalentManifest(a, b Manifest) bool {
-	if a.Format != b.Format || a.Encrypted != b.Encrypted || !sameStrings(a.Recipients, b.Recipients) || !sameCounts(a.Counts, b.Counts) || len(a.Shards) != len(b.Shards) || len(a.Files) != len(b.Files) {
+	if a.Format != b.Format || a.Encrypted != b.Encrypted || !sameStrings(a.Recipients, b.Recipients) || !maps.Equal(a.Counts, b.Counts) || len(a.Shards) != len(b.Shards) || len(a.Files) != len(b.Files) {
 		return false
 	}
 	for i := range a.Shards {
@@ -670,18 +673,6 @@ func sameStrings(a, b []string) bool {
 	}
 	for i := range a {
 		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func sameCounts(a, b map[string]int) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for key, left := range a {
-		if b[key] != left {
 			return false
 		}
 	}

--- a/backup/counts_test.go
+++ b/backup/counts_test.go
@@ -1,0 +1,54 @@
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEquivalentManifestDistinguishesZeroCountKeys(t *testing.T) {
+	left := Manifest{Counts: map[string]int{"old": 0}}
+	right := Manifest{Counts: map[string]int{"new": 0}}
+	if EquivalentManifest(left, right) {
+		t.Fatal("different zero-valued counters compare equal")
+	}
+	if !EquivalentManifest(Manifest{}, Manifest{Counts: map[string]int{}}) {
+		t.Fatal("nil and empty counters should remain equivalent")
+	}
+}
+
+func TestWriteSnapshotPublishesChangedEmptyCountKey(t *testing.T) {
+	root := t.TempDir()
+	identity := filepath.Join(root, "identity")
+	recipient, err := EnsureIdentity(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := Config{Repo: filepath.Join(root, "pack"), Identity: identity, Recipients: []string{recipient}}
+	shard := Shard{Table: "items", CountKey: "old", Path: "data/items.jsonl.gz.age", Rows: []row{}}
+	first, err := WriteSnapshot(t.Context(), cfg, []Shard{shard}, Manifest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	shard.CountKey = "new"
+	second, err := WriteSnapshot(t.Context(), cfg, []Shard{shard}, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored, err := ReadManifest(cfg.Repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, manifest := range []Manifest{second, stored} {
+		count, present := manifest.Counts["new"]
+		if _, old := manifest.Counts["old"]; old || !present || count != 0 {
+			t.Fatalf("counts = %#v", manifest.Counts)
+		}
+		if manifest.Shards[0].Path != first.Shards[0].Path {
+			t.Fatal("unchanged shard was not reused")
+		}
+	}
+	if _, err := os.Stat(filepath.Join(cfg.Repo, first.Shards[0].Path)); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

Changing the count key for an empty backup table is silently ignored even when a new manifest is requested.

## User Impact

Zero-row counter names remain significant, and changed metadata is published while unchanged encrypted shards are reused.

## Why This Change Was Made

The handwritten map comparison used a missing key's zero value as if the key existed. Equal-length maps with different zero-valued keys therefore compared equal. Use `maps.Equal` to compare both key presence and values, preserving nil/empty equivalence and the existing ignored export-time/encrypted-size fields.

## Evidence

Two regressions fail on the baseline: direct manifest equality and a real encrypted publication followed by manifest readback. Both pass after the fix; the publication regression also verifies shard reuse. Complete backup tests, race tests, and vet pass. Isolated Codex autoreview reports `scoped-clean` through P2.

A compiled public-API fixture creates a temporary encrypted empty-table backup, changes its count key, and republishes:

```text
Before: old_present=true new_present=false
After:  old_present=false new_present=true
```

The fixture uses a temporary generated identity and synthetic data; no identity value is printed or retained. No public API or archive format changes. All applicable checks pass at `b9401530b2d8ed3340e12ac0b7ecb40634e72feb`, including [Linux/race, Windows, and downstream CI](https://github.com/openclaw/crawlkit/actions/runs/34729442799), CodeQL, and verified-secret scans.
