### PR TITLE
fix(scheduler): encode literal systemd command arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Preserve file and SQLite capture contents when `MaxFileBytes` is the maximum signed 64-bit value; keep overflow-free bounded reads for growing sources.
+- Preserve literal systemd command arguments and executable names; reject executable-path characters that systemd cannot load.
 - Publish changes to zero-row backup counter keys while reusing unchanged encrypted shards.
 - Run the same validation gates locally and in Linux CI, including formatting, and cancel superseded automatic CI runs.
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ If a write is interrupted, history reads ignore a truncated final JSON value and
 
 Scheduling uses launchd on macOS, systemd user units on Linux, Task Scheduler on Windows, and cron rendering as the portable fallback.
 
+Systemd plans preserve literal argument text, including quotes, percent signs,
+and dollar signs. Executable paths must follow systemd rules: quotes,
+backslashes, and control characters are rejected before installation.
+
 See [Background workers](docs/background-workers.md) for content-triggered processing alongside ingestion.
 
 ## Boundaries

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Scheduling uses launchd on macOS, systemd user units on Linux, Task Scheduler on
 Systemd plans preserve literal argument text, including quotes, percent signs,
 and dollar signs. Executable paths must follow systemd rules: quotes,
 backslashes, and control characters are rejected before installation.
+Dry-run previews can still render plans for another operating system.
 
 See [Background workers](docs/background-workers.md) for content-triggered processing alongside ingestion.
 

--- a/scheduler/native.go
+++ b/scheduler/native.go
@@ -217,7 +217,10 @@ func renderLaunchd(args []string, paths Paths, every time.Duration) (string, err
 }
 
 func renderSystemd(args []string, every time.Duration) (string, string, error) {
-	service, err := executeTemplate(systemdServiceTemplate, map[string]any{"Command": shellQuoteArgs(args)})
+	if strings.ContainsAny(args[0], "\"'\\") || strings.IndexFunc(args[0], func(r rune) bool { return r < ' ' || r == 0x7f }) >= 0 {
+		return "", "", fmt.Errorf("systemd executable path contains unsupported characters: %q", args[0])
+	}
+	service, err := executeTemplate(systemdServiceTemplate, map[string]any{"Command": systemdQuoteArgs(args)})
 	if err != nil {
 		return "", "", err
 	}
@@ -253,6 +256,17 @@ func shellQuoteArgs(args []string) string {
 	quoted := make([]string, len(args))
 	for i, arg := range args {
 		quoted[i] = shellQuote(arg)
+	}
+	return strings.Join(quoted, " ")
+}
+
+func systemdQuoteArgs(args []string) string {
+	escape := strings.NewReplacer("%", "%%", "$", "$$")
+	quoted := make([]string, len(args)+1)
+	// @ separates the executable path (no environment expansion) from argv[0].
+	quoted[0] = "@" + strconv.Quote(strings.ReplaceAll(args[0], "%", "%%"))
+	for i, arg := range args {
+		quoted[i+1] = strconv.Quote(escape.Replace(arg))
 	}
 	return strings.Join(quoted, " ")
 }

--- a/scheduler/native.go
+++ b/scheduler/native.go
@@ -31,6 +31,10 @@ type InstallPlan struct {
 }
 
 func PlanInstall(opts InstallOptions) (InstallPlan, error) {
+	return planInstall(opts, false)
+}
+
+func planInstall(opts InstallOptions, installing bool) (InstallPlan, error) {
 	paths := opts.Paths
 	if strings.TrimSpace(opts.ConfigPath) != "" && strings.TrimSpace(paths.ConfigPath) != "" {
 		defaults, err := DefaultPaths(opts.ConfigPath)
@@ -77,6 +81,9 @@ func PlanInstall(opts InstallOptions) (InstallPlan, error) {
 		home, _ := os.UserHomeDir()
 		return InstallPlan{Backend: backend, Path: filepath.Join(home, "Library", "LaunchAgents", "org.openclaw.crawlctl.plist"), Content: content}, nil
 	case "systemd":
+		if installing && (strings.ContainsAny(exe, "\"'\\") || strings.IndexFunc(exe, func(r rune) bool { return r < ' ' || r == 0x7f }) >= 0) {
+			return InstallPlan{}, fmt.Errorf("systemd executable path contains unsupported characters: %q", exe)
+		}
 		service, timer, err := renderSystemd(args, duration)
 		if err != nil {
 			return InstallPlan{}, err
@@ -106,7 +113,7 @@ func PlanInstall(opts InstallOptions) (InstallPlan, error) {
 }
 
 func Install(opts InstallOptions) (InstallPlan, error) {
-	plan, err := PlanInstall(opts)
+	plan, err := planInstall(opts, !opts.DryRun)
 	if err != nil || opts.DryRun {
 		return plan, err
 	}
@@ -217,9 +224,6 @@ func renderLaunchd(args []string, paths Paths, every time.Duration) (string, err
 }
 
 func renderSystemd(args []string, every time.Duration) (string, string, error) {
-	if strings.ContainsAny(args[0], "\"'\\") || strings.IndexFunc(args[0], func(r rune) bool { return r < ' ' || r == 0x7f }) >= 0 {
-		return "", "", fmt.Errorf("systemd executable path contains unsupported characters: %q", args[0])
-	}
 	service, err := executeTemplate(systemdServiceTemplate, map[string]any{"Command": systemdQuoteArgs(args)})
 	if err != nil {
 		return "", "", err

--- a/scheduler/native_arguments_test.go
+++ b/scheduler/native_arguments_test.go
@@ -1,0 +1,43 @@
+package scheduler
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSystemdPlanPreservesLiteralArguments(t *testing.T) {
+	plan, err := PlanInstall(InstallOptions{
+		Backend: "systemd", Every: "1m", Executable: "/tmp/bin space-%n-${USER}/crawlctl",
+		Paths: Paths{ConfigPath: "/tmp/literal-%n-${USER}-'quoted'/config.toml"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `ExecStart=@"/tmp/bin space-%%n-${USER}/crawlctl" "/tmp/bin space-%%n-$${USER}/crawlctl" "--config" "/tmp/literal-%%n-$${USER}-'quoted'/config.toml" "run"`
+	if !strings.Contains(plan.Content, want) {
+		t.Fatalf("systemd command must preserve literal arguments:\n%s", plan.Content)
+	}
+}
+
+func TestSystemdPlanRejectsUnsupportedExecutablePaths(t *testing.T) {
+	for _, character := range []string{"'", "\"", "\\", "\n", "\t", "\x00", "\x7f"} {
+		_, err := PlanInstall(InstallOptions{Backend: "systemd", Every: "1m", Executable: "/tmp/bin" + character + "/crawlctl", Paths: Paths{ConfigPath: "/tmp/config.toml"}})
+		if err == nil || !strings.Contains(err.Error(), "systemd executable path") {
+			t.Fatalf("executable with %q: error = %v", character, err)
+		}
+	}
+}
+
+func TestSystemdPlanEscapesControlCharacters(t *testing.T) {
+	plan, err := PlanInstall(InstallOptions{
+		Backend: "systemd", Every: "1m", Executable: "/tmp/bin/crawlctl",
+		Paths: Paths{ConfigPath: "/tmp/tab\tline\nquote\"back\\slash/config.toml"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `"/tmp/tab\tline\nquote\"back\\slash/config.toml"`
+	if !strings.Contains(plan.Content, want) {
+		t.Fatalf("systemd command must escape control characters:\n%s", plan.Content)
+	}
+}

--- a/scheduler/native_arguments_test.go
+++ b/scheduler/native_arguments_test.go
@@ -19,12 +19,27 @@ func TestSystemdPlanPreservesLiteralArguments(t *testing.T) {
 	}
 }
 
-func TestSystemdPlanRejectsUnsupportedExecutablePaths(t *testing.T) {
+func TestSystemdInstallRejectsUnsupportedExecutablePaths(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("PATH", t.TempDir())
 	for _, character := range []string{"'", "\"", "\\", "\n", "\t", "\x00", "\x7f"} {
-		_, err := PlanInstall(InstallOptions{Backend: "systemd", Every: "1m", Executable: "/tmp/bin" + character + "/crawlctl", Paths: Paths{ConfigPath: "/tmp/config.toml"}})
+		_, err := Install(InstallOptions{Backend: "systemd", Every: "1m", Executable: "/tmp/bin" + character + "/crawlctl", Paths: Paths{ConfigPath: "/tmp/config.toml"}})
 		if err == nil || !strings.Contains(err.Error(), "systemd executable path") {
 			t.Fatalf("executable with %q: error = %v", character, err)
 		}
+	}
+}
+
+func TestSystemdPreviewPreservesForeignExecutablePaths(t *testing.T) {
+	opts := InstallOptions{Backend: "systemd", Every: "1m", Executable: `C:\Program Files\crawlctl.exe`, Paths: Paths{ConfigPath: "/tmp/config.toml"}}
+	if _, err := PlanInstall(opts); err != nil {
+		t.Fatalf("portable plan: %v", err)
+	}
+	opts.DryRun = true
+	if _, err := Install(opts); err != nil {
+		t.Fatalf("portable preview: %v", err)
 	}
 }
 
@@ -39,5 +54,15 @@ func TestSystemdPlanEscapesControlCharacters(t *testing.T) {
 	want := `"/tmp/tab\tline\nquote\"back\\slash/config.toml"`
 	if !strings.Contains(plan.Content, want) {
 		t.Fatalf("systemd command must escape control characters:\n%s", plan.Content)
+	}
+}
+
+func TestSystemdInstallPlanAllowsLiteralGlobCharacters(t *testing.T) {
+	plan, err := planInstall(InstallOptions{Backend: "systemd", Every: "1m", Executable: "/tmp/bin[*?]/crawlctl", Paths: Paths{ConfigPath: "/tmp/config.toml"}}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(plan.Content, "bin[*?]/crawlctl") {
+		t.Fatalf("literal executable was changed: %s", plan.Content)
 	}
 }


### PR DESCRIPTION
## What Problem This Solves

Generated systemd commands use POSIX shell quoting, which corrupts literal paths containing quotes, percent specifiers, or environment-like text.

## User Impact

Systemd schedules preserve literal executable names and config arguments. Executable-path characters that systemd itself forbids are rejected before installation.

## Why This Change Was Made

Encode ExecStart with C-style tokens, escaped percent/dollar expansion, and an explicit argv[0] using systemd's `@` prefix. This keeps the executable path separate from argument environment expansion. Validate the executable against systemd's quote/backslash/control-character restrictions only when actually installing; portable plans and dry-run previews retain foreign executable paths. Other scheduler backends are unchanged.

## Evidence

The new literal/control-character regressions fail on the baseline. All scheduler/controller tests, race tests, and vet pass. The existing Windows interval test is unchanged; a foreign-path preview regression and isolated negative-installation tests cover the validation boundary. Final staged Codex autoreview reports `scoped-clean` through P2.

Native proof builds the controller with Go 1.27.1 on isolated Linux/systemd 259.5. A clean baseline and the candidate use specially named binary/config paths, including literal percent/dollar text, quotes, spaces, and glob characters. The generated user service is exercised on the isolated system manager with `User=root` solely to supply its normal login environment. The fixture runs a synthetic echo job and verifies persisted successful history.

```text
Before: expected=broken, start_exit=1, literal_config_success=False
        systemd expands %n into the unit name; executable lookup fails.
After:  expected=fixed, start_exit=0, literal_config_success=True
        owned test unit and synthetic runtime removed.
```

The final native proof ran at `ebd69887e3355010d3a2dd93c320a2436b1519ac` with a clean working diff. Systemd accepted literal glob characters as well; validation follows its actual executable-path restrictions. The final review is scoped-clean through P2. No public API or runtime-floor change. [Exact-head CI](https://github.com/openclaw/crawlkit/actions/runs/34731126945) is checked before merging.
