### PR TITLE
fix(scheduler): preserve explicit configs and long run history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Preserve file and SQLite capture contents when `MaxFileBytes` is the maximum signed 64-bit value; keep overflow-free bounded reads for growing sources.
 - Publish changes to zero-row backup counter keys while reusing unchanged encrypted shards.
+- Apply private permissions before overwriting existing controller configurations.
+- Allow explicit controller configuration paths without a home directory while preserving default and tilde-path validation.
+- Read and repair long scheduler history records without blocking later runs or status checks.
 - Run the same validation gates locally and in Linux CI, including formatting, and cancel superseded automatic CI runs.
 
 ## 0.16.2 - 2026-09-11

--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ schedule source-specific commands such as Photos' `import_apple`.
 
 If a write is interrupted, history reads ignore a truncated final JSON value and the next run repairs that tail before appending. Valid final records without a trailing newline are retained; complete corrupt records still report an error.
 
+History reads accept the full records written by the runner, including long
+command arguments. Explicit configuration paths work without a home directory;
+default and `~/` paths still require one. Saving a controller configuration
+applies private file permissions before replacing existing content.
+
 | Command | Purpose |
 | --- | --- |
 | `init` | Discover crawl apps and write a controller config |

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -46,13 +46,17 @@ type Paths struct {
 }
 
 func DefaultPaths(configPath string) (Paths, error) {
-	app := config.App{Name: "crawlctl", PlatformDirs: true}
-	defaults, err := app.DefaultPaths()
-	if err != nil {
-		return Paths{}, err
+	trimmed := strings.TrimSpace(configPath)
+	customConfig := trimmed != ""
+	var defaults config.Paths
+	if !customConfig || trimmed == "~" || strings.HasPrefix(trimmed, "~/") {
+		var err error
+		defaults, err = (config.App{Name: "crawlctl", PlatformDirs: true}).DefaultPaths()
+		if err != nil {
+			return Paths{}, err
+		}
 	}
-	customConfig := strings.TrimSpace(configPath) != ""
-	if strings.TrimSpace(configPath) == "" {
+	if !customConfig {
 		configPath = defaults.ConfigPath
 	} else {
 		configPath = config.ExpandHome(configPath)
@@ -63,9 +67,6 @@ func DefaultPaths(configPath string) (Paths, error) {
 	if customConfig {
 		logDir = filepath.Join(base, "logs")
 		stateDir = filepath.Join(base, "state")
-	}
-	if strings.TrimSpace(logDir) == "" {
-		logDir = filepath.Join(base, "logs")
 	}
 	return Paths{
 		ConfigPath: configPath,
@@ -119,14 +120,7 @@ func Save(path string, cfg Config, force bool) (Paths, error) {
 			return paths, err
 		}
 	}
-	if err := os.MkdirAll(filepath.Dir(paths.ConfigPath), 0o755); err != nil {
-		return paths, err
-	}
-	data, err := toml.Marshal(cfg)
-	if err != nil {
-		return paths, err
-	}
-	if err := os.WriteFile(paths.ConfigPath, data, 0o600); err != nil {
+	if err := config.WriteTOML(paths.ConfigPath, cfg, 0o600); err != nil {
 		return paths, err
 	}
 	return paths, nil

--- a/scheduler/history.go
+++ b/scheduler/history.go
@@ -123,26 +123,27 @@ func ReadHistory(path string) ([]RunRecord, error) {
 	}
 	defer file.Close()
 	var records []RunRecord
-	scanner := bufio.NewScanner(file)
-	terminated := false
-	scanner.Split(func(data []byte, atEOF bool) (int, []byte, error) {
-		advance, token, err := bufio.ScanLines(data, atEOF)
-		if advance > 0 {
-			terminated = data[advance-1] == '\n'
+	reader := bufio.NewReader(file)
+	for {
+		line, readErr := reader.ReadBytes('\n')
+		if readErr != nil && !errors.Is(readErr, io.EOF) {
+			return records, readErr
 		}
-		return advance, token, err
-	})
-	for scanner.Scan() {
+		if len(line) == 0 {
+			return records, nil
+		}
 		var record RunRecord
-		if err := json.Unmarshal(scanner.Bytes(), &record); err != nil {
-			if !terminated && incompleteHistoryRecord(scanner.Bytes()) {
-				break
+		if err := json.Unmarshal(line, &record); err != nil {
+			if errors.Is(readErr, io.EOF) && incompleteHistoryRecord(line) {
+				return records, nil
 			}
 			return nil, err
 		}
 		records = append(records, record)
+		if errors.Is(readErr, io.EOF) {
+			return records, nil
+		}
 	}
-	return records, scanner.Err()
 }
 
 func LastRecords(records []RunRecord) map[string]RunRecord {

--- a/scheduler/persistence_test.go
+++ b/scheduler/persistence_test.go
@@ -1,0 +1,115 @@
+package scheduler
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestHistoryRoundTripsLongCommandRecords(t *testing.T) {
+	for _, newline := range []bool{false, true} {
+		t.Run(map[bool]string{false: "without newline", true: "with newline"}[newline], func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "runs.jsonl")
+			first := RunRecord{ID: "first", Job: "fixture", Command: []string{"echo", strings.Repeat("x", 70000)}, Status: "success"}
+			data, err := json.Marshal(first)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if newline {
+				data = append(data, '\n')
+			}
+			if err := os.WriteFile(path, data, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			got, err := ReadHistory(path)
+			if err != nil || !reflect.DeepEqual(got, []RunRecord{first}) {
+				t.Fatalf("read long record: count=%d err=%v", len(got), err)
+			}
+			second := RunRecord{ID: "second", Job: "fixture", Status: "success"}
+			if err := appendHistory(path, second); err != nil {
+				t.Fatal(err)
+			}
+			got, err = ReadHistory(path)
+			if err != nil || !reflect.DeepEqual(got, []RunRecord{first, second}) {
+				t.Fatalf("append after long record: count=%d err=%v", len(got), err)
+			}
+		})
+	}
+}
+
+func TestHistoryRepairsLongInterruptedTail(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runs.jsonl")
+	first := RunRecord{ID: "first", Job: "fixture", Status: "success"}
+	if err := appendHistory(path, first); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, writeErr := file.WriteString(`{"command":["` + strings.Repeat("x", 70000))
+	closeErr := file.Close()
+	if writeErr != nil || closeErr != nil {
+		t.Fatalf("write tail: %v %v", writeErr, closeErr)
+	}
+	got, err := ReadHistory(path)
+	if err != nil || !reflect.DeepEqual(got, []RunRecord{first}) {
+		t.Fatalf("read interrupted tail: count=%d err=%v", len(got), err)
+	}
+	second := RunRecord{ID: "second", Job: "fixture", Status: "success"}
+	if err := appendHistory(path, second); err != nil {
+		t.Fatal(err)
+	}
+	got, err = ReadHistory(path)
+	if err != nil || !reflect.DeepEqual(got, []RunRecord{first, second}) {
+		t.Fatalf("repair interrupted tail: count=%d err=%v", len(got), err)
+	}
+}
+
+func TestSaveKeepsExistingConfigPrivate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("version = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := DefaultConfig()
+	cfg.Runner.Every = "5m"
+	if _, err := Save(path, cfg, true); err != nil {
+		t.Fatal(err)
+	}
+	loaded, _, err := Load(path)
+	if err != nil || loaded.Runner.Every != "5m" {
+		t.Fatalf("load saved config: %#v, %v", loaded, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		t.Fatalf("saved config mode = %04o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestExplicitConfigPathsDoNotRequireHome(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	paths, err := DefaultPaths(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if paths.ConfigPath != path || paths.LogDir != filepath.Join(filepath.Dir(path), "logs") || paths.StateDir != filepath.Join(filepath.Dir(path), "state") {
+		t.Fatalf("explicit paths = %#v", paths)
+	}
+	for _, homePath := range []string{"", "~/config.toml"} {
+		if _, err := DefaultPaths(homePath); err == nil {
+			t.Fatalf("%q should still require a home", homePath)
+		}
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

Long command records make later controller runs and status reads fail, explicit config paths unnecessarily require a home directory, and config overwrites retain permissive file modes.

## User Impact

Controllers can keep reading and repairing their own long history records, run with an explicit config in headless environments, and save private configurations even when replacing a previously permissive file.

## Why This Change Was Made

Use buffered JSONL line reads instead of Scanner's unrelated 64 KiB token ceiling. Keep the existing EOF-tail recovery and complete-corruption errors. Resolve platform/home defaults only for default or tilde-based paths, and reuse the shared TOML writer that applies 0600 before truncation.

## Evidence

Regressions fail on the baseline for 70 KiB records with and without final newlines, long interrupted tails, an existing 0644 config, and an explicit config with HOME/USERPROFILE unset. Scheduler and controller tests, race tests, and vet pass after the fix. Isolated Codex autoreview reports `scoped-clean` through P2.

Live proof from a newly built controller uses a temporary config with a 70,000-character command argument, with HOME and USERPROFILE removed from the environment:

```text
run fixture: exit=0
status: exit=0
run fixture: exit=0
scheduler.Save existing 0644 config: resulting mode=0600
```

Before the fix, status and subsequent runs failed with `bufio.Scanner: token too long`, explicit paths failed when HOME was absent, and Save retained mode 0644. Default and tilde paths still require a valid home. Existing locking, schemas, and CLI flags remain intact. All applicable checks pass at `da29eabe4f1fe396e52524df85c2721156f16eea`, including [Linux/race, Windows, and downstream CI](https://github.com/openclaw/crawlkit/actions/runs/34730288079), CodeQL, and verified-secret scans.
