### PR TITLE
fix(embed): enforce timeouts with caller-owned clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Honor configured embedding request timeouts with caller-supplied HTTP clients without mutating those clients; retain shorter client and context deadlines.
 - Preserve file and SQLite capture contents when `MaxFileBytes` is the maximum signed 64-bit value; keep overflow-free bounded reads for growing sources.
 - Run the same validation gates locally and in Linux CI, including formatting, and cancel superseded automatic CI runs.
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -84,6 +84,10 @@ reader lease or a power-loss durability guarantee.
 - `embed` provides OpenAI-compatible, Ollama, and llama.cpp embedding clients plus probe diagnostics.
 - `vector` encodes float32 vectors, validates dimensions, runs exact cosine or optional turbovec-backed search, selects top-k results, and performs reciprocal-rank fusion.
 
+Embedding request timeouts also apply to custom HTTP clients. Providers copy
+the client settings while sharing its transport, redirects, and cookie jar;
+shorter client or context deadlines still take precedence.
+
 ## App contracts
 
 - `control` defines crawler metadata, command manifests, status payloads, contact exports, and database inventories for launchers and automation.

--- a/embed/provider.go
+++ b/embed/provider.go
@@ -95,6 +95,8 @@ type providerSettings struct {
 	HTTPClient    *http.Client
 }
 
+// WithHTTPClient preserves the client's transport, redirects and cookie jar.
+// Providers use their own client copy and retain any shorter client timeout.
 func WithHTTPClient(client *http.Client) Option {
 	return func(opts *providerOptions) {
 		opts.httpClient = client
@@ -224,9 +226,12 @@ func resolveProviderConfig(cfg Config, opts ...Option) (providerSettings, error)
 			return providerSettings{}, err
 		}
 	}
-	client := options.httpClient
-	if client == nil {
-		client = &http.Client{Timeout: timeout}
+	client := &http.Client{Timeout: timeout}
+	if options.httpClient != nil {
+		*client = *options.httpClient
+		if client.Timeout <= 0 || timeout < client.Timeout {
+			client.Timeout = timeout
+		}
 	}
 	if _, err := url.ParseRequestURI(baseURL); err != nil {
 		return providerSettings{}, fmt.Errorf("invalid embeddings base_url %q: %w", baseURL, err)

--- a/embed/provider_test.go
+++ b/embed/provider_test.go
@@ -408,15 +408,19 @@ func TestEmbeddingProvidersHandleEmptyInputsAndIndexErrors(t *testing.T) {
 func TestProviderOptionsAndProbeDecisions(t *testing.T) {
 	t.Parallel()
 
-	client := &http.Client{Timeout: time.Second}
+	client := &http.Client{Timeout: time.Second, Transport: &http.Transport{}}
 	settings, err := resolveProviderConfig(Config{
 		Provider:       ProviderOllama,
 		BaseURL:        "http://127.0.0.1:11434/",
 		RequestTimeout: "30s",
 	}, WithHTTPClient(client), WithRequestTimeout(50*time.Millisecond))
 	require.NoError(t, err)
-	require.Same(t, client, settings.HTTPClient)
-	require.Equal(t, time.Second, settings.HTTPClient.Timeout)
+	if client == settings.HTTPClient {
+		t.Fatal("provider must own its timeout configuration")
+	}
+	require.Same(t, client.Transport, settings.HTTPClient.Transport)
+	require.Equal(t, time.Second, client.Timeout)
+	require.Equal(t, 50*time.Millisecond, settings.HTTPClient.Timeout)
 	defaultClient, err := resolveProviderConfig(Config{Provider: ProviderOllama}, WithRequestTimeout(50*time.Millisecond))
 	require.NoError(t, err)
 	require.Equal(t, 50*time.Millisecond, defaultClient.HTTPClient.Timeout)

--- a/embed/timeout_test.go
+++ b/embed/timeout_test.go
@@ -1,0 +1,54 @@
+package embed
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+type waitingTransport struct{}
+
+func (waitingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	<-req.Context().Done()
+	return nil, req.Context().Err()
+}
+
+func TestCustomClientRespectsEmbeddingTimeouts(t *testing.T) {
+	for _, providerName := range []string{ProviderOllama, ProviderOpenAICompatible} {
+		for _, tc := range []struct {
+			name                                               string
+			clientTimeout, requestTimeout, parentTimeout, want time.Duration
+		}{
+			{"unbounded client", 0, 2 * time.Second, time.Minute, 2 * time.Second},
+			{"longer client", 30 * time.Second, 2 * time.Second, time.Minute, 2 * time.Second},
+			{"shorter client", time.Second, 2 * time.Second, time.Minute, time.Second},
+			{"shorter context", 30 * time.Second, 2 * time.Second, time.Second, time.Second},
+		} {
+			t.Run(providerName+"/"+tc.name, func(t *testing.T) {
+				synctest.Test(t, func(t *testing.T) {
+					client := &http.Client{Transport: waitingTransport{}, Timeout: tc.clientTimeout}
+					provider, err := NewProvider(Config{Provider: providerName, BaseURL: "http://127.0.0.1", RequestTimeout: tc.requestTimeout.String()}, WithHTTPClient(client))
+					if err != nil {
+						t.Fatal(err)
+					}
+					ctx, cancel := context.WithTimeout(context.Background(), tc.parentTimeout)
+					defer cancel()
+					start := time.Now()
+					_, err = provider.Embed(ctx, []string{"synthetic"})
+					if !errors.Is(err, context.DeadlineExceeded) {
+						t.Fatalf("error = %v, want deadline exceeded", err)
+					}
+					if elapsed := time.Since(start); elapsed != tc.want {
+						t.Fatalf("elapsed = %s, want %s", elapsed, tc.want)
+					}
+					if client.Timeout != tc.clientTimeout {
+						t.Fatal("caller-owned client timeout was mutated")
+					}
+				})
+			})
+		}
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

Embedding request timeouts are ignored when a caller supplies its own HTTP client with a longer or unbounded timeout.

## User Impact

Configured request deadlines apply to both OpenAI-compatible and Ollama providers. Shorter caller-client and context deadlines still win, and the caller's client is unchanged.

## Why This Change Was Made

Timeout policy previously applied only when constructing a default client. Give each provider a client copy with the resolved timeout cap, retaining its transport, redirect policy, and cookie jar. Tests now check actual client behavior and ownership rather than an unused derived setting.

## Evidence

Deterministic `testing/synctest` regressions exercise both providers with unbounded, longer, and shorter client timeouts, plus shorter parent contexts. Baseline requests take a virtual minute or 30 seconds instead of the configured 2 seconds; the fixed implementation enforces 2 seconds and preserves the shorter cases. All embedding tests, race tests, vet, and deadcode checks pass. Isolated Codex autoreview reports `scoped-clean` through P2.

A separately compiled program uses a real loopback HTTP server with a 120 ms response and a configured 20 ms timeout:

```text
Before: success=true  deadline_exceeded=false elapsed_ms=123
After:  success=false deadline_exceeded=true  elapsed_ms=23
```

The caller-owned client retains its original timeout, and transport identity is preserved. No public API or runtime-floor change. All applicable checks pass at `a5f6a2738de2fbfb64d5c193b531cfd639a78ad7`, including [Linux/race, Windows, and downstream CI](https://github.com/openclaw/crawlkit/actions/runs/34729819169), CodeQL, and verified-secret scans.
